### PR TITLE
Fixed bug with editing individuals with large numbers of diseases.

### DIFF
--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2016-10-14
- * For LOVD    : 3.0-18
+ * Modified    : 2017-06-19
+ * For LOVD    : 3.0-19
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -55,6 +55,10 @@ class LOVD_Individual extends LOVD_Custom {
     {
         // Default constructor.
         global $_AUTH;
+
+        // SQL code for preparing load entry query.
+        // Increase DB limits to allow concatenation of large number of disease IDs.
+        $this->sSQLPreLoadEntry = 'SET group_concat_max_len = 200000';
 
         // SQL code for loading an entry for an edit form.
         // FIXME; change owner to owned_by_ in the load entry query below.


### PR DESCRIPTION
Fixed bug with editing individuals with large numbers of diseases.
- Due to LOVD not fetching all diseases for the form, not all diseases were loaded into the form, and as such it was not in one go possible to remove all diseases, and not possible at all to remove certain diseases without removing others.
- Fixes #192.