### PR TITLE
Explicitly cast parts of viewlist row_id to integer.

### DIFF
--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-15
- * Modified    : 2017-05-15
+ * Modified    : 2017-06-19
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -126,7 +126,7 @@ class LOVD_CustomViewList extends LOVD_Object {
         if (in_array('VariantOnGenome', $aObjects) && (in_array('VariantOnTranscript', $aObjects) ||
                 in_array('VariantOnTranscriptUnique', $aObjects))) {
             // Use "vog.id:vot.transcriptid" as row_id, fall back to "vog.id" if there is no VOT entry.
-            $aSQL['SELECT'] = 'CONCAT(MIN(vog.id), IFNULL(CONCAT(":", MIN(vot.transcriptid)), "")) AS row_id';
+            $aSQL['SELECT'] = 'CONCAT(CAST(MIN(vog.id) AS UNSIGNED), IFNULL(CONCAT(":", CAST(MIN(vot.transcriptid) AS UNSIGNED)), "")) AS row_id';
             $bSetRowID = true;
         } elseif (in_array('Transcript', $aObjects)) {
             $aSQL['SELECT'] = 'MIN(t.id) AS row_id';


### PR DESCRIPTION
This fixes odd behavior of MySQL where the row_id somtimes contains zerofilled-numbers and sometimes not. (e.g. depending on presence of `ORDER BY` clause.)

Chosen solution was to cast the parts of the row_id explicitly. 2 options here, either cast the id and then take the aggregate of multiple rows with `MIN()`, or the other way around.

Performance of possible solutions compared to original (average of 10x generating the variant list for the MECP2 gene (nearly 120.000 entries)):

    Master 3.0-18 20170619: 2.136
    MIN(CAST()):            2.168
    CAST(MIN()):            2.151

In the end, `CAST(MIN())` was chosen as the most performant solution, although the differences are small.

Fixes #205