### PR TITLE
Fixes when changing your password.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -10,6 +10,8 @@
  *********/
  * Make header stick to the top of the browser's viewport, such that the links
    in the header are always visible.
+ * Fixed bug; When a user needed to change the password, the force option didn't
+   work properly, and could be circumvented.
 
 
 /************************************

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -12,6 +12,8 @@
    in the header are always visible.
  * Fixed bug; When a user needed to change the password, the force option didn't
    work properly, and could be circumvented.
+ * Improved data form when changing the password after unlocking your account,
+   to clarify that you need to insert the unlocking code again for confirmation.
 
 
 /************************************

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2016-07-20
- * For LOVD    : 3.0-17
+ * Modified    : 2016-11-11
+ * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -412,7 +412,12 @@ class LOVD_User extends LOVD_Object {
                         'skip',
       'change_other' => array('Enter your password for authorization', '', 'password', 'password', 20));
             if ($_PE[1] == $_AUTH['id']) {
+                // User is resetting password for him/herself.
                 unset($this->aFormData['change_other']);
+                // If user just logged in with an unlocking code, we will rename the "Current password" field.
+                if ($_AUTH['password'] == $_AUTH['password_autogen']) {
+                    $this->aFormData['change_self'][0] = 'Unlocking code';
+                }
             } else {
                 unset($this->aFormData['change_self']);
             }

--- a/src/login.php
+++ b/src/login.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-19
- * Modified    : 2016-08-26
- * For LOVD    : 3.0-17
+ * Modified    : 2016-11-11
+ * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -93,12 +93,10 @@ if (!empty($_POST)) {
                         // Fix weird behaviour of session_regenerate_id() - sometimes it is not sending a new cookie.
                         setcookie(session_name(), session_id(), ini_get('session.cookie_lifetime'));
                     }
-                    // Also update the password field, it needs to be used by the update password form.
+                    // Also update the password field, it needs to be used by the update password form, and force the change of password.
                     $_AUTH['password'] = $zUser['password_autogen'];
-                    $_DB->query('UPDATE ' . TABLE_USERS . ' SET password = ?, phpsessid = ?, last_login = NOW(), login_attempts = 0 WHERE id = ?', array($_AUTH['password'], session_id(), $_AUTH['id']));
-
-                    // Since this is the unlocking code, the user should be forced to change his/her password.
-                    $_SESSION['password_force_change'] = true;
+                    $_AUTH['password_force_change'] = 1;
+                    $_DB->query('UPDATE ' . TABLE_USERS . ' SET password = ?, phpsessid = ?, last_login = NOW(), login_attempts = 0, password_force_change = 1 WHERE id = ?', array($_AUTH['password'], session_id(), $_AUTH['id']));
 
                     header('Location: ' . lovd_getInstallURL() . 'users/' . $_AUTH['id'] . '?change_password');
                     exit;
@@ -150,11 +148,6 @@ if (!empty($_POST)) {
                     } else {
                         // FIXME; if this block is removed, keep this query.
                         $_DB->query('UPDATE ' . TABLE_USERS . ' SET password_autogen = "", phpsessid = ?, last_login = NOW(), login_attempts = 0 WHERE id = ?', array(session_id(), $_AUTH['id']));
-                    }
-
-                    // Check if the user should be forced to change his/her password.
-                    if (!empty($_AUTH['password_force_change'])) {
-                        $_SESSION['password_force_change'] = true;
                     }
 
                     // Check if referer is given, check it, then forward the user.


### PR DESCRIPTION
- Fixed bug; When a user needed to change the password, the force option didn't work properly, and could be circumvented.
- Improved data form when changing the password after unlocking your account, to clarify that you need to insert the unlocking code again for confirmation.