### PR TITLE
Feat/download link

### DIFF
--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2016-12-07
- * For LOVD    : 3.0-18
+ * Modified    : 2017-02-13
+ * For LOVD    : 3.0-19
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -127,7 +127,8 @@ class LOVD_Gene extends LOVD_Object {
                         'exon_tables' => 'Exon/intron information',
                         'diseases_' => 'Associated with diseases',
                         'reference' => 'Citation reference(s)',
-                        'allow_download_' => array('Allow public to download all variant entries', LEVEL_COLLABORATOR),
+                        'download_' => 'Download all information linked to this gene',
+                        'allow_download_' => array('Allow public to download linked information', LEVEL_COLLABORATOR),
                         'allow_index_wiki_' => array('Allow data to be indexed by WikiProfessional', LEVEL_COLLABORATOR),
                         'refseq_url_' => 'Refseq URL',
                         'curators_' => 'Curators',
@@ -523,6 +524,16 @@ class LOVD_Gene extends LOVD_Object {
             if (isset($zData['reference'])) {
                 // FIXME; is 't niet beter de PubMed custom link data uit de database te halen? Als ie ooit wordt aangepast, gaat dit fout.
                 $zData['reference'] = preg_replace('/\{PMID:(.*):(.*)\}/U', '<A href="http://www.ncbi.nlm.nih.gov/pubmed/$2" target="_blank">$1</A>', $zData['reference']);
+            }
+
+            if ($_AUTH['level'] >= LEVEL_CURATOR) {
+                $zData['download_'] = '<A href="download/all/gene/' . $zData['id'] . '">' .
+                    'Download all information</a>';
+            } else if (isset($zData['allow_download']) && $zData['allow_download'] == '1') {
+                $zData['download_'] = '<A href="download/all/gene_public/' . $zData['id'] . '">' .
+                    'Download all public information</a>';
+            } else {
+                unset($this->aColumnsViewEntry['download_']);
             }
 
             $zData['allow_download_']   = '<IMG src="gfx/mark_' . $zData['allow_download'] . '.png" alt="" width="11" height="11">';

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2017-02-13
+ * Modified    : 2017-02-14
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -526,12 +526,10 @@ class LOVD_Gene extends LOVD_Object {
                 $zData['reference'] = preg_replace('/\{PMID:(.*):(.*)\}/U', '<A href="http://www.ncbi.nlm.nih.gov/pubmed/$2" target="_blank">$1</A>', $zData['reference']);
             }
 
-            if ($_AUTH['level'] >= LEVEL_CURATOR) {
+            if ($_AUTH['level'] >= LEVEL_CURATOR ||
+                (isset($zData['allow_download']) && $zData['allow_download'] === '1')) {
                 $zData['download_'] = '<A href="download/all/gene/' . $zData['id'] . '">' .
                     'Download all information</a>';
-            } else if (isset($zData['allow_download']) && $zData['allow_download'] == '1') {
-                $zData['download_'] = '<A href="download/all/gene_public/' . $zData['id'] . '">' .
-                    'Download all public information</a>';
             } else {
                 unset($this->aColumnsViewEntry['download_']);
             }

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2017-02-14
+ * Modified    : 2017-06-15
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -127,9 +127,6 @@ class LOVD_Gene extends LOVD_Object {
                         'exon_tables' => 'Exon/intron information',
                         'diseases_' => 'Associated with diseases',
                         'reference' => 'Citation reference(s)',
-                        'download_' => 'Download all information linked to this gene',
-                        'allow_download_' => array('Allow public to download linked information', LEVEL_COLLABORATOR),
-                        'allow_index_wiki_' => array('Allow data to be indexed by WikiProfessional', LEVEL_COLLABORATOR),
                         'refseq_url_' => 'Refseq URL',
                         'curators_' => 'Curators',
                         'collaborators_' => array('Collaborators', LEVEL_COLLABORATOR),
@@ -137,6 +134,8 @@ class LOVD_Gene extends LOVD_Object {
                         'uniq_variants_' => 'Unique public DNA variants reported',
                         'count_individuals' => 'Individuals with public variants',
                         'hidden_variants_' => 'Hidden variants',
+                        'allow_download_' => array('Allow public to download linked information', LEVEL_COLLABORATOR),
+                        'download_' => 'Download all this gene\'s data',
                         'note_index' => 'Notes',
                         'created_by_' => array('Created by', LEVEL_COLLABORATOR),
                         'created_date_' => 'Date created',
@@ -312,13 +311,13 @@ class LOVD_Gene extends LOVD_Object {
         // If we've built the form before, simply return it. Especially imports will repeatedly call checkFields(), which calls getForm().
         if (!empty($this->aFormData)) {
             if (lovd_getProjectFile() == '/import.php') {
-                // During import the refseq_genomic is required, else the import 
+                // During import the refseq_genomic is required, else the import
                 // starts complaining that the selected refseq_genomic is not valid
-                // Therefore we set the refseq_genomic in the aFormData property 
+                // Therefore we set the refseq_genomic in the aFormData property
                 // before the getForm() is returned.
                 global $zData;
                 $aSelectRefseqGenomic = array_combine(array($zData['refseq_genomic']), array($zData['refseq_genomic']));
-         
+
                 $this->aFormData['refseq_genomic'] = array('Genomic reference sequence', '', 'select', 'refseq_genomic', 1, $aSelectRefseqGenomic, false, false, false);
             }
             return parent::getForm();
@@ -526,10 +525,9 @@ class LOVD_Gene extends LOVD_Object {
                 $zData['reference'] = preg_replace('/\{PMID:(.*):(.*)\}/U', '<A href="http://www.ncbi.nlm.nih.gov/pubmed/$2" target="_blank">$1</A>', $zData['reference']);
             }
 
-            if ($_AUTH['level'] >= LEVEL_CURATOR ||
-                (isset($zData['allow_download']) && $zData['allow_download'] === '1')) {
+            if ($_AUTH['level'] >= LEVEL_CURATOR || !empty($zData['allow_download'])) {
                 $zData['download_'] = '<A href="download/all/gene/' . $zData['id'] . '">' .
-                    'Download all information</a>';
+                    'Download all data</a>';
             } else {
                 unset($this->aColumnsViewEntry['download_']);
             }

--- a/src/download.php
+++ b/src/download.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2017-02-15
+ * Modified    : 2017-02-17
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -365,6 +365,8 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
                 $aObjects['Individuals']['filters']['statusid'] = array(STATUS_MARKED, STATUS_OK);
                 $aObjects['Phenotypes']['filters']['statusid'] = array(STATUS_MARKED, STATUS_OK);
 
+                $aObjects['Individuals']['filter_other']['Screenings']['individualid'] = 'id';
+
                 // Hide non-public columns.
                 $aObjectTranslations = array(
                     'VariantOnTranscript' => 'Variants_On_Transcripts',
@@ -502,6 +504,27 @@ foreach ($aObjectsToBeFiltered as $sObject) {
 }
 
 
+
+if (isset($sFilter) && $sFilter == 'gene_public') {
+    // Ugly hack to run otherwise ignored filter of individualid on screenings.
+    // Fixme: make sure this filter is part of the query to get screenings from DB.
+
+    if (isset($aObjects['Screenings']['filters']['individualid']) &&
+        is_array($aObjects['Screenings']['filters']['individualid'])) {
+
+        // Get allowed values as keys, for quick lookups.
+        $aValuesAsKeys = array_flip($aObjects['Screenings']['filters']['individualid']);
+
+        // Filter out non-allowed values for individualid.
+        $aNewData = array();
+        foreach ($aObjects['Screenings']['data'] as $zData) {
+            if (key_exists($zData['individualid'], $aValuesAsKeys)) {
+                $aNewData[] = $zData;
+            }
+        }
+        $aObjects['Screenings']['data'] = $aNewData;
+    }
+}
 
 
 

--- a/src/download.php
+++ b/src/download.php
@@ -4,11 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2016-11-15
- * For LOVD    : 3.0-18
+ * Modified    : 2017-02-08
+ * For LOVD    : 3.0-19
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -78,6 +79,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
     $sHeader = '';   // What header to put in the file? "<header> download".
     $sFilter = '';   // Do you want to filter the data? If so, put some string here, that marks this type of filter.
     $ID = '';
+    $aGene = array();
     if ($_PE[1] == 'all' && empty($_PE[2])) {
         // Download all data.
         $sFileName = 'full_download';
@@ -89,8 +91,11 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
         $sHeader = 'Full data';
         $sFilter = 'gene';
         $ID = $_PE[3];
+        $aGene = $_DB->query('SELECT * FROM ' . TABLE_GENES . ' WHERE id=?', array($ID))->fetchAssoc();
         lovd_isAuthorized('gene', $_PE[3]);
-        lovd_requireAuth(LEVEL_CURATOR);
+        if (!isset($aGene['allow_download']) || $aGene['allow_download'] != '1') {
+            lovd_requireAuth(LEVEL_CURATOR);
+        }
     } elseif ($_PE[1] == 'all' && $_PE[2] == 'mine' && PATH_COUNT == 3) {
         // Own data.
         $sFileName = 'owned_data';

--- a/src/download.php
+++ b/src/download.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2017-02-14
+ * Modified    : 2017-02-15
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -373,7 +373,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
                     'Phenotype' => 'Phenotypes',
                     'Screening' => 'Screenings');
                 $qHiddenCols = 'SELECT id, SUBSTRING_INDEX(id, "/", 1) AS category FROM ' .
-                               'lovd_v3_columns WHERE public_view = ?';
+                               TABLE_COLS . ' WHERE public_view = ?';
                 $aHiddenCols = $_DB->query($qHiddenCols, array('0'))->fetchAllAssoc();
                 foreach($aHiddenCols as $aHiddenCol) {
                     $sObject = $aObjectTranslations[$aHiddenCol['category']];

--- a/src/download.php
+++ b/src/download.php
@@ -361,9 +361,9 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
             $aObjects['Ind2Dis']['filter_other']['Diseases']['id'] = 'diseaseid'; // More values were already in, from Gen2Dis!
 
             if ($sFilter == 'gene_public') {
-                $aObjects['Variants']['filters']['statusid'] = STATUS_OK;
-                $aObjects['Individuals']['filters']['statusid'] = STATUS_OK;
-                $aObjects['Phenotypes']['filters']['statusid'] = STATUS_OK;
+                $aObjects['Variants']['filters']['statusid'] = array(STATUS_MARKED, STATUS_OK);
+                $aObjects['Individuals']['filters']['statusid'] = array(STATUS_MARKED, STATUS_OK);
+                $aObjects['Phenotypes']['filters']['statusid'] = array(STATUS_MARKED, STATUS_OK);
 
                 // Hide non-public columns.
                 $aObjectTranslations = array(

--- a/src/download.php
+++ b/src/download.php
@@ -365,6 +365,21 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'gen
                 $aObjects['Variants']['filters']['statusid'] = STATUS_OK;
                 $aObjects['Individuals']['filters']['statusid'] = STATUS_OK;
                 $aObjects['Phenotypes']['filters']['statusid'] = STATUS_OK;
+
+                // Hide non-public columns.
+                $aObjectTranslations = array(
+                    'VariantOnTranscript' => 'Variants_On_Transcripts',
+                    'VariantOnGenome' => 'Variants',
+                    'Individual' => 'Individuals',
+                    'Phenotype' => 'Phenotypes',
+                    'Screening' => 'Screenings');
+                $qHiddenCols = 'SELECT id, SUBSTRING_INDEX(id, "/", 1) AS category FROM ' .
+                               'lovd_v3_columns WHERE public_view = ?';
+                $aHiddenCols = $_DB->query($qHiddenCols, array('0'))->fetchAllAssoc();
+                foreach($aHiddenCols as $aHiddenCol) {
+                    $sObject = $aObjectTranslations[$aHiddenCol['category']];
+                    $aObjects[$sObject]['hide_columns'][] = $aHiddenCol['id'];
+                }
             }
         }
 


### PR DESCRIPTION
New link on gene homepage to download all related data. Link text shows up as:
  * "Download all public information" for anyone below LEVEL_CURATOR, which links to `download/all/gene_public/GENE_SYMBOL` (only if `allow_download` is true for gene)
  * "Download all information" for anyone with LEVEL_CURATOR or above, which links to `download/all/gene/GENE_SYMBOL` (always shown)

New "gene_public" category download will do same thing as `download/all/gene`, except that it strips non-public variants, individuals and phenotypes. If the gene's `allow_download` is true, it's also reachable for anyone below LEVEL_CURATOR.

Notable difference from expected behavior is that screenings linked to public variants but also to non-public individuals will be found in the output.

Fixes #78 
Fixes #183 