### PR TITLE
Fixed bug; Submitters could find a way to access the full users list.

### DIFF
--- a/src/ajax/viewlist.php
+++ b/src/ajax/viewlist.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-02-18
- * Modified    : 2016-07-01
+ * Modified    : 2016-07-14
  * For LOVD    : 3.0-17
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -55,7 +55,7 @@ $aNeededLevel =
                 'Shared_Column' => LEVEL_CURATOR,
                 'Transcript' => 0,
                 'Transcript_Variant' => 0,
-                'User' => LEVEL_SUBMITTER,
+                'User' => LEVEL_SUBMITTER, // Certain fields will be forcefully removed, though.
               );
 if (isset($aNeededLevel[$_GET['object']])) {
     $nNeededLevel = $aNeededLevel[$_GET['object']];
@@ -100,6 +100,14 @@ if ($_AUTH['level'] < LEVEL_MANAGER && (!empty($_AUTH['curates']) || !empty($_AU
     }
 }
 
+// 2016-07-14; 3.0-17; Submitters should not be allowed to retrieve more
+// information about users than the info the access sharing page gives them.
+$aColsToSkip = (!empty($_GET['skip'])? $_GET['skip'] : array());
+if ($_GET['object'] == 'User' && $_AUTH['level'] == LEVEL_SUBMITTER) {
+    // Force removal of certain columns, regardless of this has been requested or not.
+    $aColsToSkip = array_unique(array_merge($aColsToSkip, array('username', 'status_', 'last_login_', 'created_date_', 'curates', 'level_')));
+}
+
 // Require special clearance?
 if ($nNeededLevel && (!$_AUTH || $_AUTH['level'] < $nNeededLevel)) {
     // If not authorized, die with error message.
@@ -139,7 +147,6 @@ if (in_array($_GET['object'], array('Custom_ViewList', 'Phenotype', 'Shared_Colu
 }
 require $sFile;
 $_GET['object'] = 'LOVD_' . str_replace('_', '', $_GET['object']); // FIXME; test dit op een windows, test case-insensitivity.
-$aColsToSkip = (!empty($_GET['skip'])? $_GET['skip'] : array());
 $_DATA = new $_GET['object']($sObjectID, $nID);
 // Set $bHideNav to false always, since this ajax request could only have been sent if there were navigation buttons.
 $_DATA->viewList($_GET['viewlistid'], $aColsToSkip, (!empty($_GET['nohistory'])? true : false), (!empty($_GET['hidenav'])? true : false), (!empty($_GET['options'])? true : false), (!empty($_GET['only_rows'])? true : false));

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -10,7 +10,7 @@
  *********/
  * Fixed bug; Impossible for users of level submitter to browse the user list
    on the access sharing page.
- * Fixed bug; Repeated gene names on user acccount pages.
+ * Fixed bug; Repeated gene names on user account pages.
 
 
 /**************************

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2016-07-01
+ * Modified    : 2016-07-14
  * For LOVD    : 3.0-17
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -139,6 +139,9 @@ class LOVD_User extends LOVD_Object {
         // List of columns and (default?) order for viewing a list of entries.
         $this->aColumnsViewList =
                  array(
+                        'userid' => array(
+                                    'view' => false,
+                                    'db'   => array('u.id', 'ASC', true)),
                         'id' => array(
                                     'view' => array('ID', 45),
                                     'db'   => array('u.id', 'ASC', true)),

--- a/src/users.php
+++ b/src/users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2016-06-23
- * For LOVD    : 3.0-16
+ * Modified    : 2016-07-14
+ * For LOVD    : 3.0-17
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1243,7 +1243,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'share_access') {
     $_GET['page_size'] = 10;
 
     // Set filter for viewlist to hide current colleagues and the user being viewed.
-    $_GET['search_id'] = '!' . $nID;
+    $_GET['search_userid'] = '!' . $nID;
     foreach ($aColleagues as $aColleague) {
         $_GET['search_id'] .= ' !' . $aColleague['id'];
     }
@@ -1252,7 +1252,8 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'share_access') {
     $_DATA = new LOVD_User();
     $_DATA->setRowLink('users_share_access',
         'javascript:lovd_passAndRemoveViewListRow("{{ViewListID}}", "{{ID}}", {id: "{{ID}}", name: "{{zData_name}}"}, lovd_addUserShareAccess); return false;');
-    $_DATA->viewList($sUserListID, array('id', 'status_', 'last_login_', 'created_date_', 'curates', 'level_'), true);
+    // The columns hidden here are also specified (enforced) in ajax/viewlist.php to make sure Submitters can't hack their way into the users table.
+    $_DATA->viewList($sUserListID, array('username', 'status_', 'last_login_', 'created_date_', 'curates', 'level_'), true);
 
     lovd_showInfoTable('<B>' . $zData['name'] . ' (' . $nID . ')</B> shares access to all
                        data owned by him with the users listed below.', 'information');

--- a/src/users.php
+++ b/src/users.php
@@ -1245,7 +1245,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'share_access') {
     // Set filter for viewlist to hide current colleagues and the user being viewed.
     $_GET['search_userid'] = '!' . $nID;
     foreach ($aColleagues as $aColleague) {
-        $_GET['search_id'] .= ' !' . $aColleague['id'];
+        $_GET['search_userid'] .= ' !' . $aColleague['id'];
     }
 
     // Show viewlist to select new users to share access with.

--- a/tests/selenium_tests/access_sharing_tests/access_sharing_submitter.php
+++ b/tests/selenium_tests/access_sharing_tests/access_sharing_submitter.php
@@ -96,7 +96,7 @@ class AccessSharingSubmitterTest extends LOVDSeleniumBaseTestCase
         $this->waitForElementPresent($sMenuItemSelector, '8000');
         $this->click($sMenuItemSelector);
 
-        $sUserSelector = '//td[text()="' . $sSubName2 . '"]';
+        $sUserSelector = '//a[text()="' . $sSubName2 . '"]';
         $this->waitForElementPresent($sUserSelector, '8000');
         $this->click($sUserSelector);
 

--- a/tests/selenium_tests/access_sharing_tests/access_sharing_submitter.php
+++ b/tests/selenium_tests/access_sharing_tests/access_sharing_submitter.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-04-21
- * Modified    : 2016-06-21
- * For LOVD    : 3.0-16
+ * Modified    : 2016-07-14
+ * For LOVD    : 3.0-17
  *
  * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
@@ -96,7 +96,7 @@ class AccessSharingSubmitterTest extends LOVDSeleniumBaseTestCase
         $this->waitForElementPresent($sMenuItemSelector, '8000');
         $this->click($sMenuItemSelector);
 
-        $sUserSelector = '//td[text()="' . $sSubUsername2 . '"]';
+        $sUserSelector = '//td[text()="' . $sSubName2 . '"]';
         $this->waitForElementPresent($sUserSelector, '8000');
         $this->click($sUserSelector);
 


### PR DESCRIPTION
Fixed bug; Submitters could find a way to access the full users list.
- Submitters have access to the Users object for access sharing.
- This access was partially granted in 3.0-16, but the actual security issue was introduced later when the VL was released to submitters, so they could search and sort the access sharing VL.
- Certain columns were hidden for security reasons by the access sharing page, but manipulating the VL directly allowed any submitter to get a full list of the LOVD users with full columns.
- The columns hidden in the access sharing page are now forced to be hidden in any users VL for submitter level users.
- Additionally, hid the username field, and unhid the ID field.
- Fixed typo in changelog.txt.