### PR TITLE
Feat/variants in range

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -25,6 +25,8 @@
  * Fixed bug; The gene's graphs pages only showed half of the graphs due to a
    query error introduced by the recent changes making LOVD compatible with the
    new default "ONLY_FULL_GROUP_BY" MySQL setting.
+ * Added feature to show variants in a certain genomic range, using the URL
+   format /variants/chr3:20-200000.
 
 
 /**************************

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2017-02-16
- * For LOVD    : 3.0-18
+ * Modified    : 2017-04-24
+ * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -175,10 +175,10 @@ class LOVD_GenomeVariant extends LOVD_Custom {
                                     'db'   => array('vog.chromosome', 'ASC', true)),
                         'position_g_start' => array(
                                     'view' => false,
-                                    'db'   => array('position_g_start', 'ASC', 'INT')),
+                                    'db'   => array('vog.position_g_start', 'ASC', true)),
                         'position_g_end' => array(
                                      'view' => false,
-                                    'db'   => array('position_g_end', 'ASC', 'INT')),
+                                    'db'   => array('vog.position_g_end', 'ASC', true)),
                       ),
                  $this->buildViewList(),
                  array(

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2016-12-13
+ * Modified    : 2017-02-16
  * For LOVD    : 3.0-18
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -173,6 +173,12 @@ class LOVD_GenomeVariant extends LOVD_Custom {
                         'chromosome' => array(
                                     'view' => array('Chr', 50),
                                     'db'   => array('vog.chromosome', 'ASC', true)),
+                        'position_g_start' => array(
+                                    'view' => false,
+                                    'db'   => array('position_g_start', 'ASC', 'INT')),
+                        'position_g_end' => array(
+                                     'view' => false,
+                                    'db'   => array('position_g_end', 'ASC', 'INT')),
                       ),
                  $this->buildViewList(),
                  array(

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-03-01
+ * Modified    : 2017-04-24
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -100,7 +100,7 @@ if (!ACTION && (empty($_PE[1]) ||
             $_GET['search_position_g_end'] = '<' . $sPositionEnd;
             $sTitle .= ' in region ' . $sRegion;
         } else {
-            $sTitle .= ' at chromosome ' . substr($sChr, 3);
+            $sTitle .= ' on chromosome ' . substr($sChr, 3);
         }
     }
 

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-02-15
+ * Modified    : 2017-02-16
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -94,18 +94,8 @@ if (!ACTION && (empty($_PE[1]) ||
 
         if (count($aRegionArgs) == 5) {
             // Set search conditions for start and end of region.
-            $_DATA->aColumnsViewList['position_g_start'] = array(
-                'view' => array('Start position'),
-                'db'   => array('position_g_start', 'ASC', 'INT'));
             $_GET['search_position_g_start'] = '>' . str_replace(',', '', $aRegionArgs[3]);
-            $aColsToHide[] = 'position_g_start';
-
-            $_DATA->aColumnsViewList['position_g_end'] = array(
-                'view' => array('End position'),
-                'db'   => array('position_g_end', 'ASC', 'INT'));
             $_GET['search_position_g_end'] = '<' . str_replace(',', '', $aRegionArgs[4]);
-            $aColsToHide[] = 'position_g_end';
-
             $sTitle .= ' in region ' . $aRegionArgs[0];
         } else {
             $sTitle .= ' at chromosome ' . substr($aRegionArgs[1], 3);

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-02-14
+ * Modified    : 2017-02-15
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -95,13 +95,13 @@ if (!ACTION && (empty($_PE[1]) ||
         if (count($aRegionArgs) == 5) {
             // Set search conditions for start and end of region.
             $_DATA->aColumnsViewList['position_g_start'] = array(
-                'view' => false,
+                'view' => array('Start position'),
                 'db'   => array('position_g_start', 'ASC', 'INT'));
             $_GET['search_position_g_start'] = '>' . str_replace(',', '', $aRegionArgs[3]);
             $aColsToHide[] = 'position_g_start';
 
             $_DATA->aColumnsViewList['position_g_end'] = array(
-                'view' => false,
+                'view' => array('End position'),
                 'db'   => array('position_g_end', 'ASC', 'INT'));
             $_GET['search_position_g_end'] = '<' . str_replace(',', '', $aRegionArgs[4]);
             $aColsToHide[] = 'position_g_end';

--- a/src/variants.php
+++ b/src/variants.php
@@ -96,8 +96,8 @@ if (!ACTION && (empty($_PE[1]) ||
 
         if (!is_null($sPositionStart) && !is_null($sPositionEnd)) {
             // Set search conditions for start and end of region.
-            $_GET['search_position_g_start'] = '>' . $sPositionStart;
-            $_GET['search_position_g_end'] = '<' . $sPositionEnd;
+            $_GET['search_position_g_start'] = '>=' . $sPositionStart;
+            $_GET['search_position_g_end'] = '<=' . $sPositionEnd;
             $sTitle .= ' in region ' . $sRegion;
         } else {
             $sTitle .= ' on chromosome ' . substr($sChr, 3);
@@ -109,7 +109,7 @@ if (!ACTION && (empty($_PE[1]) ||
     $_T->printHeader();
     $_T->printTitle();
 
-    $_DATA->viewList('VOG', $aColsToHide, false, false, $_AUTH['level'] >= LEVEL_MANAGER,
+    $_DATA->viewList('VOG', $aColsToHide, false, false, (bool) ($_AUTH['level'] >= LEVEL_MANAGER),
                      false, true);
     $_T->printFooter();
     exit;

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-01-13
+ * Modified    : 2017-02-14
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -69,9 +69,11 @@ if (!ACTION && !empty($_GET['select_db'])) {
 
 
 
-if (!ACTION && (empty($_PE[1]) || preg_match('/^chr[0-9A-Z]{1,2}$/', $_PE[1]))) {
+if (!ACTION && (empty($_PE[1]) ||
+    preg_match('/^(chr[0-9A-Z]{1,2})(:([0-9,]+)-([0-9,]+))?$/', $_PE[1], $aRegionArgs))) {
     // URL: /variants
     // URL: /variants/chrX
+    // URL: /variants/chr3:20-200,000
     // View all genomic variant entries, optionally restricted by chromosome.
 
     // Managers are allowed to download this list...
@@ -79,26 +81,44 @@ if (!ACTION && (empty($_PE[1]) || preg_match('/^chr[0-9A-Z]{1,2}$/', $_PE[1]))) 
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
-    if (!empty($_PE[1])) {
-        $sChr = $_PE[1];
-    } else {
-        $sChr = '';
+    require_once ROOT_PATH . 'class/object_genome_variants.php';
+    $_DATA = new LOVD_GenomeVariant();
+    $aColsToHide = array('allele_');
+    $sTitle = 'View all genomic variants';
+
+    // Set conditions on viewlist if a region is specified (e.g. chr3:20-200,000)
+    if (isset($aRegionArgs)) {
+        // Set search condition for chromosome.
+        $_GET['search_chromosome'] = '="' . substr($aRegionArgs[1], 3) . '"';
+        $aColsToHide[] = 'chromosome';
+
+        if (count($aRegionArgs) == 5) {
+            // Set search conditions for start and end of region.
+            $_DATA->aColumnsViewList['position_g_start'] = array(
+                'view' => false,
+                'db'   => array('position_g_start', 'ASC', 'INT'));
+            $_GET['search_position_g_start'] = '>' . str_replace(',', '', $aRegionArgs[3]);
+            $aColsToHide[] = 'position_g_start';
+
+            $_DATA->aColumnsViewList['position_g_end'] = array(
+                'view' => false,
+                'db'   => array('position_g_end', 'ASC', 'INT'));
+            $_GET['search_position_g_end'] = '<' . str_replace(',', '', $aRegionArgs[4]);
+            $aColsToHide[] = 'position_g_end';
+
+            $sTitle .= ' in region ' . $aRegionArgs[0];
+        } else {
+            $sTitle .= ' at chromosome ' . substr($aRegionArgs[1], 3);
+        }
     }
 
-    define('PAGE_TITLE', 'View all genomic variants' . (!$sChr? '' : ' on chromosome ' . substr($sChr, 3)));
+    // Show page with variant viewlist.
+    define('PAGE_TITLE', $sTitle);
     $_T->printHeader();
     $_T->printTitle();
 
-    require ROOT_PATH . 'class/object_genome_variants.php';
-    $_DATA = new LOVD_GenomeVariant();
-    $aColsToHide = array('allele_');
-    if ($sChr) {
-        $_GET['search_chromosome'] = '="' . substr($sChr, 3) . '"';
-        $aColsToHide[] = 'chromosome';
-    }
-    $_DATA->viewList('VOG', $aColsToHide, false, false, (bool) ($_AUTH['level'] >= LEVEL_MANAGER),
+    $_DATA->viewList('VOG', $aColsToHide, false, false, $_AUTH['level'] >= LEVEL_MANAGER,
                      false, true);
-
     $_T->printFooter();
     exit;
 }

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-02-16
+ * Modified    : 2017-03-01
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -70,10 +70,10 @@ if (!ACTION && !empty($_GET['select_db'])) {
 
 
 if (!ACTION && (empty($_PE[1]) ||
-    preg_match('/^(chr[0-9A-Z]{1,2})(:([0-9,]+)-([0-9,]+))?$/', $_PE[1], $aRegionArgs))) {
+        preg_match('/^(chr[0-9A-Z]{1,2})(?::([0-9]+)-([0-9]+))?$/', $_PE[1], $aRegionArgs))) {
     // URL: /variants
     // URL: /variants/chrX
-    // URL: /variants/chr3:20-200,000
+    // URL: /variants/chr3:20-200000
     // View all genomic variant entries, optionally restricted by chromosome.
 
     // Managers are allowed to download this list...
@@ -86,19 +86,21 @@ if (!ACTION && (empty($_PE[1]) ||
     $aColsToHide = array('allele_');
     $sTitle = 'View all genomic variants';
 
-    // Set conditions on viewlist if a region is specified (e.g. chr3:20-200,000)
+    // Set conditions on viewlist if a region is specified (e.g. chr3:20-200000)
     if (isset($aRegionArgs)) {
+        list($sRegion, $sChr, $sPositionStart, $sPositionEnd) = array_pad($aRegionArgs, 4, null);
+
         // Set search condition for chromosome.
-        $_GET['search_chromosome'] = '="' . substr($aRegionArgs[1], 3) . '"';
+        $_GET['search_chromosome'] = '="' . substr($sChr, 3) . '"';
         $aColsToHide[] = 'chromosome';
 
-        if (count($aRegionArgs) == 5) {
+        if (!is_null($sPositionStart) && !is_null($sPositionEnd)) {
             // Set search conditions for start and end of region.
-            $_GET['search_position_g_start'] = '>' . str_replace(',', '', $aRegionArgs[3]);
-            $_GET['search_position_g_end'] = '<' . str_replace(',', '', $aRegionArgs[4]);
-            $sTitle .= ' in region ' . $aRegionArgs[0];
+            $_GET['search_position_g_start'] = '>' . $sPositionStart;
+            $_GET['search_position_g_end'] = '<' . $sPositionEnd;
+            $sTitle .= ' in region ' . $sRegion;
         } else {
-            $sTitle .= ' at chromosome ' . substr($aRegionArgs[1], 3);
+            $sTitle .= ' at chromosome ' . substr($sChr, 3);
         }
     }
 


### PR DESCRIPTION
Extending the view for all variants on a chromosome (e.g. `variants/chrX`) to make it possible to specify a subregion (e.g. `chr3:20-200,000`).

Note: the change in 4c910c9 moves the position fields settings for the viewlist into the VOG class definition. This causes the position fields to be ignored in the error message that appears when a region is specified for where there are no variants. E.g. `variants/chr21:1-2` will show a message like: `No variants found where chr is "21"!`. Code responsible for this message is [here](https://github.com/LOVDnl/LOVD3/blob/feat/variants_in_range/src/class/objects.php#L2437-L2450)

Fixes #57