### PR TITLE
Updated all NCBI links to use HTTPS since using HTTP broke things sometimes.

### DIFF
--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -61,7 +61,7 @@ With the official release of LOVD in 2004 the system had become much more dynami
 
 In 2004, LOVD became available under the open source license GPL and with the 1.1.0 release most of the text-files had been replaced by online forms
 so customizations can be performed through the web interface.
-Early in 2005 the \href{http://www.ncbi.nlm.nih.gov/pubmed/15977173}{first LOVD article} was published,
+Early in 2005 the \href{https://www.ncbi.nlm.nih.gov/pubmed/15977173}{first LOVD article} was published,
 and in 2005 the development of LOVD was more targeted at improving the ease of use of the system.
 \vskip \baselineskip
 
@@ -74,7 +74,7 @@ With more features being added and bugs fixed rapidly, LOVD 2.0 reached beta sta
 after which more and more users started to upgrade their 1.1.0 databases to 2.0.
 Finally, in October 2007 LOVD 2.0 reached the stable stage, after which LOVD 2.0 was continuously improved with monthly releases for two years,
 after which the releases became less frequent.
-LOVD 2.0 is described in the \href{http://www.ncbi.nlm.nih.gov/pubmed/21520333}{second LOVD paper}.
+LOVD 2.0 is described in the \href{https://www.ncbi.nlm.nih.gov/pubmed/21520333}{second LOVD paper}.
 \vskip \baselineskip
 
 By 2009 it had became clear that although LOVD 2.0 was a great step forward, there were still key improvements to be made.
@@ -195,7 +195,7 @@ Some more advanced examples:\\
   \begin{shaded}
     \frame{\includegraphics[width=0.95\linewidth]{gene_menu.png}}
     \centering
-  	\caption{Gene menu.}
+    \caption{Gene menu.}
   \end{shaded}
 \end{wrapfigure}
 When no gene is selected, the default page of the genes tab shows all genes.
@@ -204,7 +204,7 @@ When a gene is selected (shown in the page header), the default page of the gene
 
 \begin{description}
   \item[View all genes] \hfill \\
-  Here you can see all the genes for this installation. 
+  Here you can see all the genes for this installation.
   When you click on a gene entry, you're taken to the gene homepage.
   \item[View gene homepage] \hfill \\
   Here you can see the details of a gene.
@@ -382,7 +382,7 @@ When a gene is selected (shown in the page header),
   \begin{shaded}
     \frame{\includegraphics[width=0.95\linewidth]{disease_menu.png}}
     \centering
-	\caption{Diseases menu.}
+    \caption{Diseases menu.}
   \end{shaded}
 \end{wrapfigure}
 When no gene is selected, the default page of the diseases tab shows all diseases.
@@ -3198,9 +3198,9 @@ When this line is not included in the file that is imported, LOVD cannot process
 
 \begin{warntable}
   Please NOTE that spreadsheets are well known for introducing errors in importing/exporting
-   text files, due to automatic interpretation of the values. 
-  When using a spreadsheet program to edit a downloaded file, 
-   format all cells to "Text" \textbf{before} importing/pasting the downloaded data.\\   
+   text files, due to automatic interpretation of the values.
+  When using a spreadsheet program to edit a downloaded file,
+   format all cells to "Text" \textbf{before} importing/pasting the downloaded data.\\
 
   Also some cases have been reported where MS Excel removed contents of large text fields (> 255 characters).
 \end{warntable}
@@ -3335,7 +3335,7 @@ Custom columns are not listed here, since every LOVD installation has different
       information\\ \hline
     21 & Maternal (confirmed) & Variant is on maternal allele, confirmed in mother\\ \hline
   \end{tabular}
-  
+
   If left empty during import, the default value is ``0''.
 %  \item[allow\_count\_all] (from section Columns)\hfill \\
   \item[chromosome] (from sections Genes and Variants\_On\_Genome)\hfill \\

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -45,6 +45,7 @@
    - The "Include link to GenBank record" field in the final step sometimes
      contained more text than just an GenBank record ID.
  * Updated all links to the HGVS nomenclature to point to the new website.
+ * Updated all links to the NCBI to use HTTPS.
 
 
 /**************************

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-15
- * Modified    : 2017-01-25
+ * Modified    : 2017-05-15
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -828,7 +828,7 @@ class LOVD_CustomViewList extends LOVD_Object {
 
         // Replace rs numbers with dbSNP links.
         if (!empty($zData['VariantOnGenome/dbSNP'])) {
-            $zData['VariantOnGenome/dbSNP'] = preg_replace('/(rs\d+)/', '<SPAN' . ($sView != 'list'? '' : ' onclick="cancelParentEvent(event);"') . '><A href="http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?rs=' . "$1" . '" target="_blank">' . "$1" . '</A></SPAN>', $zData['VariantOnGenome/dbSNP']);
+            $zData['VariantOnGenome/dbSNP'] = preg_replace('/(rs\d+)/', '<SPAN' . ($sView != 'list'? '' : ' onclick="cancelParentEvent(event);"') . '><A href="https://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?rs=' . "$1" . '" target="_blank">' . "$1" . '</A></SPAN>', $zData['VariantOnGenome/dbSNP']);
         }
 
         foreach ($this->aColumns as $sCol => $aCol) {

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2017-05-12
+ * Modified    : 2017-05-15
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -486,7 +486,7 @@ class LOVD_Gene extends LOVD_Object {
             $zData['imprinting_'] = $_SETT['gene_imprinting'][$zData['imprinting']];
 
             // FIXME; zou dit een external source moeten zijn?
-            $zData['refseq_genomic_'] = '<A href="' . (substr($zData['refseq_genomic'], 0, 3) == 'LRG'? 'ftp://ftp.ebi.ac.uk/pub/databases/lrgex/' . $zData['refseq_genomic'] . '.xml' : 'http://www.ncbi.nlm.nih.gov/nuccore/' . $zData['refseq_genomic']) . '" target="_blank">' . $zData['refseq_genomic'] . '</A>';
+            $zData['refseq_genomic_'] = '<A href="' . (substr($zData['refseq_genomic'], 0, 3) == 'LRG'? 'ftp://ftp.ebi.ac.uk/pub/databases/lrgex/' . $zData['refseq_genomic'] . '.xml' : 'https://www.ncbi.nlm.nih.gov/nuccore/' . $zData['refseq_genomic']) . '" target="_blank">' . $zData['refseq_genomic'] . '</A>';
             $zData['refseq_UD_'] = '<A href="' . str_replace('services', 'Reference/', $_CONF['mutalyzer_soap_url']) . $zData['refseq_UD'] . '.gb" target="_blank">' . $zData['refseq_UD'] . '</A>';
 
             // Transcript links and exon/intron info table. Check if files exist, and build link. Otherwise, remove field.
@@ -521,8 +521,8 @@ class LOVD_Gene extends LOVD_Object {
             }
 
             if (isset($zData['reference'])) {
-                // FIXME; is 't niet beter de PubMed custom link data uit de database te halen? Als ie ooit wordt aangepast, gaat dit fout.
-                $zData['reference'] = preg_replace('/\{PMID:(.*):(.*)\}/U', '<A href="http://www.ncbi.nlm.nih.gov/pubmed/$2" target="_blank">$1</A>', $zData['reference']);
+                // FIXME; Isn't it better to take the PubMed custom link from the database? If it ever gets edited, this one should be edited, too.
+                $zData['reference'] = preg_replace('/\{PMID:(.*):(.*)\}/U', '<A href="https://www.ncbi.nlm.nih.gov/pubmed/$2" target="_blank">$1</A>', $zData['reference']);
             }
 
             $zData['allow_download_']   = '<IMG src="gfx/mark_' . $zData['allow_download'] . '.png" alt="" width="11" height="11">';
@@ -630,7 +630,7 @@ class LOVD_Gene extends LOVD_Object {
                 // The weird addition in the end is to fake a proper name in Ensembl.
                 $sURLEnsembl .= $sURLBedFile . rawurlencode('&name=/' . $zData['id'] . ' variants');
                 $zData['ensembl'] = 'Show variants in the Ensembl Genome Browser (<A href="' . $sURLEnsembl . '=labels" target="_blank">full view</A>, <A href="' . $sURLEnsembl . '=normal" target="_blank">compact view</A>)';
-                $zData['ncbi'] = 'Show distribution histogram of variants in the <A href="http://www.ncbi.nlm.nih.gov/projects/sviewer/?id=' . $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$zData['chromosome']] . '&amp;v=' . ($zData['position_g_mrna_start'] - 100) . ':' . ($zData['position_g_mrna_end'] + 100) . '&amp;content=7&amp;url=' . $sURLBedFile . '" target="_blank">NCBI Sequence Viewer</A>';
+                $zData['ncbi'] = 'Show distribution histogram of variants in the <A href="https://www.ncbi.nlm.nih.gov/projects/sviewer/?id=' . $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$zData['chromosome']] . '&amp;v=' . ($zData['position_g_mrna_start'] - 100) . ':' . ($zData['position_g_mrna_end'] + 100) . '&amp;content=7&amp;url=' . $sURLBedFile . '" target="_blank">NCBI Sequence Viewer</A>';
 
             } else {
                 unset($this->aColumnsViewEntry['TableStart_Graphs'],$this->aColumnsViewEntry['TableHeader_Graphs'],$this->aColumnsViewEntry['graphs'],$this->aColumnsViewEntry['ucsc'],$this->aColumnsViewEntry['ensembl'],$this->aColumnsViewEntry['ncbi'],$this->aColumnsViewEntry['TableEnd_Graphs'],$this->aColumnsViewEntry['HR_2']);

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2017-04-24
+ * Modified    : 2017-05-15
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -471,7 +471,7 @@ class LOVD_GenomeVariant extends LOVD_Custom {
         }
         // Replace rs numbers with dbSNP links.
         if (!empty($zData['VariantOnGenome/dbSNP'])) {
-            $zData['VariantOnGenome/dbSNP'] = preg_replace('/(rs\d+)/', '<SPAN' . ($sView != 'list'? '' : ' onclick="cancelParentEvent(event);"') . '><A href="http://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?rs=' . "$1" . '" target="_blank">' . "$1" . '</A></SPAN>', $zData['VariantOnGenome/dbSNP']);
+            $zData['VariantOnGenome/dbSNP'] = preg_replace('/(rs\d+)/', '<SPAN' . ($sView != 'list'? '' : ' onclick="cancelParentEvent(event);"') . '><A href="https://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?rs=' . "$1" . '" target="_blank">' . "$1" . '</A></SPAN>', $zData['VariantOnGenome/dbSNP']);
         }
 
         return $zData;

--- a/src/class/object_transcripts.php
+++ b/src/class/object_transcripts.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2016-07-20
- * For LOVD    : 3.0-17
+ * Modified    : 2017-05-15
+ * For LOVD    : 3.0-19
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -214,7 +214,7 @@ class LOVD_Transcript extends LOVD_Object {
             if (isset($_SETT['mito_genes_aliases'][$zData['geneid']])) {
                 $sNCBILink = str_replace('(' . $_SETT['mito_genes_aliases'][$zData['geneid']] . '_v001)', '', $zData['id_ncbi']);
             }
-            $zData['id_ncbi_'] = '<A href="http://www.ncbi.nlm.nih.gov/nuccore/' . $sNCBILink . '" target="_blank">' . $zData['id_ncbi'] . '</A>';
+            $zData['id_ncbi_'] = '<A href="https://www.ncbi.nlm.nih.gov/nuccore/' . $sNCBILink . '" target="_blank">' . $zData['id_ncbi'] . '</A>';
 
             // Exon/intron info table. Check if files exist, and build link. Otherwise, remove field.
             $sExonTable = '';

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2017-03-08
+ * Modified    : 2017-05-15
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -144,7 +144,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-18a',
+                            'version' => '3.0-18b',
                           ),
                 'user_levels' =>
                      array(

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2017-03-10
+ * Modified    : 2017-05-15
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -480,6 +480,14 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                  '3.0-18a' =>
                      array(
                          'UPDATE ' . TABLE_COLS . ' SET preg_pattern = "/^(chr(\\\\d{1,2}|[XYM])|(C(\\\\d{1,2}|[XYM])orf[\\\\d][\\\\dA-Z]*-|[A-Z][A-Z0-9]*-)?(C(\\\\d{1,2}|[XYM])orf[\\\\d][\\\\dA-Z]*|[A-Z][A-Z0-9-]*))_\\\\d{6}$/" WHERE id = "VariantOnGenome/DBID";',
+                     ),
+                 '3.0-18b' =>
+                     array(
+                         'UPDATE ' . TABLE_SOURCES . ' SET url = "https://www.ncbi.nlm.nih.gov/gene?cmd=Retrieve&dopt=full_report&list_uids={{ ID }}" WHERE id = "entrez"',
+                         'UPDATE ' . TABLE_SOURCES . ' SET url = "https://www.ncbi.nlm.nih.gov/nuccore/{{ ID }}" WHERE id = "genbank"',
+                         'UPDATE ' . TABLE_SOURCES . ' SET url = "https://www.ncbi.nlm.nih.gov/gtr/genes/{{ ID }}" WHERE id = "genetests"',
+                         'UPDATE ' . TABLE_SOURCES . ' SET url = "https://www.ncbi.nlm.nih.gov/pubmed?LinkName=gene_pubmed&from_uid={{ ID }}" WHERE id = "pubmed_gene"',
+                         'UPDATE ' . TABLE_SOURCES . ' SET url = "https://www.ncbi.nlm.nih.gov/pubmed/{{ ID }}" WHERE id = "pubmed_article"',
                      ),
              );
 

--- a/src/install/inc-sql-sources.php
+++ b/src/install/inc-sql-sources.php
@@ -4,12 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-23
- * Modified    : 2016-10-17
- * For LOVD    : 3.0-18
+ * Modified    : 2017-05-15
+ * For LOVD    : 3.0-19
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
  * This file is part of LOVD.
  *
@@ -31,15 +31,15 @@
 // List of external biological sources.
 $aSourceSQL =
          array(
-                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("entrez",       "http://www.ncbi.nlm.nih.gov/entrez/query.fcgi?db=gene&cmd=Retrieve&dopt=full_report&list_uids={{ ID }}")',
-                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("genbank",      "http://www.ncbi.nlm.nih.gov/nuccore/{{ ID }}")',
+                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("entrez",       "https://www.ncbi.nlm.nih.gov/gene?cmd=Retrieve&dopt=full_report&list_uids={{ ID }}")',
+                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("genbank",      "https://www.ncbi.nlm.nih.gov/nuccore/{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("genecards",    "http://www.genecards.org/cgi-bin/carddisp.pl?gene={{ ID }}")',
-                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("genetests",    "http://www.ncbi.nlm.nih.gov/sites/GeneTests/lab/gene/{{ ID }}")',
+                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("genetests",    "https://www.ncbi.nlm.nih.gov/gtr/genes/{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("hgmd",         "http://www.hgmd.cf.ac.uk/ac/gene.php?gene={{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("omim",         "http://www.omim.org/entry/{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("uniprot",      "http://www.uniprot.org/uniprot/{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("hgnc",         "http://www.genenames.org/data/hgnc_data.php?hgnc_id={{ ID }}")',
-                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("pubmed_gene",  "http://www.ncbi.nlm.nih.gov/pubmed?LinkName=gene_pubmed&from_uid={{ ID }}")',
-                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("pubmed_article", "http://www.ncbi.nlm.nih.gov/pubmed/{{ ID }}")',
+                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("pubmed_gene"  ,  "https://www.ncbi.nlm.nih.gov/pubmed?LinkName=gene_pubmed&from_uid={{ ID }}")',
+                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("pubmed_article", "https://www.ncbi.nlm.nih.gov/pubmed/{{ ID }}")',
               );
 ?>

--- a/src/scripts/refseq_parser.php
+++ b/src/scripts/refseq_parser.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-29
- * Modified    : 2017-05-08
+ * Modified    : 2017-05-15
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ir. Gerard C.P. Schaafsma <G.C.P.Schaafsma@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Gerard C.P. Schaafsma <G.C.P.Schaafsma@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -114,7 +114,7 @@ if ($_GET['step'] == 1) {
             // Read file into an array.
             $sFileID = (substr($sFileID, 0, 2) == 'UD'?
                 str_replace('services', 'Reference/', $_CONF['mutalyzer_soap_url']) . $sFileID . '.gb' :
-                'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=' . $sFileID . '&rettype=gb');
+                'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id=' . $sFileID . '&rettype=gb');
             // FIXME: Since Mutalyzer only allows for https communication since Sept 2014, lovd_php_file()'s socket communication doesn't work.
             // 2014-10-02; 3.0-12; Modified lovd_php_file() to allow http(s) communication through PHP's file() as long as there's allow_url_fopen and no POST.
             // This is a temporary fix, depends on a PHP setting, and does not work with proxies at the moment (although than can be fixed with providing a context to file()).
@@ -145,7 +145,7 @@ if ($_GET['step'] == 1) {
                     }
                     // Determine the accession number, including version.
                     if (substr($line, 0, 7) == 'VERSION') {
-                        $_POST['version_id'] = preg_replace('/^VERSION\s+(N[CG]_[0-9]+\.[0-9]+)\b/', "$1", rtrim($line));
+                        $_POST['version_id'] = preg_replace('/^VERSION\s+(N[CG]_[0-9]+\.[0-9]+)\b.*/', "$1", rtrim($line));
                     }
                     if ('/gene="' . $_POST['symbol'] . '"' == preg_replace('/\s+/', '', $line)) {
                         // We are in the right gene.
@@ -1356,7 +1356,7 @@ if ($_GET['step'] == 3) {
                 }
                 // 2009-12-03; 2.0-23; added the mRNA accession number, but only if it is the same in the database
                 if (!empty($_POST['version_id'])) {
-                    $_POST['note'] .= ' The sequence was taken from <a href="http://www.ncbi.nlm.nih.gov/nucleotide/' . $_POST['version_id'] . '">' . $_POST['version_id'] . '</a>' . ($bStep2 ? ', covering ' . $_POST['symbol'] . ' transcript <a href="http://www.ncbi.nlm.nih.gov/nucleotide/' . $_POST['transcript_id'] . '">' . $_POST['transcript_id'] . '</a>.' : '.') .'</p>';
+                    $_POST['note'] .= ' The sequence was taken from <a href="https://www.ncbi.nlm.nih.gov/nucleotide/' . $_POST['version_id'] . '">' . $_POST['version_id'] . '</a>' . ($bStep2 ? ', covering ' . $_POST['symbol'] . ' transcript <a href="https://www.ncbi.nlm.nih.gov/nucleotide/' . $_POST['transcript_id'] . '">' . $_POST['transcript_id'] . '</a>.' : '.') .'</p>';
                 }
 
                 if (trim($_POST['note'])) {


### PR DESCRIPTION
Updated all NCBI links to use HTTPS since using HTTP broke things sometimes.
- The Reference Sequence parser couldn't fetch the GenBank file over a proxy with the NCBI's HTTP to HTTPS redirect in place. Updating the URL to HTTP fixed the problem.
- Fixed all links to HTTPS to match.
- Also fixed a bug in the Reference Sequence Parser with the parsing of the GenBank ID; this problem was introduced in the recent fix.
- Updated all NCBI-based external source links.
  - The GeneTest URL now uses the NCBI ID as a source.
- Version bump to 3.0-18b.
- Updated NCBI links in the manual, too.
  - Also whitespace changes, mostly induced by the IDE.
  - Since it's just some URLs, no need to re-render it at this time.
- Added changelog entry.

Fixes #219.