### PR TITLE
Minor fixes

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -35,6 +35,10 @@
    the Exon field.
  * When a Database administrator creates a new user, the level now selected by
    default will be Submitter instead of Manager.
+ * The variant effect columns were checked twice while submitting and importing,
+   possibly resulting in repeated error messages.
+ * Fixed bug; The variant effect fields didn't have a default value when
+   importing.
 
 
 /************************************

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -39,6 +39,8 @@
    possibly resulting in repeated error messages.
  * Fixed bug; The variant effect fields didn't have a default value when
    importing.
+ * Fixed bug; Imports could set variant start positions that were higher than
+   variant end positions.
 
 
 /************************************

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -41,6 +41,10 @@
    importing.
  * Fixed bug; Imports could set variant start positions that were higher than
    variant end positions.
+ * When variants are imported without position fields or variant type filled in,
+   LOVD will now predict them.
+ * Fixed bug; Variants that were imported with empty intron positions, didn't
+   group together with variants that had a 0 filled in.
 
 
 /************************************

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -33,6 +33,8 @@
  * The VariantOnTranscript/Exon field is now no longer mandatory by default,
    allowing the submission API to directly submit data, since it doesn't contain
    the Exon field.
+ * When a Database administrator creates a new user, the level now selected by
+   default will be Submitter instead of Manager.
 
 
 /************************************

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2016-10-14
+ * Modified    : 2016-12-13
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -261,19 +261,6 @@ class LOVD_GenomeVariant extends LOVD_Custom {
         }
 
         parent::checkFields($aData);
-
-        // Checks fields before submission of data.
-        if (isset($aData['effect_reported']) && !isset($_SETT['var_effect'][$aData['effect_reported']])) {
-            lovd_errorAdd('effect_reported', 'Please select a proper functional effect from the \'Affects function (reported)\' selection box.');
-        }
-
-        if (isset($aData['effect_concluded']) && !isset($_SETT['var_effect'][$aData['effect_concluded']])) {
-            lovd_errorAdd('effect_concluded', 'Please select a proper functional effect from the \'Affects function (concluded)\' selection box.');
-        }
-
-        if (!empty($aData['chromosome']) && !isset($_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$aData['chromosome']])) {
-            lovd_errorAdd('chromosome', 'Please select a proper chromosome from the \'Chromosome\' selection box.');
-        }
 
         lovd_checkXSS();
     }

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,12 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2016-12-09
+ * Modified    : 2016-12-13
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -539,6 +539,7 @@ class LOVD_User extends LOVD_Object {
     function setDefaultValues ()
     {
         // Sets default values of fields in $_POST.
+        $_POST['level'] = LEVEL_SUBMITTER;
         $_POST['allowed_ip'] = '*';
         $_POST['send_email'] = 1;
         return true;

--- a/src/import.php
+++ b/src/import.php
@@ -1556,6 +1556,11 @@ if (POST) {
                     break;
 
                 case 'Variants_On_Genome':
+                    // Check variant positions.
+                    if ($aLine['position_g_start'] > $aLine['position_g_end']) {
+                        // Start position after end position, hell no.
+                        lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): Variant start position is larger than variant end position.');
+                    }
                     if ($zData) {
                         if ($nDifferences) {
                             $aLine['todo'] = 'update'; // OK, update only when there are differences.
@@ -1595,6 +1600,12 @@ if (POST) {
                     if ($aLine['id'] && !$bVariantInFile && !$bVariantInDB) {
                         // Variant does not exist and is not defined in the import file.
                         lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): Genomic Variant "' . htmlspecialchars($aLine['variantid']) . '" does not exist in the database and is not defined in this import file.');
+                    }
+
+                    // Check variant positions.
+                    if ($aLine['position_c_start'] > $aLine['position_c_end']) {
+                        // Start position after end position, hell no.
+                        lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): Variant start position is larger than variant end position.');
                     }
 
                     if ($zData) {

--- a/src/import.php
+++ b/src/import.php
@@ -4,12 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2016-11-15
- * For LOVD    : 3.0-17
+ * Modified    : 2016-12-13
+ * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -994,8 +994,6 @@ if (POST) {
                 // Object has been created.
                 // We'll need to split the functional consequence field to have checkFields() function normally.
                 if ($sCurrentSection == 'Variants_On_Genome' || $sCurrentSection == 'Variants_On_Transcripts') {
-                    $aLine['effect_reported'] = substr($_SETT['var_effect_default'], 0, 1); // Default value.
-                    $aLine['effect_concluded'] = substr($_SETT['var_effect_default'], -1); // Default value.
                     if (in_array('effectid', $aColumns)) {
                         if (strlen($aLine['effectid']) != 2) {
                             lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): Please select a valid entry for the \'effectid\' field.');
@@ -1003,6 +1001,11 @@ if (POST) {
                             $aLine['effect_reported'] = $aLine['effectid']{0};
                             $aLine['effect_concluded'] = $aLine['effectid']{1};
                         }
+                    } else {
+                        // Apply the default values.
+                        $aLine['effectid'] = $_SETT['var_effect_default']; // Defaults for import.
+                        $aLine['effect_reported'] = $aLine['effectid']{0}; // Defaults for checkFields().
+                        $aLine['effect_concluded'] = $aLine['effectid']{1}; // Defaults for checkFields().
                     }
                 }
 

--- a/src/import.php
+++ b/src/import.php
@@ -1557,10 +1557,21 @@ if (POST) {
 
                 case 'Variants_On_Genome':
                     // Check variant positions.
+                    if ($aLine['position_g_start'] === '' || $aLine['position_g_end'] === '' || $aLine['type'] === '') {
+                        // Predict position and type.
+                        $aVariantPositions = lovd_getVariantInfo($aLine['VariantOnGenome/DNA']);
+                        if ($aVariantPositions) {
+                            // Always let it overwrite everything.
+                            $aLine['position_g_start'] = $aVariantPositions['position_start'];
+                            $aLine['position_g_end']   = $aVariantPositions['position_end'];
+                            $aLine['type']             = $aVariantPositions['type'];
+                        }
+                    }
                     if ($aLine['position_g_start'] > $aLine['position_g_end']) {
                         // Start position after end position, hell no.
                         lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): Variant start position is larger than variant end position.');
                     }
+
                     if ($zData) {
                         if ($nDifferences) {
                             $aLine['todo'] = 'update'; // OK, update only when there are differences.
@@ -1603,9 +1614,28 @@ if (POST) {
                     }
 
                     // Check variant positions.
+                    if ($aLine['position_c_start'] === '' || $aLine['position_c_end'] === '') {
+                        // Predict position.
+                        $aVariantPositions = lovd_getVariantInfo($aLine['VariantOnTranscript/DNA']);
+                        if ($aVariantPositions) {
+                            // Always let it overwrite everything.
+                            $aLine['position_c_start'] = $aVariantPositions['position_start'];
+                            $aLine['position_c_end']   = $aVariantPositions['position_end'];
+                            // We have the intron fields only if the variant started with c. or n.
+                            if (isset($aVariantPositions['position_start_intron'])) {
+                                $aLine['position_c_start_intron'] = $aVariantPositions['position_start_intron'];
+                                $aLine['position_c_end_intron']   = $aVariantPositions['position_end_intron'];
+                            }
+                        }
+                    }
                     if ($aLine['position_c_start'] > $aLine['position_c_end']) {
                         // Start position after end position, hell no.
                         lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): Variant start position is larger than variant end position.');
+                    }
+                    foreach (array('position_c_start_intron', 'position_c_end_intron') as $sCol) {
+                        if ($aLine[$sCol] === '') {
+                            $aLine[$sCol] = 0;
+                        }
                     }
 
                     if ($zData) {

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2016-11-30
+ * Modified    : 2016-12-13
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -144,7 +144,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-17b',
+                            'version' => '3.0-17c',
                           ),
                 'user_levels' =>
                      array(

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2016-12-07
+ * Modified    : 2016-12-13
  * For LOVD    : 3.0-18
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
@@ -464,6 +464,11 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                  '3.0-17b' =>
                      array(
                          'ALTER TABLE ' . TABLE_USERS . ' ADD COLUMN auth_token CHAR(32) AFTER password_force_change, ADD COLUMN auth_token_expires DATETIME AFTER auth_token',
+                     ),
+                 '3.0-17c' =>
+                     array(
+                         'UPDATE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' SET position_c_start_intron = 0 WHERE position_c_start IS NOT NULL AND position_c_start_intron IS NULL',
+                         'UPDATE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' SET position_c_end_intron = 0 WHERE position_c_end IS NOT NULL AND position_c_end_intron IS NULL',
                      ),
                  '3.0-18' =>
                      array(


### PR DESCRIPTION
- When an Administrator creates a new user, the new default level is Submitter.
- Fixed issues with the variant effect fields:
  - The variant effect columns were checked twice while submitting and importing, possibly resulting in repeated error messages.
  - Fixed bug; The variant effect fields didn't have a default value when importing.
- Fixed issues with the position fields:
  - Fixed bug; Imports could set variant start positions that were higher than variant end positions.
  - When variants are imported without position fields or variant type filled in, LOVD will now predict them.
  - Fixed bug; Variants that were imported with empty intron positions, didn't group together with variants that had a 0 filled in.
    - All variants already imported that way, are fixed.
  - Closes #140.