### PR TITLE
Clarify IP allow list feature

### DIFF
--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -274,7 +274,14 @@ class LOVD_User extends LOVD_Object {
                 // Check given security IP range.
                 if ($bIP && !lovd_validateIP($aData['allowed_ip'], $_SERVER['REMOTE_ADDR'])) {
                     // This IP range is not allowing the current IP to connect. This ain't right.
-                    lovd_errorAdd('allowed_ip', 'Your current IP address is not matched by the given IP range. This would mean you would not be able to get access to LOVD with this IP range.');
+                    // If IP address is actually IPv6, then complain that we can't restrict at all.
+                    // Otherwise, be clear the current setting just doesn't match.
+                    if (strpos($_SERVER['REMOTE_ADDR'], ':') !== false) {
+                        // IPv6...
+                        lovd_errorAdd('allowed_ip', 'Your current IP address is IPv6 (' . $_SERVER['REMOTE_ADDR'] . '), which is not supported by LOVD to restrict access to your account.');
+                    } else {
+                        lovd_errorAdd('allowed_ip', 'Your current IP address is not matched by the given IP range. This would mean you would not be able to get access to LOVD with this IP range.');
+                    }
                 }
             }
 
@@ -364,7 +371,7 @@ class LOVD_User extends LOVD_Object {
                         'hr',
              'level' => array('Level', ($_AUTH['level'] != LEVEL_ADMIN? '' : '<B>Managers</B> basically have the same rights as you, but can\'t uninstall LOVD nor can they create or edit other Manager accounts.<BR>') . '<B>Submitters</B> can submit, but not publish information in the database. Submitters can also create their own accounts, you don\'t need to do this for them.<BR><BR>In LOVD 3.0, <B>Curators</B> are Submitter-level users with Curator rights on certain genes. To create a Curator account, you need to create a Submitter and then grant this user rights on the necessary genes.', 'select', 'level', 1, $aUserLevels, false, false, false),
                         array('Allowed IP address list (optional)', 'To help prevent others to try and guess the username/password combination, you can restrict access to the account to a number of IP addresses or ranges.', 'text', 'allowed_ip', 20),
-                        array('', '', 'note', 'Default value: *<BR><I>Your current IP address: ' . $_SERVER['REMOTE_ADDR'] . '</I><BR><B>Please be extremely careful using this setting.</B> Using this setting too strictly, can deny the user access to LOVD, even if the correct credentials have been provided.<BR>Set to \'*\' to allow all IP addresses, use \'-\' to specify a range and use \';\' to separate addresses or ranges.'),
+                        array('', '', 'note', 'Default value: *<BR>' . (strpos($_SERVER['REMOTE_ADDR'], ':') !== false? '' : '<I>Your current IP address: ' . $_SERVER['REMOTE_ADDR'] . '</I><BR>') . '<B>Please be extremely careful using this setting.</B> Using this setting too strictly, can deny the user access to LOVD, even if the correct credentials have been provided.<BR>Set to \'*\' to allow all IP addresses, use \'-\' to specify a range and use \';\' to separate addresses or ranges.'),
             'locked' => array('Locked', '', 'checkbox', 'locked'),
                         'hr',
 'authorization_skip' => 'skip',

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2016-02-17
- * For LOVD    : 3.0-15
+ * Modified    : 2016-06-09
+ * For LOVD    : 3.0-16
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -363,8 +363,8 @@ class LOVD_User extends LOVD_Object {
                         array('', '', 'print', '<B>Security</B>'),
                         'hr',
              'level' => array('Level', ($_AUTH['level'] != LEVEL_ADMIN? '' : '<B>Managers</B> basically have the same rights as you, but can\'t uninstall LOVD nor can they create or edit other Manager accounts.<BR>') . '<B>Submitters</B> can submit, but not publish information in the database. Submitters can also create their own accounts, you don\'t need to do this for them.<BR><BR>In LOVD 3.0, <B>Curators</B> are Submitter-level users with Curator rights on certain genes. To create a Curator account, you need to create a Submitter and then grant this user rights on the necessary genes.', 'select', 'level', 1, $aUserLevels, false, false, false),
-                        array('Allowed IP address list', 'To help prevent others to try and guess the username/password combination, you can restrict access to the account to a number of IP addresses or ranges.', 'text', 'allowed_ip', 20),
-                        array('', '', 'note', '<I>Your current IP address: ' . $_SERVER['REMOTE_ADDR'] . '</I><BR><B>Please be extremely careful using this setting.</B> Using this setting too strictly, can deny the user access to LOVD, even if the correct credentials have been provided.<BR>Set to \'*\' to allow all IP addresses, use \'-\' to specify a range and use \';\' to separate addresses or ranges.'),
+                        array('Allowed IP address list (optional)', 'To help prevent others to try and guess the username/password combination, you can restrict access to the account to a number of IP addresses or ranges.', 'text', 'allowed_ip', 20),
+                        array('', '', 'note', 'Default value: *<BR><I>Your current IP address: ' . $_SERVER['REMOTE_ADDR'] . '</I><BR><B>Please be extremely careful using this setting.</B> Using this setting too strictly, can deny the user access to LOVD, even if the correct credentials have been provided.<BR>Set to \'*\' to allow all IP addresses, use \'-\' to specify a range and use \';\' to separate addresses or ranges.'),
             'locked' => array('Locked', '', 'checkbox', 'locked'),
                         'hr',
 'authorization_skip' => 'skip',

--- a/src/inc-js-submit-userform.php
+++ b/src/inc-js-submit-userform.php
@@ -1,0 +1,54 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2016-06-09
+ * Modified    : 2016-06-09
+ * For LOVD    : 3.0-16
+ *
+ * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
+header('Content-type: text/javascript; charset=UTF-8');
+header('Expires: ' . date('r', time()+(180*60)));
+?>
+function lovd_checkForm ()
+{
+    // Check the user account creation/edit form.
+    // The IP address allow list is a sensitive field that sometimes can lead to
+    // problems when a value is filled in that does not match the user's IP
+    // later in time. Not everybody understands that this is an optional field
+    // that should normally be left empty.
+    var oIPField = $("input[name='allowed_ip']");
+
+    // Check if the field contains something else than just '*'.
+    if (oIPField && oIPField.val() && oIPField.val() != '*') {
+        // FIXME: Make a dialog? With 3 buttons? Yes, Review settings, Allow all?
+        if (window.confirm('Are you sure you want to restrict access to your account using this IP address?\nYou can then not access your account from a different computer, or if your computer changes its address.')) {
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        return true;
+    }
+}

--- a/src/inc-js-submit-userform.php
+++ b/src/inc-js-submit-userform.php
@@ -46,6 +46,7 @@ function lovd_checkForm ()
         if (window.confirm('Are you sure you want to restrict access to your account using this IP address?\nYou can then not access your account from a different computer, or if your computer changes its address.')) {
             return true;
         } else {
+            oIPField.focus();
             return false;
         }
     } else {

--- a/src/login.php
+++ b/src/login.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-19
- * Modified    : 2013-02-20
- * For LOVD    : 3.0-03
+ * Modified    : 2016-06-09
+ * For LOVD    : 3.0-16
  *
- * Copyright   : 2004-2013 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -63,7 +63,18 @@ if (!empty($_POST)) {
                 // Instead of having inc-auth.php stop the user when his IP is not allowed to log in, it's better to do that here.
                 if ($zUser['allowed_ip'] && !lovd_validateIP($zUser['allowed_ip'], $_SERVER['REMOTE_ADDR'])) {
                     lovd_writeLog('Auth', 'AuthError', $_SERVER['REMOTE_ADDR'] . ' (' . gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') is not in IP allow list for ' . $_POST['username'] . ': "' . $zUser['allowed_ip'] . '"');
-                    lovd_errorAdd('', 'Your current IP address does not allow you access using this username.');
+
+                    // Provide manager information, so that the user knows where to go for help.
+                    $aManagers = $_DB->query('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ? ORDER BY name', array(LEVEL_MANAGER))->fetchAllAssoc();
+                    if (!$aManagers) {
+                        $aManagers = array($_SETT['admin']);
+                    }
+                    $sManagers = 'For technical assistance, please contact ' . (count($aManagers) == 1? 'the system\'s manager' : 'one of the system\'s managers') . ':';
+                    foreach ($aManagers as $aManager) {
+                        $sManagers .= '<BR><A href="mailto:' . str_replace(array("\r\n", "\r", "\n"), ', ', trim($aManager['email'])) . '">' . $aManager['name'] . '</A>';
+                    }
+
+                    lovd_errorAdd('', 'Your current IP address does not allow you access using this username. ' . $sManagers);
                 }
 
 

--- a/src/users.php
+++ b/src/users.php
@@ -449,6 +449,15 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
                         $_CONF['location_url'] . $_PE[0] . '/' . $nID . "\n\n";
                 }
 
+                // If the user has a specific IP address allow list, warn this user.
+                if (!empty($_POST['allowed_ip']) && $_POST['allowed_ip'] != '*') {
+                    // A certain set of IPs has been specified by the person creating the account.
+                    $sMessage .= 'Note that a restriction has been placed on this account by limiting access to this account from only the IP address(es) specified at the bottom of this email. ' .
+                                 'This might cause you to be unable to log in, even if you have the correct username and password. ' .
+                                 'If this restriction was an error, please log into your account and empty the IP address list field. ' .
+                                 'If you have problems logging in, please contact the LOVD\'s manager.' . "\n\n";
+                }
+
                 $sMessage .= 'Regards,' . "\n" .
                     '    LOVD system at ' . $_CONF['institute'] . "\n\n";
 
@@ -471,6 +480,7 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
                         'reference' => 'Reference',
                         'username' => 'Username',
                         'password_1' => 'Password',
+                        'allowed_ip' => 'Allowed IPs',
                     );
                 if ($_POST['orcid_id'] == 'none') {
                     unset($aMailFields['orcid_id']);
@@ -530,7 +540,7 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
 
     if (GET) {
         print('      To ' . (ACTION == 'create'? 'create a new user' : 'register as a new submitter') . ', please fill out the form below.<BR>' . "\n" .
-            '      <BR>' . "\n\n");
+              '      <BR>' . "\n\n");
     }
 
     if (ACTION == 'register') {

--- a/src/users.php
+++ b/src/users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2016-03-21
- * For LOVD    : 3.0-15
+ * Modified    : 2016-06-09
+ * For LOVD    : 3.0-16
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -540,8 +540,11 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
 
     // Tooltip JS code.
     lovd_includeJS('inc-js-tooltip.php');
+    // Check form (IP address allow list).
+    lovd_includeJS('inc-js-submit-userform.php');
 
-    print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '" method="post">' . "\n" .
+    // Table.
+    print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '" method="post" onsubmit="return lovd_checkForm();">' . "\n" .
           '        <INPUT type="hidden" name="orcid_id" value="' . $_POST['orcid_id'] . '">' . "\n");
 
     // Array which will make up the form table.
@@ -668,9 +671,11 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
 
     // Tooltip JS code.
     lovd_includeJS('inc-js-tooltip.php');
+    // Check form (IP address allow list).
+    lovd_includeJS('inc-js-submit-userform.php');
 
     // Table.
-    print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '" method="post">' . "\n");
+    print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '" method="post" onsubmit="return lovd_checkForm();">' . "\n");
 
     // Array which will make up the form table.
     $aForm = array_merge(


### PR DESCRIPTION
The IP allow list feature needed clarification.
- Clarified that the IP address list is optional.
- Clarified that the IP address list field's default value is *.
- Added JS notice with a warning when user sets the IP address allow list.
- When the form warns about the field being filled in, and you press "Cancel", the IP address list field receives focus.
- Added the IP addresses to the email sent to the user after registering.
- Added a message to the email body when the IP address list has been set to something other than '*'.
- When user is blocked by IP, the manager info is shown.  …
- This, so that the user can know who to contact to get help.
- Clarified we don't support IPv6 for restricting access:  …
  * The form won't show your current address any more, when it's IPv6.
  * When it's IPv6, no input in the IP address list field will be allowed, and LOVD will tell you it's because we don't support IPv6.

Implements #69.