### PR TITLE
Fix ugly link to reading frame checker when there are no variants.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -5,6 +5,14 @@
  *************/
 
 /**************************
+ * 3.0 Build 20
+ * 2017-09-??
+ *********/
+ * Fixed bug; The link to the Reading Frame Checker was a bit malformed when the
+   gene had no variants to show.
+
+
+/**************************
  * 3.0 Build 19
  * 2017-06-19
  *********/
@@ -1266,8 +1274,6 @@
  * The screenings & individuals pages now have gene specific page, which shows
    the entries that have been screened for the currently selected gene.
  * Mails are now being sent to the appropriate users after an edit of data.
- * Submission emails now have their Reply-To set to the curators and submitters,
-   so that both parties can just reply to end up with the correct addressees.
 
 
 /*******************

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2017-06-16
+ * Modified    : 2017-06-26
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -649,7 +649,18 @@ class LOVD_Gene extends LOVD_Object {
                 $zData['ncbi'] = 'Show distribution histogram of variants in the <A href="https://www.ncbi.nlm.nih.gov/projects/sviewer/?id=' . $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$zData['chromosome']] . '&amp;v=' . ($zData['position_g_mrna_start'] - 100) . ':' . ($zData['position_g_mrna_end'] + 100) . '&amp;content=7&amp;url=' . $sURLBedFile . '" target="_blank">NCBI Sequence Viewer</A>';
 
             } else {
-                unset($this->aColumnsViewEntry['TableStart_Graphs'],$this->aColumnsViewEntry['TableHeader_Graphs'],$this->aColumnsViewEntry['graphs'],$this->aColumnsViewEntry['ucsc'],$this->aColumnsViewEntry['ensembl'],$this->aColumnsViewEntry['ncbi'],$this->aColumnsViewEntry['TableEnd_Graphs'],$this->aColumnsViewEntry['HR_2']);
+                if (!$zData['rf_checker_']) {
+                    // Remove the displays/utilities info table when there are also no reading
+                    // frame checker results.
+                    unset($this->aColumnsViewEntry['TableStart_Graphs'],
+                          $this->aColumnsViewEntry['TableHeader_Graphs'],
+                          $this->aColumnsViewEntry['TableEnd_Graphs'],
+                          $this->aColumnsViewEntry['HR_2']);
+                }
+                unset($this->aColumnsViewEntry['graphs'],
+                      $this->aColumnsViewEntry['ucsc'],
+                      $this->aColumnsViewEntry['ensembl'],
+                      $this->aColumnsViewEntry['ncbi']);
             }
 
             // URLs for "Links to other resources".

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-06-16
+ * Modified    : 2017-06-28
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1689,7 +1689,9 @@ if (PATH_COUNT == 2 && $_PE[1] == 'upload' && ACTION == 'create') {
                                     // Got gene information, prepare to add the gene to the database.
                                     // Extract gene information.
                                     list($sHgncID, $sSymbol, $sGeneName, $sChromLocation, $sLocusType, $sEntrez, $sOmim) = array_values($aGeneInfo[$sSymbol]);
-                                    list($sEntrez, $sOmim) = array_map('trim', array($sEntrez, $sOmim));
+                                    list($sEntrez, $sOmim) = array_map(function($var) {
+                                        return is_string($var)? trim($var) : $var;
+                                    }, array($sEntrez, $sOmim));
                                     if ($sChromLocation == 'mitochondria') {
                                         $sChromosome = 'M';
                                         $sChromBand = '';


### PR DESCRIPTION
Fix ugly link to reading frame checker when there are no variants.
- Fixes #237.
- Also, empty OMIM IDs were no longer sent to MySQL as NULL.