### PR TITLE
Fix/travis new trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,15 @@ matrix:
 sudo: required
 dist: trusty
 
+# Currently running on an image that was deprecated 2017-06-21. The latest
+# Trusty image does not have a firefox version that plays well with the
+# facebook webdriver client and Selenium 2.53 or 3.4 stack. At least partially
+# due to this bug: https://github.com/SeleniumHQ/selenium/issues/3607 which
+# also seems to affect the PHP client. Travis will disable the deprecated image
+# by first of September, a solution is needed by then.
+# FIXME: upgrade to latest Trusty image by removing line below.
+group: deprecated-2017Q2
+
 addons:
   apt:
     packages:

--- a/tests/upload_test_results.sh
+++ b/tests/upload_test_results.sh
@@ -9,5 +9,5 @@ for file in `ls -1 -t -r ${GLOB}/test_results/error_screenshots/*.png`; do
 
     # Upload to transfer.sh, this command will output the URL on which the
     # uploaded file can be reached.
-    curl --upload-file ${file} http://transfer.sh
+    curl --upload-file ${file} https://transfer.sh
 done


### PR DESCRIPTION
Return to old version of Travis' build image. Newest version gives problems for tests running on Firefox.