### PR TITLE
Review r709

### DIFF
--- a/src/ajax/get_gene_switcher.php
+++ b/src/ajax/get_gene_switcher.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-11-27
- * Modified    : 2015-12-21
+ * Modified    : 2016-02-02
  * For LOVD    : 3.0-15
  *
  * Copyright   : 2004-2015 Leiden University Medical Center; http://www.LUMC.nl/
@@ -79,7 +79,7 @@ if (count($zGenes) < $nMaxDropDown) {
         'html' =>
             '<FORM action="" id="SelectGeneDBInline" method="get" style="margin : 0px;" onsubmit="lovd_changeURL(); return false;">' . "\n" .
             '  <DIV id="div_gene_autocomplete">' . "\n" .
-            '    <INPUT name="select_db" id="select_gene_autocomplete">' . "\n" .
+            '    <INPUT name="select_db" id="select_gene_autocomplete" style="width : 75ex;">' . "\n" .
             '    <INPUT type="submit" value="Switch" id="select_gene_switch">' . "\n" .
             '  </DIV>' . "\n" .
             '</FORM>',

--- a/src/ajax/get_gene_switcher.php
+++ b/src/ajax/get_gene_switcher.php
@@ -33,46 +33,56 @@ require ROOT_PATH . 'inc-init.php';
 session_write_close();
 $nMaxDropDown = 10;
 
-$qGenes = $_DB->query('SELECT id, id as value, CONCAT(id, " (", name, ")") AS label FROM ' . TABLE_GENES . ' ORDER BY id');
-//$qGenes = $_DB->query('SELECT id, id as value, CONCAT(id, " (", name, ")") AS label FROM ' . TABLE_GENES . ' WHERE id = ?', array('ARSE'));
+$qGenes = $_DB->query('SELECT id AS value, CONCAT(id, " (", name, ")") AS label FROM ' . TABLE_GENES . ' ORDER BY id');
 $zGenes = $qGenes->fetchAllAssoc();
 
 if (empty($zGenes)) {
     die(json_encode(AJAX_DATA_ERROR));
 }
 
-foreach ($zGenes as $key => $value) {
-    //This will shorten the gene names nicely, to prevent long gene names from messing up the form.
-    $zGenes[$key]['label'] = lovd_shortenString($zGenes[$key]['label'], 75);
+foreach ($zGenes as $key => $aValues) {
+    // This will shorten the gene names nicely, to prevent long gene names from messing up the form.
+    $zGenes[$key]['label'] = lovd_shortenString($aValues['label'], 75);
 }
 
 if (count($zGenes) < $nMaxDropDown) {
     // Create the option elements.
-    $options = '';
-    foreach ($zGenes as $aGene) { 
-        $options .= '<OPTION value=' . $aGene['id'] . '>' . $aGene['label'] . ' </OPTION>' . "\n";
+    // Try to determine the currently selected gene, so we can pre-select that one,
+    // making it easier to select genes close alphabetically, and also ensuring the
+    // onChange() to run if the first gene from the list is selected.
+    // This code is similar to inc-init.php's parsing to find CurrDB.
+    $sCurrDB = '';
+    if (!empty($_SERVER['HTTP_REFERER']) && preg_match('/^' . preg_quote(lovd_getInstallURL(), '/') . '(configuration|genes|transcripts|variants|individuals|view)\/([^\/]+)/', $_SERVER['HTTP_REFERER'], $aRegs)) {
+        if (!in_array($aRegs[2], array('in_gene', 'upload')) && !ctype_digit($aRegs[2])) {
+            $sCurrDB = strtoupper($aRegs[2]); // Not checking capitalization here yet.
+        }
+    }
+
+    $sOptions = '';
+    foreach ($zGenes as $aGene) {
+        $sOptions .= '<OPTION value="' . $aGene['value'] . '"' . (!$sCurrDB || $sCurrDB != strtoupper($aGene['value'])? '' : ' selected') . '>' . $aGene['label'] . ' </OPTION>' . "\n";
     }
     die(json_encode(array(
         'switchType' => 'dropdown',
-        'html' => 
+        'html' =>
             '<FORM action="" id="SelectGeneDBInline" method="get" style="margin : 0px;" onsubmit="lovd_changeURL(); return false;">' . "\n" .
-            '   <DIV id="div_gene_dropdown">' . "\n" .
-            '        <SELECT name="select_db" id="select_gene_dropdown" onchange="$(this).parent().submit();">' . "\n" .
-                        $options .
-            '       </SELECT>' . "\n" .
-            '       <INPUT type="submit" value="Switch" id="select_gene_switch">' . "\n" .
-            '    </DIV>' . "\n" .
+            '  <DIV id="div_gene_dropdown">' . "\n" .
+            '    <SELECT name="select_db" id="select_gene_dropdown" onchange="$(this).parent().parent().submit();">' . "\n" .
+                   $sOptions .
+            '    </SELECT>' . "\n" .
+            '    <INPUT type="submit" value="Switch" id="select_gene_switch">' . "\n" .
+            '  </DIV>' . "\n" .
             '</FORM>')));
 } else {
     die(json_encode(array(
         'switchType' => 'autocomplete',
-        'html' => 
+        'html' =>
             '<FORM action="" id="SelectGeneDBInline" method="get" style="margin : 0px;" onsubmit="lovd_changeURL(); return false;">' . "\n" .
-            '   <DIV id="div_gene_autocomplete">' . "\n" .
-            '       <INPUT name="select_db" id="select_gene_autocomplete" onchange="$(this).parent().submit();">' . "\n" .
-            '       <INPUT type="submit" value="Switch" id="select_gene_switch">' . "\n" .
-            '   </DIV>' . "\n" .
-            '</FORM>', 
+            '  <DIV id="div_gene_autocomplete">' . "\n" .
+            '    <INPUT name="select_db" id="select_gene_autocomplete">' . "\n" .
+            '    <INPUT type="submit" value="Switch" id="select_gene_switch">' . "\n" .
+            '  </DIV>' . "\n" .
+            '</FORM>',
         'data' => $zGenes)));
 }
 ?>

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -35,13 +35,14 @@
    an import file resulted in a fatal error.
  * Fixed bug; Under certain circumstances, fatal errors would not be logged even
    though LOVD reported they had been logged.
- * Fixed bug; During an insert import the progress bar was hanging when a 
-   transcript ID is missing in the section variants on transcripts.
- * The geneswitcher in the header is now an autocomplete field for large databases.
+ * Fixed bug; During an insert import, the progress bar was hanging when a
+   transcript ID was missing in the section Variants_On_Transcripts.
+ * The geneswitcher in the header is now an autocomplete field for large
+   databases.
  * Improved error message when LOVD could not retrieve a valid gene reference
    sequence from Mutalyzer.
- * Fixed bug; During update import no difference was seen between '02' and '2', 
-   this is not correct for string fields. 
+ * Fixed bug; During update import no difference was seen between '02' and '2',
+   this is not correct for string fields.
  * Fixed bug; During import diseaseID 0 was not recognized.
 
 

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -533,7 +533,7 @@ function lovd_mapVariants ()
                 $("#select_gene_autocomplete").autocomplete({
                     source: geneSwitcher['data'],
                     minLength: 3
-                });
+                }).on( "autocompleteselect", function( e, ui ) { alert(ui.prop('value')); } );
             }
         },"json"
         ).fail(function (sData, sStatus) {

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -517,32 +517,39 @@ function lovd_mapVariants ()
 ?>
 
   <SCRIPT type="text/javascript">
-    var geneSwitcher="";
+    var geneSwitcher = '';
 
-    function lovd_switchGene() {
-        $.get('ajax/get_gene_switcher.php',function(sData, sStatus) {
-            geneSwitcher = sData
+    function lovd_switchGene()
+    {
+        // Fetches the gene switcher data from LOVD. Might be a form with a
+        // dropdown, or a form with a text field for autocomplete.
+        $.get('ajax/get_gene_switcher.php', function (sData, sStatus)
+        {
+            geneSwitcher = sData;
             if (geneSwitcher === '<?php echo AJAX_DATA_ERROR; ?>') {
                 alert('Error when retrieving a list of genes');
                 return;
             }
-            $("#gene_name").hide();
+            $('#gene_name').hide();
 
             $('#gene_switcher').html(geneSwitcher['html']);
             if (geneSwitcher['switchType'] === 'autocomplete') {
-                $("#select_gene_autocomplete").autocomplete({
+                $('#select_gene_autocomplete').autocomplete({
                     source: geneSwitcher['data'],
                     minLength: 3
-                }).on( "autocompleteselect", function( e, ui ) { alert(ui.prop('value')); } );
+                }).on('autocompleteselect', function (e, ui) { $(this).val(ui['item']['value']); $(this).parent().parent().submit(); }); // Autosubmit on selecting the gene from the list.
             }
         },"json"
-        ).fail(function (sData, sStatus) {
+        ).fail(function (sData, sStatus)
+        {
             alert('Error when retrieving a list of genes: ' + sStatus);
         });
     }
 
-    function lovd_changeURL () {
-        var sURL = "<?php if (!empty($_SESSION['currdb'])) {echo $sGeneSwitchURL;} ?>";
+    function lovd_changeURL ()
+    {
+        // Replaces the gene in the current URL with the one selected.
+        var sURL = '<?php if (!empty($_SESSION['currdb'])) { echo $sGeneSwitchURL; } ?>';
         if (geneSwitcher['switchType'] === 'autocomplete') {
             document.location.href = (sURL.replace('{{GENE}}', document.getElementById('select_gene_autocomplete').value));
         } else {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,13 +3,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-20
- * Modified    : 2015-12-21
- * For LOVD    : 3.0-15
+ * Modified    : 2012-12-06
+ * For LOVD    : 3.0-beta-12
  *
  * Copyright   : 2004-2012 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -204,8 +203,6 @@ table.data_red textarea         {font-size : 11px;}
 .autocomplete_item             {padding: 1px; padding-left: 5px; color: black; width: 100%;}
 .autocomplete_item_highlighted {padding: 1px; padding-left: 5px; color: white; background-color: #0A246A;}
 */
-/* jQuery autocomplete: */
-.ui-autocomplete-input  {width: 75ex;}
 
 /* For sortable lists */
 table.sortable_head     {background : #AFC8FA; border-top : 2px solid #AFC8FA; border-bottom : 2px solid #AFC8FA;}


### PR DESCRIPTION
Reviewed r709:
- Saved bandwidth and increase efficiency, by selecting and downloading only the data that's necessary for the autocomplete.
- Coding style fixes.
- For selection list: auto select current gene, like LOVD3 did before.
- Auto submit autocomplete list on selecting the gene from the list.
- Placed back old comments and code that had been removed.
- The autocomplete field gets focus on initialization.
- Use jQuery rather than old-style JS.
- Moved width specification of autocomplete field to the field itself. Not the styles.css, which sets it for all future autocomplete fields.
- Reverted styles.css to previous state.
- Improved changelog entries, and white space changes by editor.