### PR TITLE
Fixed problem with double DBID assignment.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -11,6 +11,8 @@
  * Fixed bug; RNA prediction of a variant affecting splicing was 'r.(?)' instead
    of 'r.spl?'.
  * Protein prediction for non-coding transcripts now defaults to "-".
+ * Fixed bug; Variants with both a chromosomal DBID and a gene's DBID, were
+   assigned new gene-specific DBIDs, instead of reusing the existing one.
 
 
 /**************************

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2016-02-17
+ * Modified    : 2016-05-30
  * For LOVD    : 3.0-15
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -432,7 +432,7 @@ function lovd_fetchDBID ($aData)
                 if ($sDBIDoptionSymbol == $sDBIDnewSymbol && $sDBIDoptionNumber < $sDBIDnewNumber && $sDBIDoptionNumber != '000000') {
                     // If the symbol of the option is the same, but the number is lower(not including 000000), take it.
                     $sDBID = $sDBIDoption;
-                } elseif ($sDBIDoptionSymbol != $sDBIDnewSymbol && isset($aGenes) && in_array($sDBIDnewSymbol, $aGenes)) {
+                } elseif ($sDBIDoptionSymbol != $sDBIDnewSymbol && isset($aGenes) && in_array($sDBIDoptionSymbol, $aGenes)) {
                     // If the symbol of the option is different and is one of the genes of the variant you are editing/creating, take it.
                     $sDBID = $sDBIDoption;
                 } elseif (substr($sDBIDnewSymbol, 0, 3) == 'chr' && substr($sDBIDoptionSymbol, 0, 3) != 'chr') {


### PR DESCRIPTION
- Variants with both a chromosomal DBID and a gene's DBID, were assigned new gene-specific DBIDs, instead of reusing the existing one.
- When many observations of the variant existed, LOVD kept assigning new DBIDs and the number of different values per unique variant would increase with every new observation.
- Waiting for travis test to complete. Upon absence of failures, will be merged into master.