### PR TITLE
Let users configure an API token

### DIFF
--- a/src/__function_list.txt
+++ b/src/__function_list.txt
@@ -28,6 +28,7 @@
 4.0.0 asort
 4.0.0 base64_encode
 4.0.0 basename
+4.0.0 bin2hex
 4.0.0 ceil
 4.0.0 chdir
 4.0.0 checkdate
@@ -115,6 +116,7 @@
 4.3.0 ob_get_clean
 4.0.0 ob_start
 4.0.0 opendir
+5.3.0 openssl_random_pseudo_bytes
 4.0.0 parse_url
 4.0.0 phpversion
 4.0.0 preg_match

--- a/src/ajax/auth_token.php
+++ b/src/ajax/auth_token.php
@@ -55,8 +55,28 @@ if (!$zUser) {
 // If we get there, we want to show the dialog for sure.
 print('
 if (!$("#auth_token_dialog").hasClass("ui-dialog-content") || !$("#auth_token_dialog").dialog("isOpen")) {
-    $("#auth_token_dialog").dialog({draggable:false,resizable:false,minWidth:600,show:"fade",closeOnEscape:true,hide:"fade",modal:true,buttons:{"Close":function(){$(this).dialog("close");}}});
-}');
+    $("#auth_token_dialog").dialog({draggable:false,resizable:false,minWidth:600,show:"fade",closeOnEscape:true,hide:"fade",modal:true});
+}
+
+
+');
+
+$sMessageIntro  = 'Since LOVD 3.0-18, LOVD contains an API that allows for the direct submission of data into the database. This API is currently undocumented and stil in beta. To use this API, you\'ll need an API token that serves to authorize you instead of using your username and password in the data file.';
+$sMessageCreate = 'You can create a new token by clicking &quot;Create new token&quot; below. This will revoke any existing tokens, if any. This also allows you to set an expiration to your token; after the expiration date, you will no longer be able to use this token and you will need to renew it.';
+$sMessageRevoke = 'You can also revoke your token completely, without creating a new one, blocking access of this token to the API completely. You can do this by clicking &quote;Revoke token&quot; below.';
+$bToken = !empty($zUser['auth_token']);
+$bTokenExpired = (strtotime($zUser['auth_token_expires']) <= time());
+
+// Set JS variables and objects.
+print('
+var bToken = ' . (int) $bToken . ';
+var bTokenExpired = ' . (int) $bTokenExpired . ';
+var oButtonCreate = {"Create new token":function () { $.get("' . CURRENT_PATH . '?create"); }};
+var oButtonRevoke = {"Revoke token":function () { $.get("' . CURRENT_PATH . '?revoke"); }};
+var oButtonClose  = {"Close":function () { $(this).dialog("close"); }};
+
+
+');
 
 
 
@@ -64,6 +84,27 @@ if (!$("#auth_token_dialog").hasClass("ui-dialog-content") || !$("#auth_token_di
 
 if (ACTION == 'view') {
     // View current token and status.
+    print('
+    $("#auth_token_dialog").html("' . $sMessageIntro . '<BR>");
+    $("#auth_token_dialog").append("' . $sMessageCreate . '<BR>");
+    if (bToken) {
+        $("#auth_token_dialog").append("' . $sMessageRevoke . '<BR>");
+    }
+    $("#auth_token_dialog").append("<BR>");
+    
+    // If we have a token, show it.
+    if (bToken) {
+        $("#auth_token_dialog").append("Your current token:<BR><PRE>' . $zUser['auth_token'] . '</PRE><BR>");
+    }
+    
+    // Select the right buttons.
+    var oButtons = $.extend({}, oButtonCreate);
+    if (bToken) {
+        $.extend(oButtons, oButtonRevoke);
+    }
+    $.extend(oButtons, oButtonClose);
+    $("#auth_token_dialog").dialog({buttons: oButtons}); 
+    ');
     exit;
 }
 ?>

--- a/src/ajax/auth_token.php
+++ b/src/ajax/auth_token.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-17
- * Modified    : 2016-11-17
+ * Modified    : 2016-11-18
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -61,8 +61,8 @@ if (!$("#auth_token_dialog").hasClass("ui-dialog-content") || !$("#auth_token_di
 
 ');
 
-$sFormCreate    = '<FORM id=\'auth_token_create_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'\'>Please select the validity of the token.<BR><SELECT name=\'auth_token_expires\'><OPTION value=\'\'>forever</OPTION><OPTION value=\'604800\'>1 week</OPTION><OPTION value=\'2592000\'>1 month</OPTION><OPTION value=\'7776000\'>3 months</OPTION><OPTION value=\'31536000\'>1 year</OPTION></SELECT>';
-$sMessageIntro  = 'Since LOVD 3.0-18, LOVD contains an API that allows for the direct submission of data into the database. This API is currently undocumented and stil in beta. To use this API, you\'ll need an API token that serves to authorize you instead of using your username and password in the data file.';
+$sFormCreate    = '<FORM id=\'auth_token_create_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>Please select the validity of the token.<BR><SELECT name=\'auth_token_expires\'><OPTION value=\'\'>forever</OPTION><OPTION value=\'604800\'>1 week</OPTION><OPTION value=\'2592000\'>1 month</OPTION><OPTION value=\'7776000\'>3 months</OPTION><OPTION value=\'31536000\'>1 year</OPTION></SELECT>';
+$sMessageIntro  = 'Since LOVD 3.0-18, LOVD contains an API that allows for the direct submission of data into the database. This API is currently undocumented and still in beta. To use this API, you\'ll need an API token that serves to authorize you instead of using your username and password in the data file.';
 $sMessageCreate = 'You can create a new token by clicking &quot;Create new token&quot; below. This will revoke any existing tokens, if any. This also allows you to set an expiration to your token; after the expiration date, you will no longer be able to use this token and you will need to renew it.';
 $sMessageRevoke = 'You can also revoke your token completely, without creating a new one, blocking access of this token to the API completely. You can do this by clicking &quote;Revoke token&quot; below.';
 $bToken = !empty($zUser['auth_token']);
@@ -90,16 +90,14 @@ if (ACTION == 'create' && GET) {
     // We do this in two steps, not only because we need to know the expiration of the token, but also to prevent CSRF.
 
     $_SESSION['csrf_tokens']['auth_token_create'] = md5(uniqid());
-    $sFormCreate = str_replace('value=""', 'value="' . $_SESSION['csrf_tokens']['auth_token_create'] . '"', $sFormCreate);
+    $sFormCreate = str_replace('{{CSRF_TOKEN}}', $_SESSION['csrf_tokens']['auth_token_create'], $sFormCreate);
 
     // Display the form, and put the right buttons in place.
     print('
     $("#auth_token_dialog").html("' . $sFormCreate . '<BR>");
     
     // Select the right buttons.
-    var oButtons = $.extend({}, oButtonFormCreate);
-    $.extend(oButtons, oButtonCancel);
-    $("#auth_token_dialog").dialog({buttons: oButtons}); 
+    $("#auth_token_dialog").dialog({buttons: $.extend({}, oButtonFormCreate, oButtonCancel)}); 
     ');
     exit;
 }

--- a/src/ajax/auth_token.php
+++ b/src/ajax/auth_token.php
@@ -71,7 +71,7 @@ $bTokenExpired = (strtotime($zUser['auth_token_expires']) <= time());
 print('
 var bToken = ' . (int) $bToken . ';
 var bTokenExpired = ' . (int) $bTokenExpired . ';
-var oButtonCreate = {"Create new token":function () { $.get("' . CURRENT_PATH . '?create"); }};
+var oButtonCreate = {"Create new token":function () { if (bToken && !bTokenExpired) { if (!window.confirm("Are you sure you want to create a new token, invalidating the current token?")) { return false; }} $.get("' . CURRENT_PATH . '?create"); }};
 var oButtonRevoke = {"Revoke token":function () { $.get("' . CURRENT_PATH . '?revoke"); }};
 var oButtonClose  = {"Close":function () { $(this).dialog("close"); }};
 
@@ -94,7 +94,11 @@ if (ACTION == 'view') {
     
     // If we have a token, show it.
     if (bToken) {
-        $("#auth_token_dialog").append("Your current token:<BR><PRE>' . $zUser['auth_token'] . '</PRE><BR>");
+        if (bTokenExpired) {
+            $("#auth_token_dialog").append("Your current token has expired.<BR>");
+        } else {
+            $("#auth_token_dialog").append("Your current token:<BR><PRE>' . $zUser['auth_token'] . '</PRE><BR>");
+        }
     }
     
     // Select the right buttons.

--- a/src/ajax/auth_token.php
+++ b/src/ajax/auth_token.php
@@ -1,0 +1,69 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2016-11-17
+ * Modified    : 2016-11-17
+ * For LOVD    : 3.0-18
+ *
+ * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
+define('ROOT_PATH', '../');
+require ROOT_PATH . 'inc-init.php';
+header('Content-type: text/javascript; charset=UTF-8');
+
+// Check for basic format.
+if (PATH_COUNT != 3 || !ctype_digit($_PE[2]) || !in_array(ACTION, array('view'))) {
+    die('alert("Error while sending data.");');
+}
+
+// Require manager clearance.
+if (!$_AUTH || !lovd_isAuthorized('user', $_PE[2])) {
+    // If not authorized, die with error message.
+    die('alert("Lost your session. Please log in again.");');
+}
+
+// Let's download the user's data.
+$nID = sprintf('%0' . $_SETT['objectid_length']['users'] . 'd', $_PE[2]);
+$zUser = $_DB->query('SELECT id, auth_token, auth_token_expires FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchAssoc();
+
+if (!$zUser) {
+    // FIXME: Should we log this?
+    die('alert("Data not found.");');
+}
+
+// If we get there, we want to show the dialog for sure.
+print('
+if (!$("#auth_token_dialog").hasClass("ui-dialog-content") || !$("#auth_token_dialog").dialog("isOpen")) {
+    $("#auth_token_dialog").dialog({draggable:false,resizable:false,minWidth:600,show:"fade",closeOnEscape:true,hide:"fade",modal:true,buttons:{"Close":function(){$(this).dialog("close");}}});
+}');
+
+
+
+
+
+if (ACTION == 'view') {
+    // View current token and status.
+    exit;
+}
+?>

--- a/src/ajax/auth_token.php
+++ b/src/ajax/auth_token.php
@@ -53,7 +53,10 @@ if (!$zUser) {
 }
 
 // If we get there, we want to show the dialog for sure.
-print('// Make sure we show the dialog.
+print('// Make sure we have and show the dialog.
+if (!$("#auth_token_dialog").length) {
+    $("body").append("<DIV id=\'auth_token_dialog\' title=\'API authorization token\'></DIV>");
+}
 if (!$("#auth_token_dialog").hasClass("ui-dialog-content") || !$("#auth_token_dialog").dialog("isOpen")) {
     $("#auth_token_dialog").dialog({draggable:false,resizable:false,minWidth:600,show:"fade",closeOnEscape:true,hide:"fade",modal:true});
 }
@@ -147,6 +150,7 @@ if (ACTION == 'create' && POST) {
         die('alert("Failed to create new token.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }
     // If we get here, the token has been created and stored successfully!
+    lovd_writeLog('Event', 'AuthTokenCreate', 'Successfully created new API token, expires ' . $sAuthTokenExpires);
 
     // Display the form, and put the right buttons in place.
     print('
@@ -197,6 +201,7 @@ if (ACTION == 'revoke' && POST) {
         die('alert("Failed to revoke token.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }
     // If we get here, the token has been revoked successfully!
+    lovd_writeLog('Event', 'AuthTokenRevoke', 'Successfully revoked current API token');
 
     // Display the form, and put the right buttons in place.
     print('

--- a/src/ajax/viewentry.php
+++ b/src/ajax/viewentry.php
@@ -4,12 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-11-09
- * Modified    : 2016-08-09
- * For LOVD    : 3.0-17
+ * Modified    : 2016-11-18
+ * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -33,7 +33,12 @@
 define('ROOT_PATH', '../');
 require ROOT_PATH . 'inc-init.php';
 
-if (empty($_GET['id']) || empty($_GET['object']) || !preg_match('/^[A-Z_]+$/i', $_GET['object'])) {
+// Get viewentry-identifying arguments from request and check their validity.
+$sObject = (isset($_REQUEST['object'])? $_REQUEST['object'] : '');
+$sObjectID = (isset($_REQUEST['object_id'])? $_REQUEST['object_id'] : '');
+$nID = (isset($_REQUEST['id'])? $_REQUEST['id'] : '');
+
+if (empty($nID) || empty($sObject) || !preg_match('/^[A-Z_]+$/i', $sObject)) {
     die(AJAX_DATA_ERROR);
 }
 
@@ -42,19 +47,26 @@ if (empty($_GET['id']) || empty($_GET['object']) || !preg_match('/^[A-Z_]+$/i', 
 $aNeededLevel =
          array(
                 'Transcript_Variant' => 0,
+                'User' => LEVEL_OWNER,
               );
 
-if (isset($aNeededLevel[$_GET['object']])) {
-    $nNeededLevel = $aNeededLevel[$_GET['object']];
+if (isset($aNeededLevel[$sObject])) {
+    $nNeededLevel = $aNeededLevel[$sObject];
 } else {
     $nNeededLevel = LEVEL_ADMIN;
 }
 
 // Call isAuthorized() on the object. NB: isAuthorized() modifies the global
 // $_AUTH for curators, owners and colleagues.
-if ($_GET['object'] == 'Transcript_Variant') {
-    list($nVariantID, $nTranscriptID) = explode(',', $_GET['id']);
+if ($sObject == 'Transcript_Variant') {
+    list($nVariantID, $nTranscriptID) = explode(',', $nID);
     lovd_isAuthorized('variant', $nVariantID);
+} elseif ($sObject == 'User') {
+    lovd_isAuthorized(strtolower($sObject), $nID);
+    // Users viewing their own profile should see a lot more...
+    if ($_AUTH['id'] == $nID && $_AUTH['level'] < LEVEL_CURATOR) {
+        $_AUTH['level'] = LEVEL_CURATOR;
+    }
 }
 // FIXME; other lovd_isAuthorized() calls?
 
@@ -68,7 +80,7 @@ if (FORMAT == 'text/plain' && !defined('FORMAT_ALLOW_TEXTPLAIN')) {
     die(AJAX_NO_AUTH);
 }
 
-$sFile = ROOT_PATH . 'class/object_' . strtolower($_GET['object']) . 's.php';
+$sFile = ROOT_PATH . 'class/object_' . strtolower($sObject) . 's.php';
 
 if (!file_exists($sFile)) {
     header('HTTP/1.0 404 Not Found');
@@ -77,25 +89,16 @@ if (!file_exists($sFile)) {
 
 
 
-$sObjectID = '';
-$nID = '';
-if (in_array($_GET['object'], array('Phenotype', 'Transcript_Variant', 'Custom_ViewList'))) {
-    if (isset($_GET['object_id'])) {
-        $sObjectID = $_GET['object_id'];
-    }
-    if (isset($_GET['id'])) {
-        $nID = $_GET['id'];
-    }
-
+if (in_array($sObject, array('Phenotype', 'Transcript_Variant', 'Custom_ViewList'))) {
     // Exception for VOT viewEntry, we need to isolate the gene from the ID to correctly pass this to the data object.
-    if ($_GET['object'] == 'Transcript_Variant') {
+    if ($sObject == 'Transcript_Variant') {
         // This line below is redundant as long as it's also called at the lovd_isAuthorized() call. Remove it here maybe...?
         list($nVariantID, $nTranscriptID) = explode(',', $nID);
         $sObjectID = $_DB->query('SELECT geneid FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ?', array($nTranscriptID))->fetchColumn();
     }
 }
 require $sFile;
-$_GET['object'] = 'LOVD_' . str_replace('_', '', $_GET['object']); // FIXME; test dit op een windows, test case-insensitivity.
-$_DATA = new $_GET['object']($sObjectID);
+$sObjectClassName = 'LOVD_' . str_replace('_', '', $sObject);
+$_DATA = new $sObjectClassName($sObjectID);
 $_DATA->viewEntry($nID);
 ?>

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -20,6 +20,8 @@
    prefix, because the import code misunderstood the table types that way.
  * Large downloads are now allowed to take a longer time, to make sure they
    finish before the server interrupts them.
+ * Users can now create their own API tokens to use for the LOVD data submission
+   API.
 
 
 /************************************

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -487,7 +487,7 @@ class LOVD_User extends LOVD_Object {
                 // Either we're viewing ourselves, or we're manager or up.
 
                 // Auth token links. We don't show the token by default.
-                $zData['auth_token_'] = '(<A href="#" onclick="lovd_showAuthTokenDialog(); return false;">Show / More information</A>)';
+                $zData['auth_token_'] = '(<A href="#" onclick="$.get(\'ajax/auth_token.php/' . $zData['id'] . '?view\'); return false;">Show / More information</A>)';
                 if ($zData['auth_token_expires']) {
                     $tDiff = strtotime($zData['auth_token_expires']) - time();
                     $sDiff = lovd_convertSecondsToTime(abs($tDiff));

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2016-11-18
+ * Modified    : 2016-12-09
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -487,7 +487,7 @@ class LOVD_User extends LOVD_Object {
                 // Either we're viewing ourselves, or we're manager or up.
 
                 // Auth token links. We don't show the token by default.
-                $zData['auth_token_'] = '(<A href="#" onclick="$.get(\'ajax/auth_token.php/' . $zData['id'] . '?view\'); return false;">Show / More information</A>)';
+                $zData['auth_token_'] = '(<A href="#" onclick="$.get(\'ajax/auth_token.php/' . $zData['id'] . '?view\').fail(function(){alert(\'Error viewing token, please try again later.\');}); return false;">Show / More information</A>)';
                 if ($zData['auth_token_expires']) {
                     $tDiff = strtotime($zData['auth_token_expires']) - time();
                     $sDiff = lovd_convertSecondsToTime(abs($tDiff));

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,11 +4,11 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2016-11-17
+ * Modified    : 2016-11-18
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -493,7 +493,7 @@ class LOVD_User extends LOVD_Object {
                     $sDiff = lovd_convertSecondsToTime(abs($tDiff));
                     $zData['auth_token_expires_'] = '<SPAN title="' . $zData['auth_token_expires'] . '">' . ($tDiff > 0? 'In ' . $sDiff : 'Expired ' . $sDiff . ' ago') . '</SPAN>';
                 } else {
-                    $zData['auth_token_expires_'] = '';
+                    $zData['auth_token_expires_'] = '- (Never)';
                 }
 
                 // Since we're manager or viewing ourselves, we don't need to check for the data status of the data.

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2016-07-20
- * For LOVD    : 3.0-17
+ * Modified    : 2016-11-17
+ * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -120,6 +120,8 @@ class LOVD_User extends LOVD_Object {
                         'username' => array('Username', LEVEL_MANAGER),
                         'password_force_change_' => array('Force change password', LEVEL_MANAGER),
                         'phpsessid' => array('Session ID', LEVEL_MANAGER),
+                        'auth_token_' => array('API token', LEVEL_CURATOR), // Will be unset if user is not authorized on this user (i.e., not himself or manager or up).
+                        'auth_token_expires_' => array('API token expiration', LEVEL_CURATOR), // Will be unset if user is not authorized on this user (i.e., not himself or manager or up).
                         'saved_work_' => array('Saved work', LEVEL_MANAGER),
                         'curates_' => 'Curator for',
                         'collaborates_' => array('Collaborator for', LEVEL_CURATOR),
@@ -480,9 +482,21 @@ class LOVD_User extends LOVD_Object {
             // Submissions...
             if (lovd_isAuthorized('user', $zData['id']) === false) {
                 // Not authorized to view hidden data for this user; so we're not manager and we're not viewing ourselves. Nevermind then.
-                unset($this->aColumnsViewEntry['ownes_']);
+                unset($this->aColumnsViewEntry['ownes_'], $this->aColumnsViewEntry['auth_token_'], $this->aColumnsViewEntry['auth_token_expires_']);
             } else {
-                // Either we're viewing ourselves, or we're manager or up. Like this is easy, because now we don't need to check for the data status of the data.
+                // Either we're viewing ourselves, or we're manager or up.
+
+                // Auth token links. We don't show the token by default.
+                $zData['auth_token_'] = '(<A href="#" onclick="lovd_showAuthTokenDialog(); return false;">Show / More information</A>)';
+                if ($zData['auth_token_expires']) {
+                    $tDiff = strtotime($zData['auth_token_expires']) - time();
+                    $sDiff = lovd_convertSecondsToTime(abs($tDiff));
+                    $zData['auth_token_expires_'] = '<SPAN title="' . $zData['auth_token_expires'] . '">' . ($tDiff > 0? 'In ' . $sDiff : 'Expired ' . $sDiff . ' ago') . '</SPAN>';
+                } else {
+                    $zData['auth_token_expires_'] = '';
+                }
+
+                // Since we're manager or viewing ourselves, we don't need to check for the data status of the data.
                 $nOwnes = 0;
                 $sOwnes = '';
 

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -493,7 +493,7 @@ class LOVD_User extends LOVD_Object {
                     $sDiff = lovd_convertSecondsToTime(abs($tDiff));
                     $zData['auth_token_expires_'] = '<SPAN title="' . $zData['auth_token_expires'] . '">' . ($tDiff > 0? 'In ' . $sDiff : 'Expired ' . $sDiff . ' ago') . '</SPAN>';
                 } else {
-                    $zData['auth_token_expires_'] = '- (Never)';
+                    $zData['auth_token_expires_'] = (!$zData['auth_token']? '' : '- (Never)');
                 }
 
                 // Since we're manager or viewing ourselves, we don't need to check for the data status of the data.

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2016-09-21
- * For LOVD    : 3.0-17
+ * Modified    : 2016-11-17
+ * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -139,7 +139,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-17',
+                            'version' => '3.0-17b',
                           ),
                 'user_levels' =>
                      array(

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,11 +4,11 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2016-11-17
+ * Modified    : 2016-11-18
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -572,7 +572,10 @@ function lovd_isAuthorized ($sType, $Data, $bSetUserLevel = true)
         } else {
             // If viewing himself, always get authorization.
             if ($Data == $_AUTH['id']) {
-                return 1; // FIXME: We're not supporting $bSetUserLevel at the moment (not required right now, either).
+                if ($bSetUserLevel) {
+                    $_AUTH['level'] = LEVEL_OWNER;
+                }
+                return 1;
             } elseif ($_AUTH['level'] < LEVEL_MANAGER) {
                 // Lower than managers never get access to hidden data of other users.
                 return false;

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2016-09-08
- * For LOVD    : 3.0-17
+ * Modified    : 2016-11-17
+ * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1501,5 +1501,41 @@ function lovd_convertIniValueToBytes ($sValue)
     }
 
     return $nValue;
+}
+
+
+
+
+
+function lovd_convertSecondsToTime ($sValue, $nDecimals = 0)
+{
+    // This function takes a number of seconds and converts it into whole
+    // minutes, hours, days, months or years.
+    // FIXME; Implement proper checks here? Regexp?
+
+    $nValue = (int) $sValue;
+    if (ctype_digit((string) $sValue)) {
+        $sValue .= 's';
+    }
+    $sLast = strtolower(substr($sValue, -1));
+    $nDecimals = (int) $nDecimals;
+
+    $aConversion =
+        array(
+            's' => array(60, 'm'),
+            'm' => array(60, 'h'),
+            'h' => array(24, 'd'),
+            'd' => array(265, 'y'),
+        );
+
+    foreach ($aConversion as $sUnit => $aConvert) {
+        list($nFactor, $sNextUnit) = $aConvert;
+        if ($sLast == $sUnit && $nValue > $nFactor) {
+            $nValue /= $nFactor;
+            $sLast = $sNextUnit;
+        }
+    }
+
+    return round($nValue, $nDecimals) . $sLast;
 }
 ?>

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -572,7 +572,7 @@ function lovd_isAuthorized ($sType, $Data, $bSetUserLevel = true)
         } else {
             // If viewing himself, always get authorization.
             if ($Data == $_AUTH['id']) {
-                if ($bSetUserLevel) {
+                if ($bSetUserLevel && $_AUTH['level'] < LEVEL_OWNER) {
                     $_AUTH['level'] = LEVEL_OWNER;
                 }
                 return 1;

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2016-09-05
- * For LOVD    : 3.0-17
+ * Modified    : 2016-11-17
+ * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -461,6 +461,10 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                             ENGINE=InnoDB,
                             DEFAULT CHARACTER SET utf8',
                     ),
+                 '3.0-17b' =>
+                     array(
+                         'ALTER TABLE ' . TABLE_USERS . ' ADD COLUMN auth_token CHAR(32) AFTER password_force_change, ADD COLUMN auth_token_expires DATETIME AFTER auth_token',
+                     )
              );
 
     if ($sCalcVersionDB < lovd_calculateVersion('3.0-alpha-01')) {

--- a/src/install/inc-sql-tables.php
+++ b/src/install/inc-sql-tables.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-22
- * Modified    : 2016-09-05
- * For LOVD    : 3.0-17
+ * Modified    : 2016-11-17
+ * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -79,6 +79,8 @@ $aTableSQL =
     password CHAR(50) NOT NULL,
     password_autogen CHAR(50),
     password_force_change BOOLEAN NOT NULL,
+    auth_token CHAR(32),
+    auth_token_expires DATETIME,
     phpsessid CHAR(32),
     saved_work TEXT,
     level TINYINT(1) UNSIGNED NOT NULL,

--- a/src/users.php
+++ b/src/users.php
@@ -106,7 +106,9 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     require ROOT_PATH . 'class/object_users.php';
     $_DATA = new LOVD_User();
 
+    print('      <DIV id="viewentryDiv">' . "\n");
     $zData = $_DATA->viewEntry($nID);
+    print('      </DIV>' . "\n\n");
 
     $aNavigation = array();
     // Since we're faking the user's level to show some more columns when the user is viewing himself, we must put the check on the ID here.

--- a/src/users.php
+++ b/src/users.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2016-11-11
+ * Modified    : 2016-11-18
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -152,16 +152,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         $_GET['search_userid'] = $nID;
         $_DATA->viewList('Logs_for_Users_VE', array('user_', 'del'), true);
     }
-
-    // DIV for Dialog meant for the authorization token.
-    print('      <DIV id="auth_token_dialog" title="API authorization token" style="display : none;"></DIV>' . "\n\n" .
-          '      <SCRIPT type="text/javascript">' . "\n" .
-          '        function lovd_showAuthTokenDialog ()' . "\n" .
-          '        {' . "\n" .
-          '          // This is enough to get the code evaluated.' . "\n" .
-          '          $.get("ajax/auth_token.php/' . $nID . '?view");' . "\n" .
-          '        }' . "\n" .
-          '      </SCRIPT>' . "\n\n");
 
     $_T->printFooter();
     exit;

--- a/src/users.php
+++ b/src/users.php
@@ -8,7 +8,7 @@
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -150,6 +150,16 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         $_GET['search_userid'] = $nID;
         $_DATA->viewList('Logs_for_Users_VE', array('user_', 'del'), true);
     }
+
+    // DIV for Dialog meant for the authorization token.
+    print('      <DIV id="auth_token_dialog" title="API authorization token" style="display : none;"></DIV>' . "\n\n" .
+          '      <SCRIPT type="text/javascript">' . "\n" .
+          '        function lovd_showAuthTokenDialog ()' . "\n" .
+          '        {' . "\n" .
+          '          // This is enough to get the code evaluated.' . "\n" .
+          '          $.get("ajax/auth_token.php/' . $nID . '?view");' . "\n" .
+          '        }' . "\n" .
+          '      </SCRIPT>' . "\n\n");
 
     $_T->printFooter();
     exit;


### PR DESCRIPTION
Users can now create their own API tokens to use for the future LOVD data submission API.
- Adapted data model to store authorization token and its expiration date.			
- Added fields to users VE; the token (hidden, only link shown for more info) and the token expiration.
- Needed `lovd_convertSecondsToTime()` from LOVD+ for the latter.
- Clicking the link for the API token information opens a dialog that's fed through an AJAX request.
- Dialog shows some information on the token, also displays buttons to create and revoke the token.
- Dialog displays when token has expired, and asks for confirmation when creating a new one while one is still valid.
- Dialog can create a new token, setting the expiration.
- Dialog can revoke a token.
- Both features are CSRF protected.
- Modernized `ajax/viewentry.php` and enabled it to load Users VEs. Also had to change `lovd_isAuthorized()` for that.
- Put a DIV around the Users VE so we can replace it. Users VE is reloaded when tokens are created or revoked.
- New tokens and revokes are logged.
- Added changelog entry.