### PR TITLE
Fix/test fnr

### DIFF
--- a/src/inc-js-viewlist.php
+++ b/src/inc-js-viewlist.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-29
- * Modified    : 2016-09-08
+ * Modified    : 2016-09-29
  * For LOVD    : 3.0-17
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -496,25 +496,21 @@ function lovd_activateMenu (sViewListID)
 
 
 
-function onNextDocumentClick (callback)
+function onNextDocumentClick (callback, eventName)
 {
-    // Call callback function on next click anywhere on the page.
+    if (typeof eventName == 'undefined') {
+        // Create a random name if none is specified.
+        eventName = 'click.' + Math.random().toString(36).substr(2, 5);
+    }
 
-    $(document).on('click.onNextDocumentClick', function() {
+    // Call callback function on next click anywhere on the page.
+    $(document).on(eventName, function() {
         // Remove event binding.
-        $(document).off('click.onNextDocumentClick');
+        $(document).off(eventName);
         callback();
     });
 }
 
-
-
-
-function closeAllTooltips ()
-{
-    // Remove tooltip elements from DOM.
-    $('div[role="tooltip"]').remove();
-}
 
 
 
@@ -612,8 +608,15 @@ function lovd_FRShowOverlayColumn (index, targetTH, sOverlayClassname, tableHeig
             bShowPreview: true,
             bShowSubmit: false
         };
-        overlayDiv.on('click', function () {
+        overlayDiv.on('click', function (clickEvent) {
+            // Make sure the click event is propagated now and not after this
+            // function is finished.
+            clickEvent.stopPropagation();
+            $(this).parent().click();
             $('.' + sOverlayClassname).remove();
+
+            // Open F&R options menu (including tooltip, which closes on next
+            // click event).
             lovd_FRShowOptionsMenu(sViewListID, oCurrentOptions);
         });
     } else {
@@ -626,12 +629,13 @@ function lovd_FRShowOverlayColumn (index, targetTH, sOverlayClassname, tableHeig
 
     if (index == 0) {
         // Show tooltip near first column.
-        overlayDiv.tooltip({
-            items: '.' + sOverlayClassname,
+        $(targetTH).tooltip({
+            items: targetTH,
             content: 'Select a column to use for Find & Replace',
+            disabled: true, // don't show tooltip on mouseover
             position: {
                 my: 'left bottom',
-                at: 'right top',
+                at: 'right top-20',
                 using: function(position, feedback) {
                     $(this).css(position);
                     $('<DIV>')
@@ -640,10 +644,12 @@ function lovd_FRShowOverlayColumn (index, targetTH, sOverlayClassname, tableHeig
                         .addClass(feedback.horizontal)
                         .appendTo(this);
                     $(this).removeClass('ui-widget-content');
-                    onNextDocumentClick(closeAllTooltips);
                 }
             }
         }).tooltip('open');
+        onNextDocumentClick(function() {
+            $(targetTH).tooltip('close');
+        });
     }
 }
 
@@ -678,15 +684,9 @@ function lovd_FRColumnSelector (sViewListID)
     });
 
     // Capture clicks outside the column overlays to cancel the F&R action.
-    $(document).on('click.columnSelector', function(event) {
-        if (!$(event.target).closest('.' + sOverlayClassname).length) {
-            // Remove viewlist column overlays.
-            $('.' + sOverlayClassname).remove();
-
-            // Remove page-wide click event capture.
-            $(document).off('click.columnSelector');
-        }
-    })
+    onNextDocumentClick(function () {
+        $('.' + sOverlayClassname).remove();
+    });
 }
 
 
@@ -705,29 +705,37 @@ function lovd_FRShowOptionsMenu (sViewListID, oNewOptions)
     if (FRState[sViewListID]['phase'] == 'input' || FRState[sViewListID]['phase'] == 'preview') {
         var FROptions = lovd_getFROptionsElement(sViewListID);
         FROptions.show();
-    }
 
-    if (FRState[sViewListID]['phase'] == 'input') {
-        // Display a tooltip for the options menu.
-        var displayNameElement = $('#viewlistFRColDisplay_' + sViewListID);
-        displayNameElement.tooltip({
-            items: '#viewlistFRColDisplay_' + sViewListID,
-            content: 'Specify find & replace options',
-            position: {
-                my: 'left bottom',
-                at: 'left-40 top-15',
-                using: function (position, feedback) {
-                    $(this).css(position);
-                    $('<DIV>')
-                        .addClass('arrow')
-                        .addClass(feedback.vertical)
-                        .addClass(feedback.horizontal)
-                        .appendTo(this);
-                    $(this).removeClass('ui-widget-content');
-                    onNextDocumentClick(closeAllTooltips);
-                }
-            }
-        }).tooltip('open');
+        // Jquery-ui tooltip keeps jumping just after it is displayed. Attempts to
+        // avoid this (show: false, hide:false, collision: 'none') have failed. As
+        // it is quite annoying, I have disabled it for now.
+//        if (FRState[sViewListID]['phase'] == 'input') {
+//            // Display a tooltip for the options menu.
+//            FROptions.tooltip({
+//                items: FROptions,
+//                content: 'Specify find & replace options',
+//                disabled: true, // Do not show tooltip on mouseover.
+//                show: false,
+//                hide: false,
+//                position: {
+//                    my: 'left bottom',
+//                    at: 'left top+40',
+//                    collision: 'none',
+//                    using: function (position, feedback) {
+//                        $(this).css(position);
+//                        $('<DIV>')
+//                            .addClass('arrow')
+//                            .addClass(feedback.vertical)
+//                            .addClass(feedback.horizontal)
+//                            .appendTo(this);
+//                        $(this).removeClass('ui-widget-content');
+//                    }
+//                }
+//            }).tooltip('open');
+//            onNextDocumentClick(function() {
+//                FROptions.tooltip('close');
+//            });
+//        }
     }
 }
 
@@ -754,6 +762,7 @@ function lovd_FRPreview (sViewListID)
         FRPreviewHeader.tooltip({
             items: 'th',
             content: 'Preview changes (' + sFRRowsAffected + ' rows affected)',
+            disabled: true, // Don't show tooltip on mouseover.
             position: {
                 my: 'center bottom',
                 at: 'center top-15',
@@ -765,10 +774,15 @@ function lovd_FRPreview (sViewListID)
                         .addClass(feedback.horizontal)
                         .appendTo(this);
                     $(this).removeClass('ui-widget-content');
-                    onNextDocumentClick(closeAllTooltips);
                 }
             }
         }).tooltip('open');
+        onNextDocumentClick(function() {
+            FRPreviewHeader.tooltip('close');
+            // Calling 'close' in this case does not remove tooltip from page,
+            // therefore we destroy the tooltip too, removing it from the DOM.
+            FRPreviewHeader.tooltip('destroy');
+        });
     });
 }
 
@@ -821,7 +835,7 @@ function lovd_FRCleanup (sViewListID, bSubmitVL, afterSubmitCallback)
     }
 
     // Hide all tooltips.
-    closeAllTooltips();
+    $('div[role="tooltip"]').remove();
 }
 
 

--- a/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
+++ b/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-03-02
- * Modified    : 2016-09-23
- * For LOVD    : 3.0-18
+ * Modified    : 2016-10-26
+ * For LOVD    : 3.0-17
  *
  * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
@@ -31,6 +31,7 @@
 
 
 require_once 'inc-lib-test.php';
+require_once 'RefreshingWebDriverElement.php';
 
 use \Facebook\WebDriver\Exception\NoSuchElementException;
 use \Facebook\WebDriver\Exception\WebDriverException;

--- a/tests/selenium_tests/LOVDWebDriver.php
+++ b/tests/selenium_tests/LOVDWebDriver.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-10-26
- * Modified    : 2016-10-26
+ * Modified    : 2016-10-27
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -30,9 +30,10 @@
 
 require_once 'RefreshingWebDriverElement.php';
 
-use \Facebook\WebDriver\WebDriverBy;
 use \Facebook\WebDriver\Remote\DriverCommand;
 use \Facebook\WebDriver\Remote\RemoteWebDriver;
+use \Facebook\WebDriver\WebDriverBy;
+
 
 class LOVDWebDriver extends RemoteWebDriver {
     /**
@@ -40,7 +41,7 @@ class LOVDWebDriver extends RemoteWebDriver {
      * to make use of RefreshingWebDriverElement.
      */
 
-    public function findElement(WebDriverBy $by)
+    public function findElement (WebDriverBy $by)
     {
         // This method is similar to RemoteWebDriver::findElement() but
         // returns an instance of RefreshingWebElement.
@@ -50,6 +51,8 @@ class LOVDWebDriver extends RemoteWebDriver {
             $params
         );
 
+        // Create a RefreshingWebElement and set resources needed to let the
+        // element refresh in the future.
         $element = new RefreshingWebElement($this->getExecuteMethod(), $raw_element['ELEMENT']);
         $element->setLocator($by);
         $element->setWebDriver($this);

--- a/tests/selenium_tests/LOVDWebDriver.php
+++ b/tests/selenium_tests/LOVDWebDriver.php
@@ -1,0 +1,59 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2016-10-26
+ * Modified    : 2016-10-26
+ * For LOVD    : 3.0-18
+ *
+ * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : M. Kroon <m.kroon@lumc.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
+require_once 'RefreshingWebDriverElement.php';
+
+use \Facebook\WebDriver\WebDriverBy;
+use \Facebook\WebDriver\Remote\DriverCommand;
+use \Facebook\WebDriver\Remote\RemoteWebDriver;
+
+class LOVDWebDriver extends RemoteWebDriver {
+    /**
+     * Custom wrapper for RemoteWebDriver. Overloading its findElement method
+     * to make use of RefreshingWebDriverElement.
+     */
+
+    public function findElement(WebDriverBy $by)
+    {
+        // This method is similar to RemoteWebDriver::findElement() but
+        // returns an instance of RefreshingWebElement.
+        $params = array('using' => $by->getMechanism(), 'value' => $by->getValue());
+        $raw_element = $this->execute(
+            DriverCommand::FIND_ELEMENT,
+            $params
+        );
+
+        $element = new RefreshingWebElement($this->getExecuteMethod(), $raw_element['ELEMENT']);
+        $element->setLocator($by);
+        $element->setWebDriver($this);
+        return $element;
+    }
+}
+

--- a/tests/selenium_tests/LOVDWebDriver.php
+++ b/tests/selenium_tests/LOVDWebDriver.php
@@ -37,7 +37,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class LOVDWebDriver extends RemoteWebDriver {
     /**
-     * Custom wrapper for RemoteWebDriver. Overloading its findElement method
+     * Sub class of RemoteWebDriver. Overloading its findElement method
      * to make use of RefreshingWebDriverElement.
      */
 

--- a/tests/selenium_tests/RefreshingWebDriverElement.php
+++ b/tests/selenium_tests/RefreshingWebDriverElement.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-09-27
- * Modified    : 2016-10-26
+ * Modified    : 2016-10-27
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -54,63 +54,25 @@ class RefreshingWebElement extends RemoteWebElement {
     protected $locator;
 
 
-    public function setWebDriver(WebDriver $driver)
-    {
-        $this->driver = $driver;
-    }
-
-
-    public function setLocator(WebDriverBy $locator)
-    {
-        $this->locator = $locator;
-    }
-
-
-    public function clear()
+    public function clear ()
     {
         return $this->tryWithRefresh('clear');
     }
 
 
-    public function click()
+    public function click ()
     {
         return $this->tryWithRefresh('click');
     }
 
 
-    public function getText()
+    public function getText ()
     {
         return $this->tryWithRefresh('getText');
     }
 
 
-    public function sendKeys($value)
-    {
-        return $this->tryWithRefresh('sendKeys', array($value));
-    }
-
-
-    private function tryWithRefresh($sParentMethod, $args=array())
-    {
-        $aFunction = array(get_parent_class($this), $sParentMethod);
-        $e = null;
-        for ($i = 0; $i < MAX_TRIES_STALE_REFRESH; $i++) {
-            try {
-                return call_user_func_array($aFunction, $args);
-            } catch (StaleElementReferenceException $e) {
-                // Refresh the element so we can try again.
-                if (!$this->refresh()) {
-                    // Refresh failed, can't do anything better than to re-throw the exception.
-                    throw $e;
-                }
-            }
-        }
-        // Too many tries, rethrow the exception.
-        throw $e;
-    }
-
-
-    private function refresh()
+    private function refresh ()
     {
         // Refresh this element by re-running findElement() using the locator.
 
@@ -126,6 +88,50 @@ class RefreshingWebElement extends RemoteWebElement {
 
         // Cannot refresh element without locator or driver.
         return false;
+    }
+
+
+    public function sendKeys($value)
+    {
+        return $this->tryWithRefresh('sendKeys', array($value));
+    }
+
+
+    public function setWebDriver(WebDriver $driver)
+    {
+        // Set webdriver instance to be used for refreshing element.
+        $this->driver = $driver;
+    }
+
+
+    public function setLocator(WebDriverBy $locator)
+    {
+        // Set locator to be used for refreshing element.
+        $this->locator = $locator;
+    }
+
+
+    private function tryWithRefresh($sParentMethod, $args=array())
+    {
+        // Call method of the parent class with method name $sParentMethod and
+        // contents of array $args as arguments. If the method call results in
+        // a stale element reference exception, it will try a number of times
+        // to refresh the element and call the method again.
+        $aFunction = array(get_parent_class($this), $sParentMethod);
+        $e = null;
+        for ($i = 0; $i < MAX_TRIES_STALE_REFRESH; $i++) {
+            try {
+                return call_user_func_array($aFunction, $args);
+            } catch (StaleElementReferenceException $e) {
+                // Refresh the element so we can try again.
+                if (!$this->refresh()) {
+                    // Refresh failed, can't do anything better than to re-throw the exception.
+                    throw $e;
+                }
+            }
+        }
+        // Too many tries, rethrow the exception.
+        throw $e;
     }
 }
 

--- a/tests/selenium_tests/RefreshingWebDriverElement.php
+++ b/tests/selenium_tests/RefreshingWebDriverElement.php
@@ -42,7 +42,7 @@ class RefreshingWebElement extends RemoteWebElement {
      * exception is thrown, it tries to reload the element using the
      * locator.
      *
-     * This strategy tries to overcome stale elements resulting from unforseen
+     * This strategy tries to overcome stale elements resulting from unforeseen
      * re-rendering of the DOM instead of expected element staleness for
      * example due to page reloading.
      */
@@ -91,27 +91,27 @@ class RefreshingWebElement extends RemoteWebElement {
     }
 
 
-    public function sendKeys($value)
+    public function sendKeys ($value)
     {
         return $this->tryWithRefresh('sendKeys', array($value));
     }
 
 
-    public function setWebDriver(WebDriver $driver)
+    public function setWebDriver (WebDriver $driver)
     {
         // Set webdriver instance to be used for refreshing element.
         $this->driver = $driver;
     }
 
 
-    public function setLocator(WebDriverBy $locator)
+    public function setLocator (WebDriverBy $locator)
     {
         // Set locator to be used for refreshing element.
         $this->locator = $locator;
     }
 
 
-    private function tryWithRefresh($sParentMethod, $args=array())
+    private function tryWithRefresh ($sParentMethod, $args=array())
     {
         // Call method of the parent class with method name $sParentMethod and
         // contents of array $args as arguments. If the method call results in

--- a/tests/selenium_tests/RefreshingWebDriverElement.php
+++ b/tests/selenium_tests/RefreshingWebDriverElement.php
@@ -1,0 +1,132 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2016-09-27
+ * Modified    : 2016-10-26
+ * For LOVD    : 3.0-18
+ *
+ * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : M. Kroon <m.kroon@lumc.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
+
+use \Facebook\WebDriver\Exception\StaleElementReferenceException;
+use \Facebook\WebDriver\Remote\RemoteWebElement;
+use \Facebook\WebDriver\WebDriverBy;
+use \Facebook\WebDriver\WebDriver;
+
+
+class RefreshingWebElement extends RemoteWebElement {
+    /**
+     * RefreshingWebElement keeps track of the locator that was used to
+     * retrieve it from the web page. Whenever a StaleElementReference
+     * exception is thrown, it tries to reload the element using the
+     * locator.
+     *
+     * This strategy tries to overcome stale elements resulting from unforseen
+     * re-rendering of the DOM instead of expected element staleness for
+     * example due to page reloading.
+     */
+
+    // WebDriver instance used for refreshing the element.
+    protected $driver;
+
+    // Locator used to generate $element (of WebDriverBy type).
+    protected $locator;
+
+
+    public function setWebDriver(WebDriver $driver)
+    {
+        $this->driver = $driver;
+    }
+
+
+    public function setLocator(WebDriverBy $locator)
+    {
+        $this->locator = $locator;
+    }
+
+
+    public function clear()
+    {
+        return $this->tryWithRefresh('clear');
+    }
+
+
+    public function click()
+    {
+        return $this->tryWithRefresh('click');
+    }
+
+
+    public function getText()
+    {
+        return $this->tryWithRefresh('getText');
+    }
+
+
+    public function sendKeys($value)
+    {
+        return $this->tryWithRefresh('sendKeys', array($value));
+    }
+
+
+    private function tryWithRefresh($sParentMethod, $args=array())
+    {
+        $aFunction = array(get_parent_class($this), $sParentMethod);
+        $e = null;
+        for ($i = 0; $i < MAX_TRIES_STALE_REFRESH; $i++) {
+            try {
+                return call_user_func_array($aFunction, $args);
+            } catch (StaleElementReferenceException $e) {
+                // Refresh the element so we can try again.
+                if (!$this->refresh()) {
+                    // Refresh failed, can't do anything better than to re-throw the exception.
+                    throw $e;
+                }
+            }
+        }
+        // Too many tries, rethrow the exception.
+        throw $e;
+    }
+
+
+    private function refresh()
+    {
+        // Refresh this element by re-running findElement() using the locator.
+
+        if (isset($this->locator) && isset($this->driver)) {
+            fwrite(STDERR, 'Refreshing element, locator = "' . $this->locator->getValue() . '" (' .
+                $this->locator->getMechanism() . ')' . PHP_EOL);
+            $newElement = $this->driver->findElement($this->locator);
+
+            // Overwrite ID of current element with new one.
+            $this->id = $newElement->id;
+            return true;
+        }
+
+        // Cannot refresh element without locator or driver.
+        return false;
+    }
+}
+
+

--- a/tests/selenium_tests/find_replace_tests/find_replace.php
+++ b/tests/selenium_tests/find_replace_tests/find_replace.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-09-07
- * Modified    : 2016-09-23
+ * Modified    : 2016-10-26
  * For LOVD    : 3.0-17
  *
  * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -55,6 +55,7 @@ class FindReplaceTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->openFRMenuForCol(6);
 
         // Click cancel button.
+        sleep(1);
         $cancelButton = $this->driver->findElement(WebDriverBy::id('FRCancel_VOG'));
         $cancelButton->click();
 
@@ -65,8 +66,8 @@ class FindReplaceTest extends LOVDSeleniumWebdriverBaseTestCase
         // Open find and replace for Reference col.
         $this->openFRMenuForCol(6);
 
-        $this->assertEquals($this->driver->findElement(
-            WebDriverBy::id('viewlistFRColDisplay_VOG'))->getText(), 'Reference');
+        $columnReference = $this->driver->findElement(WebDriverBy::id('viewlistFRColDisplay_VOG'));
+        $this->assertEquals($columnReference->getText(), 'Reference');
 
         $this->enterValue(WebDriverBy::name('FRReplace_VOG'), 'newvalue');
 
@@ -194,5 +195,8 @@ class FindReplaceTest extends LOVDSeleniumWebdriverBaseTestCase
         $columnOverlay = $this->driver->findElement(
                 WebDriverBy::xpath('//div[@class="vl_overlay"][' . $nCol . ']'));
         $columnOverlay->click();
+
+        // Wait a second to handle click event properly and let tooltip disaapear.
+        sleep(1);
     }
 }

--- a/tests/selenium_tests/find_replace_tests/find_replace.php
+++ b/tests/selenium_tests/find_replace_tests/find_replace.php
@@ -196,7 +196,7 @@ class FindReplaceTest extends LOVDSeleniumWebdriverBaseTestCase
                 WebDriverBy::xpath('//div[@class="vl_overlay"][' . $nCol . ']'));
         $columnOverlay->click();
 
-        // Wait a second to handle click event properly and let tooltip disaapear.
+        // Wait a second to handle click event properly and let tooltip disappear.
         sleep(1);
     }
 }

--- a/tests/selenium_tests/inc-lib-test.php
+++ b/tests/selenium_tests/inc-lib-test.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-07-13
- * Modified    : 2016-09-23
- * For LOVD    : 3.0-18
+ * Modified    : 2016-10-26
+ * For LOVD    : 3.0-17
  *
  * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
@@ -30,6 +30,7 @@
  *************/
 
 
+require_once 'LOVDWebDriver.php';
 
 use \Facebook\WebDriver\Chrome\ChromeOptions;
 use \Facebook\WebDriver\Remote\DesiredCapabilities;
@@ -49,6 +50,7 @@ function getWebDriverInstance()
 
         $driverType = getenv('LOVD_SELENIUM_DRIVER');
         $host = 'http://localhost:4444/wd/hub';
+        $capabilities = null;
 
         if ($driverType == 'chrome') {
             // This is the documented way of starting the chromedriver, but it fails. (at least
@@ -62,17 +64,16 @@ function getWebDriverInstance()
             $options->addArguments(array('--no-sandbox'));
             $capabilities = DesiredCapabilities::chrome();
             $capabilities->setCapability(ChromeOptions::CAPABILITY, $options);
-            $webDriver = RemoteWebDriver::create($host, $capabilities,
-                WEBDRIVER_MAX_WAIT_DEFAULT * 1000,
-                WEBDRIVER_MAX_WAIT_DEFAULT * 1000);
         } else {
             // Create Firefox webdriver
             fwrite(STDERR, 'Connecting to Firefox driver via Selenium at ' . $host . PHP_EOL);
-            $capabilities = DesiredCapabilities::firefox();
-            $webDriver = RemoteWebDriver::create($host, $capabilities,
-                WEBDRIVER_MAX_WAIT_DEFAULT * 1000,
-                WEBDRIVER_MAX_WAIT_DEFAULT * 1000);
+            $capabilities = array(WebDriverCapabilityType::BROWSER_NAME => 'firefox');
         }
+
+        $webDriver = LOVDWebDriver::create($host, $capabilities,
+            WEBDRIVER_MAX_WAIT_DEFAULT * 1000,
+            WEBDRIVER_MAX_WAIT_DEFAULT * 1000);
+
 
         // Set time for trying to access DOM elements
         $webDriver->manage()->timeouts()->implicitlyWait(WEBDRIVER_IMPLICIT_WAIT);
@@ -87,6 +88,8 @@ function getWebDriverInstance()
                 'value' => 'selenium'));
         }
     }
+
+    // Wrap the webdriver instance in a custom processor.
     return $webDriver;
 }
 

--- a/tests/selenium_tests/inc-lib-test.php
+++ b/tests/selenium_tests/inc-lib-test.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-07-13
- * Modified    : 2016-10-26
+ * Modified    : 2016-10-27
  * For LOVD    : 3.0-17
  *
  * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -34,12 +34,11 @@ require_once 'LOVDWebDriver.php';
 
 use \Facebook\WebDriver\Chrome\ChromeOptions;
 use \Facebook\WebDriver\Remote\DesiredCapabilities;
-use \Facebook\WebDriver\Remote\RemoteWebDriver;
 use \Facebook\WebDriver\Remote\WebDriverCapabilityType;
 
 
 
-function getWebDriverInstance()
+function getWebDriverInstance ()
 {
     // Provide a re-usable webdriver for selenium tests.
 
@@ -74,7 +73,6 @@ function getWebDriverInstance()
             WEBDRIVER_MAX_WAIT_DEFAULT * 1000,
             WEBDRIVER_MAX_WAIT_DEFAULT * 1000);
 
-
         // Set time for trying to access DOM elements
         $webDriver->manage()->timeouts()->implicitlyWait(WEBDRIVER_IMPLICIT_WAIT);
 
@@ -98,7 +96,7 @@ function getWebDriverInstance()
 
 
 
-function setMutalyzerServiceURL($sURL)
+function setMutalyzerServiceURL ($sURL)
 {
     // Set up the LOVD environment with all common globals like a database
     // connection, configuration settings, etc. by including inc-init.php.

--- a/tests/selenium_tests/phpunit_bootstrap.php
+++ b/tests/selenium_tests/phpunit_bootstrap.php
@@ -68,3 +68,7 @@ define('SELENIUM_TEST_SLEEP', 10);
 // check/uncheck a box the first time.
 define('MAX_TRIES_CHECKING_BOX', 10);
 
+// Maximum number of tries to refresh an element after a
+// StaleElementReferenceException has been thrown.
+define('MAX_TRIES_STALE_REFRESH', 10);
+


### PR DESCRIPTION
Not all peculiarities with the find&replace test are fixed, but with the fallback for the StaleElementReferenceException and some extra sleeps, it seems to be more stable now.

@ifokkema: please notice the introduced RefreshingWebElement which can act as a normal [WebDriverElement](http://facebook.github.io/php-webdriver/classes/WebDriverElement.html) but will catch StaleElementReferenceException and retry to find the element and execute the action.