### PR TITLE
Fixed bug; Importing data failed for installations with a '2' in the table prefix, because the import code misunderstood the table types that way.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -14,6 +14,8 @@
    of the links actually worked because of security measures, now the menu has
    been removed.
  * Full disease data can now also be downloaded by Managers and up.
+ * Fixed bug; Importing data failed for installations with a '2' in the table
+   prefix, because the import code misunderstood the table types that way.
 
 
 /************************************

--- a/src/import.php
+++ b/src/import.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2016-08-08
+ * Modified    : 2016-11-15
  * For LOVD    : 3.0-17
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -648,7 +648,7 @@ if (POST) {
                         $sTableName = constant($sTableName);
                         $aSection['allowed_columns'] = lovd_getColumnList($sTableName);
 
-                        if (strpos($sTableName, '2') !== false) {
+                        if (strpos($sTableName, '2', strlen(TABLEPREFIX)) !== false) {
                             // Linking tables (such as GEN2DIS) require all available columns to be present.
                             $aSection['required_columns'] = $aSection['allowed_columns'];
                         } else {


### PR DESCRIPTION
Every table was considered a linking table, making all columns mandatory, even `edited*` columns.