### PR TITLE
Fix "all variants affecting transcripts" VL

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -13,6 +13,10 @@
    "ONLY_FULL_GROUP_BY" MySQL setting.
    Closes #167: "Manage transcripts feature doesn't allow addition of transcript
    anymore".
+ * Fixed bug; The "all variants affecting transcripts" view showed only one
+   entry. This was caused by the recent changes making LOVD compatible with the
+   new default "ONLY_FULL_GROUP_BY" MySQL setting.
+   Closes #176: "Viewlist entry count differs from what is displayed".
 
 
 /**************************

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-15
- * Modified    : 2017-01-13
+ * Modified    : 2017-01-25
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -290,6 +290,11 @@ class LOVD_CustomViewList extends LOVD_Object {
                             $aSQL['FROM'] .= 't.id = vot.transcriptid)';
                             // Nice, but if we're showing transcripts and variants on transcripts in one viewList, we'd only want to see the transcripts that HAVE variants.
                             $aSQL['WHERE'] .= (!$aSQL['WHERE']? '' : ' AND ') . 'vot.id IS NOT NULL';
+                            // Then also make sure we group on the VOT's ID, unless we're already grouping on something.
+                            if (!$aSQL['GROUP_BY']) {
+                                // t.geneid needs to be included because we order on this as well (otherwise, we could have used t.id).
+                                $aSQL['GROUP_BY'] = 't.geneid, vot.id';
+                            }
                         }
                         // We have no fallback, so we'll easily detect an error if we messed up somewhere.
                     }


### PR DESCRIPTION
Fixed bug; The "all variants affecting transcripts" view showed only one entry.
- This error is related to #167.
- This was caused by the recent changes making LOVD compatible with the new default `ONLY_FULL_GROUP_BY` MySQL setting.
- There was no more GROUP BY defined, after which MySQL grouped all results into one.
- Closes #176: "Viewlist entry count differs from what is displayed".
- Checked all other Custom VLs for this error as well, now they are all fine.