### PR TITLE
Fixed update import bug

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -17,6 +17,9 @@
    and leaving the owned_by field out of the file or empty, LOVD would overwrite
    the existing value with the ID of the user importing the file.
    Closes #66: "Update import always wants to edit the owned_by field".
+ * Fixed bug; When running the update import, LOVD would complain if fields are
+   not filled in correctly, even if those fields are not defined in the file.
+   Closes #53: "Importing records fails on existing fields in database".
 
 
 /**************************


### PR DESCRIPTION
Fixed update import bug:
- Fixed bug; When running the update import, LOVD would complain if fields are not filled in correctly, even if those fields are not defined in the file.
- Now, if updating, LOVD will ignore errors that are linked to fields that are not in the file that is being imported.
- Closes #53: "Importing records fails on existing fields in database".