### PR TITLE
Fixed bug in the update import

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -16,6 +16,7 @@
  * Fixed bug; When updating data using the update through import beta feature
    and leaving the owned_by field out of the file or empty, LOVD would overwrite
    the existing value with the ID of the user importing the file.
+   Closes #66: "Update import always wants to edit the owned_by field".
 
 
 /**************************

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -13,6 +13,9 @@
  * Protein prediction for non-coding transcripts now defaults to "-".
  * Fixed bug; Variants with both a chromosomal DBID and a gene's DBID, were
    assigned new gene-specific DBIDs, instead of reusing the existing one.
+ * Fixed bug; When updating data using the update through import beta feature
+   and leaving the owned_by field out of the file or empty, LOVD would overwrite
+   the existing value with the ID of the user importing the file.
 
 
 /**************************

--- a/src/import.php
+++ b/src/import.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2016-05-02
- * For LOVD    : 3.0-15
+ * Modified    : 2016-06-22
+ * For LOVD    : 3.0-16
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -793,7 +793,7 @@ if (POST) {
 
             // General default values.
             // Owned By.
-            if (in_array('owned_by', $aSection['allowed_columns']) && (!isset($aLine['owned_by']) || $aLine['owned_by'] === '')) {
+            if (in_array('owned_by', $aSection['allowed_columns']) && (!isset($aLine['owned_by']) || $aLine['owned_by'] === '') && $sMode != 'update') {
                 // Owned_by not filled in, and not set to LOVD (0) either. Set to user.
                 $aLine['owned_by'] = $_AUTH['id'];
             }


### PR DESCRIPTION
Fixed bug in the update import:
- Fixed bug; When updating data using the update through import beta feature and leaving the owned_by field out of the file or empty, LOVD would overwrite the existing value with the ID of the user importing the file.
- Currently, no default value will be filled in for the owned_by field when updating, also not when the file is given in the file but left empty.
- This is now consistent with the statusid column, that had been modified previously to no longer apply defaults for updates through import.
- Closes #66.