### PR TITLE
Let viewlist rows open link in new window with middle-click.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -46,6 +46,9 @@
      contained more text than just an GenBank record ID.
  * Updated all links to the HGVS nomenclature to point to the new website.
  * Updated all links to the NCBI to use HTTPS.
+ * Added feature to open links in tables in a new browser tab. Does not work
+   for some older browsers based on webkit.
+   Closes #227: "Let viewlist rows open link in new window with middle-click."
 
 
 /**************************

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2017-06-01
+ * Modified    : 2017-06-06
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2505,8 +2505,11 @@ FROptions
                                 // Rowlink is javascript code, define it with an onClick attribute.
                                 ' onclick="' . rawurldecode(substr($zData['row_link'], 11)) . '"' :
                                 // Rowlink is a URL, define a data-href attribute which is used to
-                                // generate a link with jquery.
-                                'data-href="' . lovd_getInstallURL(false) . $zData['row_link'] . '"')
+                                // by javascript open the page in the current window (onclick) or
+                                // in a new window (middle-click event caught with jquery in
+                                // inc-js-viewlist.php).
+                                ' data-href="' . lovd_getInstallURL(false) . $zData['row_link'] . '"' .
+                                ' onclick="javascript:window.location.href=this.getAttribute(\'data-href\');"')
                         ) . '>');
                 if ($bOptions) {
                     print("\n" . '          <TD align="center" class="checkbox" onclick="cancelParentEvent(event);"><INPUT id="check_' . $zData['row_id'] . '" class="checkbox" type="checkbox" name="check_' . $zData['row_id'] . '" onclick="lovd_recordCheckChanges(this, \'' . $sViewListID . '\');"' . (in_array($zData['row_id'], $aSessionViewList['checked'])? ' checked' : '') . '></TD>');

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2017-06-06
+ * Modified    : 2017-06-19
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2509,6 +2509,9 @@ FROptions
                                 // in a new window (middle-click event caught with jquery in
                                 // inc-js-viewlist.php).
                                 ' data-href="' . lovd_getInstallURL(false) . $zData['row_link'] . '"' .
+                                // Note: older browsers will also trigger `onClick` events when the middle
+                                // mouse button is clicked, this will interfere with functionality to open
+                                // links in new tabs, provided in inc-js-viewlist.php.
                                 ' onclick="javascript:window.location.href=this.getAttribute(\'data-href\');"')
                         ) . '>');
                 if ($bOptions) {

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2017-04-24
+ * Modified    : 2017-06-01
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2499,7 +2499,15 @@ FROptions
                 // FIXME; rawurldecode() in the line below should have a better solution.
                 // IE (who else) refuses to respect the BASE href tag when using JS. So we have no other option than to include the full path here.
                 print("\n" .
-                      '        <TR class="' . (empty($zData['class_name'])? 'data' : $zData['class_name']) . '"' . (!$zData['row_id']? '' : ' id="' . $zData['row_id'] . '"') . ' valign="top"' . (!$zData['row_link']? '' : ' style="cursor : pointer;"') . (!$zData['row_link']? '' : ' onclick="' . (substr($zData['row_link'], 0, 11) == 'javascript:'? rawurldecode(substr($zData['row_link'], 11)) : 'window.location.href = \'' . lovd_getInstallURL(false) . $zData['row_link'] . '\';') . '"') . '>');
+                      '        <TR class="' . (empty($zData['class_name'])? 'data' : $zData['class_name']) . '"' . (!$zData['row_id']? '' : ' id="' . $zData['row_id'] . '"') . ' valign="top"' . (!$zData['row_link']? '' : ' style="cursor : pointer;"') .
+                        (!$zData['row_link']? '' :
+                            (substr($zData['row_link'], 0, 11) == 'javascript:'?
+                                // Rowlink is javascript code, define it with an onClick attribute.
+                                ' onclick="' . rawurldecode(substr($zData['row_link'], 11)) . '"' :
+                                // Rowlink is a URL, define a data-href attribute which is used to
+                                // generate a link with jquery.
+                                'data-href="' . lovd_getInstallURL(false) . $zData['row_link'] . '"')
+                        ) . '>');
                 if ($bOptions) {
                     print("\n" . '          <TD align="center" class="checkbox" onclick="cancelParentEvent(event);"><INPUT id="check_' . $zData['row_id'] . '" class="checkbox" type="checkbox" name="check_' . $zData['row_id'] . '" onclick="lovd_recordCheckChanges(this, \'' . $sViewListID . '\');"' . (in_array($zData['row_id'], $aSessionViewList['checked'])? ' checked' : '') . '></TD>');
                 }

--- a/src/inc-js-viewlist.php
+++ b/src/inc-js-viewlist.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-29
- * Modified    : 2016-10-14
- * For LOVD    : 3.0-18
+ * Modified    : 2017-06-01
+ * For LOVD    : 3.0-19
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -937,3 +937,22 @@ function lovd_passAndRemoveViewListRow (sViewListID, sRowID, aRowData, callback)
 
 
 
+
+
+$(document).ready(function() {
+    // Bind mouse clicking events to viewlist rows. Open urls specified in a
+    // 'data-url' attribute if it's available.
+    $('table .data').on('mouseup', 'tr', function(e) {
+        if ($(this).data('href')) {
+            switch (e.which) {
+                case 1:
+                    // Left mouse button clicked, open url in current window.
+                    window.location.href = $(this).data('href');
+                    break;
+                case 2:
+                    // Middle mouse button clicked, open url in new window.
+                    window.open($(this).data('href'), '_blank');
+            }
+        }
+    });
+});

--- a/src/inc-js-viewlist.php
+++ b/src/inc-js-viewlist.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-29
- * Modified    : 2017-06-01
+ * Modified    : 2017-06-06
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -940,19 +940,13 @@ function lovd_passAndRemoveViewListRow (sViewListID, sRowID, aRowData, callback)
 
 
 $(document).ready(function() {
-    // Bind mouse clicking events to viewlist rows. Open urls specified in a
+    // Bind mouse clicking events to viewlist rows to let clicking of middle-
+    // mousebutton open URLs in new tab/window. Open urls specified in a
     // 'data-url' attribute if it's available.
     $('table .data').on('mouseup', 'tr', function(e) {
-        if ($(this).data('href')) {
-            switch (e.which) {
-                case 1:
-                    // Left mouse button clicked, open url in current window.
-                    window.location.href = $(this).data('href');
-                    break;
-                case 2:
-                    // Middle mouse button clicked, open url in new window.
-                    window.open($(this).data('href'), '_blank');
-            }
+        if ($(this).data('href') && e.which == 2) {
+            // Middle mouse button clicked, open url in new window.
+            window.open($(this).data('href'), '_blank');
         }
     });
 });


### PR DESCRIPTION
Let users open a link from a row in a viewlist by clicking with the middle button of the mouse. Pure javascript row links are unaffected.

Fixes #196.