### PR TITLE
Minor bug fix in the refseq parser.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -40,6 +40,10 @@
    1, even though they will be interpreted as 1, since the field is a flag.
  * When a form field contains incorrect values (usally when importing), LOVD
    won't print more than one error message about that field's value anymore.
+ * Included version 3.0-19 of the official LOVD Reference Sequence Parser
+   script.
+   - The "Include link to GenBank record" field in the final step sometimes
+     contained more text than just an GenBank record ID.
 
 
 /**************************

--- a/src/scripts/refseq_parser.php
+++ b/src/scripts/refseq_parser.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-29
- * Modified    : 2014-10-02
- * For LOVD    : 3.0-12
+ * Modified    : 2017-05-08
+ * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2014 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -144,7 +144,7 @@ if ($_GET['step'] == 1) {
                     }
                     // Determine the accession number, including version.
                     if (substr($line, 0, 7) == 'VERSION') {
-                        $_POST['version_id'] = preg_replace('/^VERSION\s+(N[CG]_[0-9]+\.[0-9]+)\s+.*$/', "$1", rtrim($line));
+                        $_POST['version_id'] = preg_replace('/^VERSION\s+(N[CG]_[0-9]+\.[0-9]+)\b/', "$1", rtrim($line));
                     }
                     if ('/gene="' . $_POST['symbol'] . '"' == preg_replace('/\s+/', '', $line)) {
                         // We are in the right gene.


### PR DESCRIPTION
- The "Include link to GenBank record" field in the final step sometimes contained more text than just an GenBank record ID.
- The regexp somehow expected text after the ID, now we no longer do.