### PR TITLE
Fix manage transcripts feature

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -5,6 +5,17 @@
  *************/
 
 /**************************
+ * 3.0 Build 19
+ * 2017-0?-??
+ *********/
+ * Fixed bug; Transcripts could not easily be added to variants anymore. This
+   was caused by the recent changes making LOVD compatible with the new default
+   "ONLY_FULL_GROUP_BY" MySQL setting.
+   Closes #167: "Manage transcripts feature doesn't allow addition of transcript
+   anymore".
+
+
+/**************************
  * 3.0 Build 18
  * 2016-12-23
  *********/

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-15
- * Modified    : 2016-12-14
- * For LOVD    : 3.0-18
+ * Modified    : 2017-01-13
+ * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -166,6 +166,8 @@ class LOVD_CustomViewList extends LOVD_Object {
                         if ($nKeyG !== false && $nKeyG < $nKey) {
                             // Earlier, Gene was used, join to that.
                             $aSQL['FROM'] .= 'g.id = t.geneid)';
+                            // A view with gene info and transcript info will be grouped on the transcripts.
+                            $aSQL['GROUP_BY'] = 't.id';
                         } elseif ($nKeyVOT !== false && $nKeyVOT < $nKey) {
                             // Earlier, VOT was used, join to that.
                             $aSQL['FROM'] .= 'vot.transcriptid = t.id)';

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -7,7 +7,7 @@
  * Modified    : 2017-01-13
  * For LOVD    : 3.0-19
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2016-11-15
- * For LOVD    : 3.0-18
+ * Modified    : 2017-01-13
+ * For LOVD    : 3.0-19
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
@@ -3081,6 +3081,10 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'map') {
                 // Reset the viewList.
                 // Does an ltrim, too. But trim() doesn't work in IE < 9.
                 objViewListF.search_tid.value = objViewListF.search_tid.value.replace('!' + nID, '').replace('  ', ' ').replace(/^\s*/, '');
+                // If the filter is now empty, it will be disabled by the submitting VL and it won't function anymore.
+                if (!objViewListF.search_tid.value) {
+                    objViewListF.search_tid.value = '!0';
+                }
                 lovd_AJAX_viewListSubmit(sViewListID);
 
                 return true;


### PR DESCRIPTION
Fix problem with manage transcripts feature.
- Fixed bug; Transcripts could not easily be added to variants anymore.
  - This was caused by the recent changes making LOVD compatible with the new default `ONLY_FULL_GROUP_BY` MySQL setting.
  - Closes #167: "Manage transcripts feature doesn't allow addition of transcript anymore".
- Fixed bug; The filter for transcripts to add didn't work anymore if you had removed all transcripts from the list.
  - The filter got disabled when all transcripts were removed, because the lovd_AJAX_viewListSubmit() disables empty filters.
  - Also fixed forgotten copyright header in class/object_custom_viewlists.php.