### PR TITLE
Fixed bug; The recent SOAP fix broke POST calls over proxy servers using the fsockopen() implementation.

### DIFF
--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2016-08-26
+ * Modified    : 2016-09-08
  * For LOVD    : 3.0-17
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -930,7 +930,7 @@ function lovd_php_file ($sURL, $bHeaders = false, $sPOST = false, $aAdditionalHe
 
     // Prepare proxy authorization header.
     if (!empty($_CONF['proxy_username']) && !empty($_CONF['proxy_password'])) {
-        $aAdditionalHeaders[] = 'Proxy-Authorization: Basic ' . base64_encode($_CONF['proxy_username'] . ':' . $_CONF['proxy_password']) . "\r\n";
+        $aAdditionalHeaders[] = 'Proxy-Authorization: Basic ' . base64_encode($_CONF['proxy_username'] . ':' . $_CONF['proxy_password']);
     }
 
     $aAdditionalHeaders[] = ''; // To make sure we end with a \r\n.


### PR DESCRIPTION
Too much whitespace was added to the SOAP login information, breaking the headers. Part of the headers then got attached to the POST information.