### PR TITLE
Add the URL of the new public list of LOVDs on the LOVD3 site, instead of using the 2.0 website URL.

### DIFF
--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -828,8 +828,8 @@ We use this information to see how many LOVDs there are worldwide, which version
    genes, individuals, variants and unique variants in your system.
   No specific information is sent, just the numbers.
   \hypertarget{item:include_in_listing}{}
-  \item[Include in the global LOVD listing] \hfill \\ %% FIXME; When LOVD 3.0 site has such a list, use that URL here.
-  On our website, we keep a \href{http://www.lovd.nl/2.0/index_list.php}{list of public LOVD installations}.
+  \item[Include in the global LOVD listing] \hfill \\
+  On our website, we keep a \href{http://www.lovd.nl/3.0/public_list}{list of public LOVD installations}.
   This list is also feeding our \href{http://www.lovd.nl/LSDBs}{worldwide LSDB list},
    through which submitters can locate databases for a specific gene to submit data to.
   If you enable the ``Include in the global LOVD listing'' setting,
@@ -4287,7 +4287,7 @@ However, for LOVD2 installations, this does not always work, and as such the ext
 \subsection{World-wide LOVD quering service}
 There is also a world-wide LOVD query API that allows you to query a genomic location to find out
  whether there is a variant reported in any public LOVD installation that has registered at
- \href{http://lovd.nl/2.0/index_list.php}{LOVD.nl}.
+ \href{http://lovd.nl/3.0/public_list}{LOVD.nl}.
 Please \href{http://www.lovd.nl/3.0/contact}{contact us directly} for more information on that API.
 
 


### PR DESCRIPTION
Add the URL of the new public list of LOVDs on the LOVD3 site, instead of using the 2.0 website URL.
Don't see the need to regenerate the manual, for just the URL change. The old URL remains to work anyway.

Closes #246.