### PR TITLE
Added links to overviews of created entries on user page.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -32,7 +32,7 @@
  * Fixed bug; The variant mapper gets stuck when encountering variants with no
    position set.
  * Added links to overviews of created entries on user page.
-   Closes #190: "Add Records Created".
+   Closes #190: "Add links to records created by user on user's profile page".
 
 
 /**************************

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -31,6 +31,8 @@
    Closes #98: "Configurable homepage".
  * Fixed bug; The variant mapper gets stuck when encountering variants with no
    position set.
+ * Added links to overviews of created entries on user page.
+   Closes #190: "Add Records Created".
 
 
 /**************************

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2017-06-19
- * For LOVD    : 3.0-19
+ * Modified    : 2017-08-04
+ * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -191,6 +191,9 @@ class LOVD_Individual extends LOVD_Custom {
                                     'view' => array('Status', 70),
                                     'db'   => array('ds.name', false, true),
                                     'auth' => LEVEL_COLLABORATOR),
+                        'created_by' => array(
+                                    'view' => false,
+                                    'db'   => array('i.created_by', false, true)),
                       ));
         $this->sSortDefault = 'id';
 

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2016-07-20
- * For LOVD    : 3.0-17
+ * Modified    : 2017-08-04
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -154,6 +154,9 @@ class LOVD_Screening extends LOVD_Custom {
                         'created_date' => array(
                                     'view' => array('Date created', 130),
                                     'db'   => array('s.created_date', 'ASC', true)),
+                        'created_by' => array(
+                                    'view' => false,
+                                    'db'   => array('s.created_by', false, true)),
                       ));
         $this->sSortDefault = 'id';
 


### PR DESCRIPTION
* Links to overviews are similar to those for data owned by the given
  user.
* Edited individual and screening classes to include created_by in
  their viewlist (hidden but searchable).

Fixes #190 