### PR TITLE
Prevent browsers from auto-filling usernames in data entry forms

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -59,11 +59,15 @@
    is active for, is now shown on the column's detailed view.
  * Fixed bug; Transcript viewlists included non-public variants in the variant
    counts also for non-authorized users.
- * Fixed bug; automatic filling of certain password fields in forms is now
+ * Fixed bug; Automatic filling of certain password fields in forms is now
    blocked and a fake text field is used to capture auto-filled usernames.
-   Closes #30
- * Fixed bug; fixed link in drop-down under Configuration tab to variants that
-   require attention. Closes #28.
+   Closes #30: "Prevent browsers from auto-filling usernames in data entry
+   forms".
+ * Fixed bug; Fixed the "View uncurated variants" link in the drop-down menu of
+   the Configuration tab as it didn't show all uncurated variants, and changed
+   its name to "Variants that require attention".
+   Closes #26: "Wrong link for uncurated variants in drop-down menu
+   Configuration area".
 
 
 /**************************

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -59,6 +59,11 @@
    is active for, is now shown on the column's detailed view.
  * Fixed bug; Transcript viewlists included non-public variants in the variant
    counts also for non-authorized users.
+ * Fixed bug; automatic filling of certain password fields in forms is now
+   blocked and a fake text field is used to capture auto-filled usernames.
+   Closes #30
+ * Fixed bug; fixed link in drop-down under Configuration tab to variants that
+   require attention. Closes #28.
 
 
 /**************************

--- a/src/class/object_system_settings.php
+++ b/src/class/object_system_settings.php
@@ -4,12 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-23
- * Modified    : 2015-09-21
- * For LOVD    : 3.0-14
+ * Modified    : 2016-02-17
+ * For LOVD    : 3.0-15
  *
- * Copyright   : 2004-2015 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -209,7 +210,7 @@ class LOVD_SystemSetting extends LOVD_Object {
                         'skip',
                         array('', '', 'note', 'The following two fields only apply if the proxy server requires authentication.'),
                         array('Proxy server username', 'In case the proxy server requires authentication, please enter the required username here.', 'text', 'proxy_username', 20),
-                        array('Proxy server password', 'In case the proxy server requires authentication, please enter the required password here.', 'password', 'proxy_password', 20),
+                        array('Proxy server password', 'In case the proxy server requires authentication, please enter the required password here.', 'password', 'proxy_password', 20, true),
                         'hr',
                         'skip',
                         'skip',

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2016-02-09
+ * Modified    : 2016-02-17
  * For LOVD    : 3.0-15
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Mark Kroon MSc. <M.Kroon@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -348,8 +348,8 @@ class LOVD_User extends LOVD_Object {
                         array('Email address(es), one per line', '', 'textarea', 'email', 30, 3),
                         array('Telephone (optional)', '', 'text', 'telephone', 20),
           'username' => array('Username', '', 'text', 'username', 20),
-            'passwd' => array('Password', 'A proper password is at least 4 characters long and contains at least one number or special character.', 'password', 'password_1', 20),
-    'passwd_confirm' => array('Password (confirm)', '', 'password', 'password_2', 20),
+            'passwd' => array('Password', 'A proper password is at least 4 characters long and contains at least one number or special character.', 'password', 'password_1', 20, true),
+    'passwd_confirm' => array('Password (confirm)', '', 'password', 'password_2', 20, true),
      'passwd_change' => array('Must change password at next logon', '', 'checkbox', 'password_force_change'),
                         'hr',
                         'skip',
@@ -393,8 +393,8 @@ class LOVD_User extends LOVD_Object {
                  array(
                         array('POST', '', '', '', '50%', '14', '50%'),
        'change_self' => array('Current password', '', 'password', 'password', 20),
-                        array('New password', '', 'password', 'password_1', 20),
-                        array('New password (confirm)', '', 'password', 'password_2', 20),
+                        array('New password', '', 'password', 'password_1', 20, true),
+                        array('New password (confirm)', '', 'password', 'password_2', 20, true),
                         'skip',
       'change_other' => array('Enter your password for authorization', '', 'password', 'password', 20));
             if ($_PE[1] == $_AUTH['id']) {

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -4,12 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2015-04-20
- * For LOVD    : 3.0-14
+ * Modified    : 2016-02-16
+ * For LOVD    : 3.0-15
  *
- * Copyright   : 2004-2015 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -751,7 +752,8 @@ function lovd_viewForm ($a,
                         $sHelpSuffix   = '</TD>',
                         $sDataPrefix   = "\n            <TD class=\"{{ CLASS }}\" width=\"{{ WIDTH }}\">",
                         $sDataSuffix   = '</TD></TR>',
-                        $sNewLine      = '              ')
+                        $sNewLine      = '              ',
+                        $enableAutofillCred = false)
 {
     // Based on a function provided by Ileos.nl.
     /***************************************************************************
@@ -774,6 +776,8 @@ function lovd_viewForm ($a,
      * array('<header>', '<help_text>', 'checkbox', '<field_name>'),
      * array('<header>', '<help_text>', 'submit', '<button_value>', '<field_name>'),
      *
+     * If parameter $enableAutofillCred is false, the function will try to prevent
+     * the browser from automatically filling credential fields (username/password)
      **********/
 
     // Options.
@@ -891,7 +895,12 @@ function lovd_viewForm ($a,
                 list($sHeader, $sHelp, $sType, $sName, $nSize) = $aField;
                 if (!isset($GLOBALS['_' . $sMethod][$sName])) { $GLOBALS['_' . $sMethod][$sName] = ''; }
 
-                print('<INPUT type="' . $sType . '" name="' . $sName . '" size="' . $nSize . '" value="' . htmlspecialchars($GLOBALS['_' . $sMethod][$sName]) . '"' . (!lovd_errorFindField($sName)? '' : ' class="err"') . '>' . $sDataSuffix);
+                $autofillBlockerAtts = '';
+                if ($sType == 'password' && !$enableAutofillCred) {
+                    // Block editing of the actual password field until onFocus event.
+                    $autofillBlockerAtts = ' readonly onfocus="this.removeAttribute(\'readonly\');" ';
+                }
+                print('<INPUT type="' . $sType . '" name="' . $sName . '" size="' . $nSize . '" value="' . htmlspecialchars($GLOBALS['_' . $sMethod][$sName]) . '"' . (!lovd_errorFindField($sName)? '' : ' class="err"') . $autofillBlockerAtts . '>' . $sDataSuffix);
                 continue;
 
 

--- a/tests/open_close_form.php
+++ b/tests/open_close_form.php
@@ -3,11 +3,11 @@
  *
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
- * Created     : ?
+ * Created     : 2011-04-07
  * Modified    : 2016-02-17
  * For LOVD    : 3.0-15
  *
- * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2011-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *

--- a/tests/open_close_form.php
+++ b/tests/open_close_form.php
@@ -1,4 +1,33 @@
 <?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : ?
+ * Modified    : 2016-02-17
+ * For LOVD    : 3.0-15
+ *
+ * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
 define('ROOT_PATH', '../src/');
 require ROOT_PATH . 'inc-init.php';
 
@@ -37,8 +66,8 @@ $aForm =
                         array('Email address(es), one per line', '', 'textarea', 'email', 30, 3),
                         array('Telephone (optional)', '', 'text', 'telephone', 20),
           'username' => array('Username', '', 'text', 'username', 20),
-            'passwd' => array('Password', '', 'password', 'password_1', 20),
-    'passwd_confirm' => array('Password (confirm)', '', 'password', 'password_2', 20),
+            'passwd' => array('Password', '', 'password', 'password_1', 20, true),
+    'passwd_confirm' => array('Password (confirm)', '', 'password', 'password_2', 20, true),
      'passwd_change' => array('Must change password at next logon', '', 'checkbox', 'password_force_change'),
                         'end_fieldset',
                         'skip',


### PR DESCRIPTION
Improvements to getForm() form generator in inc-lib-form.php. Blocking the autofill browser feature for password fields is off by default. All password fields are preceded by a hidden text field to avoid mistakenly autofilling the username in some unrelated text field.
Resolves #27