### PR TITLE
Protein prediction failed for non-coding transcripts.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -5,6 +5,14 @@
  *************/
 
 /**************************
+ * 3.0 Build 16 ()
+ * 2016-06-..
+ *********/
+ * Fixed bug; RNA prediction of a variant affecting splicing was 'r.(?)' instead
+   of 'r.spl?'.
+
+
+/**************************
  * 3.0 Build 15 (tag:3.0-15)
  * 2016-05-02
  *********/

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -10,6 +10,7 @@
  *********/
  * Fixed bug; RNA prediction of a variant affecting splicing was 'r.(?)' instead
    of 'r.spl?'.
+ * Protein prediction for non-coding transcripts now defaults to "-".
 
 
 /**************************

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2016-05-20
+ * Modified    : 2016-05-27
  * For LOVD    : 3.0-16
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -130,7 +130,7 @@ function lovd_getRNAProteinPrediction ($sVariant, $sGene)
             // Non-coding transcript, Mutalyzer does not return a protein field, but also no error.
             // FIXME: Check for intronic variants here, that do not span over an exon, and give them r.(=).
             $aMutalyzerData['predict']['RNA'] = 'r.(?)';
-            $aMutalyzerData['predict']['protein'] = 'p.0';
+            $aMutalyzerData['predict']['protein'] = '-';
         } elseif ($aMutalyzerData['predict']['protein'] == 'p.?') {
             $aMutalyzerData['predict']['RNA'] = 'r.?';
         } elseif ($aMutalyzerData['predict']['protein'] == 'p.(=)') {

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2016-02-05
- * For LOVD    : 3.0-15
+ * Modified    : 2016-05-20
+ * For LOVD    : 3.0-16
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -124,9 +124,14 @@ function lovd_getRNAProteinPrediction ($sVariant, $sGene)
         }
     }
 
-    if ($oOutput->errors === 0) {
+    if ($oOutput->errors === 0 && empty($aMutalyzerData['predict']['RNA'])) {
         // RNA not filled in yet.
-        if ($aMutalyzerData['predict']['protein'] == 'p.?') {
+        if (!isset($aMutalyzerData['predict']['protein'])) {
+            // Non-coding transcript, Mutalyzer does not return a protein field, but also no error.
+            // FIXME: Check for intronic variants here, that do not span over an exon, and give them r.(=).
+            $aMutalyzerData['predict']['RNA'] = 'r.(?)';
+            $aMutalyzerData['predict']['protein'] = 'p.0';
+        } elseif ($aMutalyzerData['predict']['protein'] == 'p.?') {
             $aMutalyzerData['predict']['RNA'] = 'r.?';
         } elseif ($aMutalyzerData['predict']['protein'] == 'p.(=)') {
             // FIXME: Not correct in case of substitutions e.g. in the third position of the codon, not leading to a protein change.


### PR DESCRIPTION
- Notices where thrown in the script that called Mutalyzer's NameChecker. With notices turned on, this resulted in the never finishing of the loading.
- With notices turned off, it resulted in an empty protein change, while this field is mandatory.
- LOVD will now default to r.(?)/- for non-coding transcripts.
- Later we'll have to implement r.(=) for intronic variants on non-coding transcripts.
- Also fixed bug that splicing errors returned a wrong RNA description:
- Fixed bug; RNA prediction of a variant affecting splicing was 'r.(?)' instead of 'r.spl?'.