### PR TITLE
Custom columns could no longer be edited because of a double inclusion of a library file.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -5,6 +5,14 @@
  *************/
 
 /**************************
+ * 3.0 Build 17 patch 02
+ * 2016-09-2?
+ *********/
+ * Fixed bug; Custom columns could no longer be edited because of a double
+   inclusion of a library file.
+
+
+/**************************
  * 3.0 Build 17 patch 01
  * 2016-09-22
  *********/

--- a/src/columns.php
+++ b/src/columns.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-03-04
- * Modified    : 2016-07-25
- * For LOVD    : 3.0-17
+ * Modified    : 2016-09-26
+ * For LOVD    : 3.0-17-patch-02
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -54,7 +54,7 @@ if (PATH_COUNT < 3 && !ACTION) {
             $_GET['search_category'] = $_PE[1];
             define('PAGE_TITLE', 'Browse ' . $_PE[1] . ' custom data columns');
 
-            require ROOT_PATH . 'inc-lib-columns.php';
+            require_once ROOT_PATH . 'inc-lib-columns.php';
             $aTableInfo = lovd_getTableInfoByCategory($_PE[1]);
         } else {
             header('Location:' . lovd_getInstallURL() . $_PE[0] . '?search_category=' . $_PE[1]);
@@ -122,7 +122,7 @@ if (PATH_COUNT > 2 && !ACTION) {
     lovd_isAuthorized('gene', $_AUTH['curates']); // Will set user's level to LEVEL_CURATOR if he is one at all.
     lovd_requireAUTH(LEVEL_CURATOR);
 
-    require ROOT_PATH . 'inc-lib-columns.php';
+    require_once ROOT_PATH . 'inc-lib-columns.php';
     require ROOT_PATH . 'class/object_columns.php';
     $_DATA = new LOVD_Column();
     $zData = $_DATA->viewEntry($sColumnID);
@@ -156,7 +156,7 @@ if (PATH_COUNT == 2 && ACTION == 'order') {
 
     $sCategory = $_PE[1];
 
-    require ROOT_PATH . 'inc-lib-columns.php';
+    require_once ROOT_PATH . 'inc-lib-columns.php';
     $aTableInfo = lovd_getTableInfoByCategory($sCategory);
     if (!$aTableInfo) {
         $_T->printHeader();
@@ -849,7 +849,7 @@ if (PATH_COUNT > 2 && ACTION == 'edit') {
 
     // Require form functions.
     require ROOT_PATH . 'inc-lib-form.php';
-    require ROOT_PATH . 'inc-lib-columns.php';
+    require_once ROOT_PATH . 'inc-lib-columns.php';
 
     // Generate a unique workID, that is sortable.
     if (!isset($_POST['workID'])) {
@@ -1360,7 +1360,7 @@ if (PATH_COUNT > 2 && ACTION == 'add') {
 
     // Require form & column functions.
     require ROOT_PATH . 'inc-lib-form.php';
-    require ROOT_PATH . 'inc-lib-columns.php';
+    require_once ROOT_PATH . 'inc-lib-columns.php';
 
     // Required clearance depending on which type of column is being added.
     $aTableInfo = lovd_getTableInfoByCategory($sCategory);
@@ -1711,7 +1711,7 @@ if (PATH_COUNT > 2 && ACTION == 'remove') {
 
     // Require form & column functions.
     require ROOT_PATH . 'inc-lib-form.php';
-    require ROOT_PATH . 'inc-lib-columns.php';
+    require_once ROOT_PATH . 'inc-lib-columns.php';
 
     // Required clearance depending on which type of column is being added.
     $aTableInfo = lovd_getTableInfoByCategory($sCategory);

--- a/src/references.php
+++ b/src/references.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-03-11
- * Modified    : 2015-12-01
- * For LOVD    : 3.0-15
+ * Modified    : 2016-09-26
+ * For LOVD    : 3.0-17-patch-02
  *
  * Copyright   : 2004-2015 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -72,7 +72,7 @@ if (PATH_COUNT >= 2 && (substr($aPathElements[1], 0, 4) == 'DOI:' || substr($aPa
     // URL: /references/PMID:...../image
     // View specific DOI or PMID.
 
-    require ROOT_PATH . 'inc-lib-columns.php';
+    require_once ROOT_PATH . 'inc-lib-columns.php';
 
     if (substr($aPathElements[1], 0, 4) == 'DOI:') {
         $sSearchPattern = '%{DOI:%' . substr($aPathElements[1], 4) . '}%';


### PR DESCRIPTION
Could have removed some of the `inc-lib-columns.php` inclusions, but now their presence can remind us we may need to split that file, and keep the inclusion for the functions that stay in it.
Fixes #136.