### PR TITLE
Let dev/test installations identify themselves correctly

### DIFF
--- a/src/install/index.php
+++ b/src/install/index.php
@@ -4,13 +4,14 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2017-01-25
+ * Modified    : 2017-02-07
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -334,14 +335,17 @@ if ($_GET['step'] == 2 && defined('NOT_INSTALLED')) {
     // Restart session, now with correct session name.
     session_destroy();
     $sSignature = md5($_SERVER['HTTP_HOST'] . dirname($_SERVER['SCRIPT_NAME']) . time());
-// DMD_SPECIFIC
-if ($_SERVER['SERVER_ADMIN'] == 'i.f.a.c.fokkema@lumc.nl' && $_SERVER['HTTP_HOST'] == 'localhost') {
-    $sSignature = 'ifokkema_local_3.0';
-} elseif ($_SERVER['SERVER_ADMIN'] == 'd.asscheman@lumc.nl' && $_SERVER['HTTP_HOST'] == 'localhost') {
-    $sSignature = 'dasscheman_local_3.0';
-} elseif (isset($_SERVER['USER']) && $_SERVER['USER'] === 'travis') {
-    $sSignature = 'travis_CI_3.0';
-}
+
+    // DMD_SPECIFIC
+    // Set alternative signature for development/test installations.
+    $aFilterAdmins = array(
+        'i.f.a.c.fokkema@lumc.nl' => 'ifokkema_local_3.0',
+        'm.kroon@lumc.nl' => 'mkroon_local_3.0',
+        'travis-ci@localhost' => 'travis_CI_3.0');
+    if (key_exists($_SERVER['SERVER_ADMIN'], $aFilterAdmins) && $_SERVER['HTTP_HOST'] == 'localhost') {
+        $sSignature = $aFilterAdmins[$_SERVER['SERVER_ADMIN']];
+    }
+
     // Set the session name to something unique, to prevent mixing cookies with other LOVDs on the same server.
     $_SETT['cookie_id'] = md5($sSignature);
     session_name('PHPSESSID_' . $_SETT['cookie_id']);

--- a/src/install/index.php
+++ b/src/install/index.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2017-02-07
+ * Modified    : 2017-02-20
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -342,7 +342,7 @@ if ($_GET['step'] == 2 && defined('NOT_INSTALLED')) {
         'i.f.a.c.fokkema@lumc.nl' => 'ifokkema_local_3.0',
         'm.kroon@lumc.nl' => 'mkroon_local_3.0',
         'travis-ci@localhost' => 'travis_CI_3.0');
-    if (key_exists($_SERVER['SERVER_ADMIN'], $aFilterAdmins) && $_SERVER['HTTP_HOST'] == 'localhost') {
+    if (isset($aFilterAdmins[$_SERVER['SERVER_ADMIN']]) && $_SERVER['HTTP_HOST'] == 'localhost') {
         $sSignature = $aFilterAdmins[$_SERVER['SERVER_ADMIN']];
     }
 

--- a/tests/selenium_tests/shared_tests/create_gene_GJB.php
+++ b/tests/selenium_tests/shared_tests/create_gene_GJB.php
@@ -1,4 +1,35 @@
 <?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : ?
+ * Modified    : 2017-02-07
+ * For LOVD    : 3.0-19
+ *
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
 require_once 'LOVDSeleniumBaseTestCase.php';
 
 use \Facebook\WebDriver\WebDriverBy;
@@ -8,6 +39,9 @@ class CreateGeneGJBTest extends LOVDSeleniumWebdriverBaseTestCase
 {
     public function testCreateGeneGJB()
     {
+        // Open genes page.
+        $this->driver->get(ROOT_URL . '/src/genes');
+
         // Mouse hover over genes tab, to make 'create a new gene entry' link visible.
         $tabElement = $this->driver->findElement(WebDriverBy::id("tab_genes"));
         $this->driver->getMouse()->mouseMove($tabElement->getCoordinates());

--- a/tests/travis/setup/setup_apache.sh
+++ b/tests/travis/setup/setup_apache.sh
@@ -35,6 +35,10 @@ sudo sed -i -e "s,/var/www/html,/home/travis/build/${GITHUBACCOUNT},g" /etc/apac
 sudo sed -i -e "s,/var/www,/home/travis/build/${GITHUBACCOUNT},g" /etc/apache2/apache2.conf
 sudo sed -i -e "s,AllowOverride[ ]None,AllowOverride All,g" /etc/apache2/apache2.conf
 
+# Set server administrator directive (used for installation signature that is
+# sent to lovd.nl for identification).
+sudo sed -i -e "s,ServerAdmin webmaster@localhost,ServerAdmin travis-ci@localhost,g" /etc/apache2/sites-available/000-default.conf
+
 # Make all source files readable and all source dirs executable.
 # (requirement of Apache)
 sudo chmod -R +r /home/travis


### PR DESCRIPTION
Overwrite default signature for development and test installations based on `$_SERVER['SERVER_ADMIN']`. Fixes #174 

@ifokkema: I was not able to test on the receiving end whether the correct signature was set. Do you know how to do this? As of now there should be test installations showing up in the statistics with the following signatures (name -- md5 hash):

    travis_CI_3.0 -- 1951dc9caea4b8c053d26612d1d7eee2
    mkroon_local_3.0 -- f85e532c2b3819323effc9d3be4baa02