### PR TITLE
Fixed issue with HGNC returning multiple OMIM IDs sometimes.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -36,6 +36,9 @@
    (thanks to Jorge Oliveira, Centro Hospitalar do Porto, for reporting)
  * Fixed bug; For curators, editing a disease could result in a fatal error in
    some conditions.
+ * Fixed issue with the HGNC returning multiple OMIM IDs sometimes. Some LOVD
+   installations refuse to create such genes.
+   (thanks to Jorge Oliveira, Centro Hospitalar do Porto, for reporting)
 
 
 /**************************

--- a/src/genes.php
+++ b/src/genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2016-07-15
+ * Modified    : 2016-09-14
  * For LOVD    : 3.0-17
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -284,8 +284,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                         $sGeneName = $aGeneInfo['name'];
                         $sChromLocation = $aGeneInfo['location'];
                         $sEntrez = $aGeneInfo['entrez_id'];
-                        // OMIM ID is not always defined.
-                        $nOmim = (!isset($aGeneInfo['omim_id'])? '' : $aGeneInfo['omim_id']);
+                        $nOmim = $aGeneInfo['omim_id'];
                     }
                 }
             }

--- a/src/inc-lib-genes.php
+++ b/src/inc-lib-genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-01-25
- * Modified    : 2016-08-12
+ * Modified    : 2016-09-14
  * For LOVD    : 3.0-17
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -214,9 +214,11 @@ function lovd_getGeneInfoFromHGNC ($sHgncId, $bRecursion = false)
     foreach (array('omim_id') as $sCol) {
         // Columns presented as arrays (new?), but should contain just one value.
         // 2014-12-23; 3.0-13; Can also not be defined.
+        // 2016-09-14; 3.0-17; HGNC can actually return multiple OMIM IDs,
+        //  take just the first one.
         if (!isset($aGene[$sCol])) {
             $aGene[$sCol] = '';
-        } elseif (is_array($aGene[$sCol]) && count($aGene[$sCol]) == 1) {
+        } elseif (is_array($aGene[$sCol])) {
             $aGene[$sCol] = $aGene[$sCol][0];
         }
     }
@@ -347,6 +349,12 @@ function lovd_getGeneInfoFromHgncOld ($sHgncId, $aCols, $bRecursion = false)
         foreach (array_diff($aColumns, $aCols) as $sUnwantedColumn) {
             // Don't return columns the caller hasn't asked for.
             unset($aGene[$sUnwantedColumn]);
+        }
+
+        // 2016-09-14; 3.0-17; HGNC can return multiple OMIM IDs.
+        if (isset($aGene['md_mim_id']) && preg_match('/^(\d+), /', $aGene['md_mim_id'], $aRegs)) {
+            // Just trim the other(s) off.
+            $aGene['md_mim_id'] = $aRegs[1];
         }
 
         return $aGene;


### PR DESCRIPTION
Databases set to strict mode would refuse to create such genes.