### PR TITLE
Submission emails now have their Reply-To set to the curators and sub…

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1216,6 +1216,8 @@
  * The screenings & individuals pages now have gene specific page, which shows
    the entries that have been screened for the currently selected gene.
  * Mails are now being sent to the appropriate users after an edit of data.
+ * Submission emails now have their Reply-To set to the curators and submitters,
+   so that both parties can just reply to end up with the correct addressees.
 
 
 /*******************

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -623,6 +623,13 @@ function lovd_sendMail ($aTo, $sSubject, $sBody, $sHeaders, $bHalt = true, $bFwd
 
     $sHeaders = $sHeaders . (!empty($sCc)? PHP_EOL . 'Cc: ' . $sCc : '') . (!empty($sBcc)? PHP_EOL . 'Bcc: ' . $sBcc : '');
 
+    // Submission emails should have the Reply-To set to the curator
+    //  and the submitter, so both benefit from it.
+    if (strpos($sSubject, 'LOVD submission') === 0) {
+        // Reply-to should be original addressees.
+        $sHeaders .= PHP_EOL . 'Reply-To: ' . $sTo . ', ' . $sCc;
+    }
+
     // 2013-08-26; 3.0-08; Encode the subject as well. Prefixing with "Subject: " to make sure the first line including the SMTP header does not exceed the 76 chars.
     $sSubjectEncoded = substr(mb_encode_mimeheader('Subject: ' . $sSubject, 'UTF-8'), 9);
     $bSafeMode = ini_get('safe_mode');

--- a/src/submit.php
+++ b/src/submit.php
@@ -1054,6 +1054,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
     $sBody = lovd_formatMail($aBody);
 
     // Set proper subject.
+    // Don't just change this subject, it's being parsed in inc-lib-form.php (lovd_sendMail()).
     $sSubject = 'LOVD submission' . (ACTION != 'edit'? '' : ' update') . (!empty($aGenes)? ' (' . implode(', ', array_slice($aGenes, 0, 20)) . (count($aGenes) > 20? ', ...' : '') . ')' : ''); // Don't just change this; lovd_sendMail() is parsing it.
 
     $aCC = array();


### PR DESCRIPTION
Submission emails now have their Reply-To set to the curators and submitters, so that both parties can just reply to end up with the correct addressees.
- Also set a reminder in submit.php to not just change the subject of the submission emails.
- Fixes #217.