### PR TITLE
Fix effect_reported not set by curator

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -31,9 +31,9 @@
    Closes #98: "Configurable homepage".
  * Fixed bug; The variant mapper gets stuck when encountering variants with no
    position set.
- * Fixed bug; A variant cannot be made public when `effect_reported` is set to
-   "unclassified".
-   Closes #213: "Curator is allowed to leave `effect_reported` set to 
+ * Fixed bug; A variant could be made public when "Affects function (reported)"
+   was set to "Not classified".
+   Closes #213: "Curator is allowed to leave `effect_reported` set to
    unclassified."
 
 

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -31,6 +31,10 @@
    Closes #98: "Configurable homepage".
  * Fixed bug; The variant mapper gets stuck when encountering variants with no
    position set.
+ * Fixed bug; A variant cannot be made public when `effect_reported` is set to
+   "unclassified".
+   Closes #213: "Curator is allowed to leave `effect_reported` set to 
+   unclassified."
 
 
 /**************************

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2017-08-08
+ * Modified    : 2017-08-10
  * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -253,10 +253,10 @@ class LOVD_GenomeVariant extends LOVD_Custom {
             if ($_AUTH['level'] < LEVEL_CURATOR) {
                 // Remove the mandatory `effect_reported` field to throw an error.
                 unset($aData['effect_reported']);
-            } elseif (isset($aData['statusid']) && intval($aData['statusid']) == 9) {
+            } elseif (isset($aData['statusid']) && $aData['statusid'] == STATUS_OK) {
                 // Show error for curator/manager trying to publish variant without effect.
                 lovd_errorAdd('effect_reported', 'The \'Affects function (reported)\' field ' .
-                    'must be filled when variant status is Public');
+                    'may not be "Not classified" when variant status is "Public".');
             }
         }
 

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2017-05-15
- * For LOVD    : 3.0-19
+ * Modified    : 2017-08-08
+ * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -245,9 +245,19 @@ class LOVD_GenomeVariant extends LOVD_Custom {
 
         if ($_AUTH['level'] >= LEVEL_CURATOR) {
             $this->aCheckMandatory[] = 'effect_concluded';
-        } elseif (isset($aData['effect_reported']) && $aData['effect_reported'] === '0') {
-            // Submitters must fill in the variant effect field; '0' is not allowed for them.
-            unset($aData['effect_reported']);
+        }
+
+        if (isset($aData['effect_reported']) && $aData['effect_reported'] === '0') {
+            // `effect_reported` is not allowed to be '0' (Not classified) when user is a submitter
+            // or when the variant has status '9' (Public).
+            if ($_AUTH['level'] < LEVEL_CURATOR) {
+                // Remove the mandatory `effect_reported` field to throw an error.
+                unset($aData['effect_reported']);
+            } elseif (isset($aData['statusid']) && intval($aData['statusid']) == 9) {
+                // Show error for curator/manager trying to publish variant without effect.
+                lovd_errorAdd('effect_reported', 'The \'Affects function (reported)\' field ' .
+                    'must be filled when variant status is Public');
+            }
         }
 
         // Do this before running checkFields so that we have time to predict the DBID and fill it in.

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2017-08-10
+ * Modified    : 2017-08-14
  * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -232,7 +232,7 @@ class LOVD_GenomeVariant extends LOVD_Custom {
 
     function checkFields ($aData, $zData = false)
     {
-        global $_AUTH, $_CONF, $_SETT;
+        global $_AUTH, $_SETT;
 
         // Mandatory fields.
         $this->aCheckMandatory =
@@ -256,7 +256,7 @@ class LOVD_GenomeVariant extends LOVD_Custom {
             } elseif (isset($aData['statusid']) && $aData['statusid'] == STATUS_OK) {
                 // Show error for curator/manager trying to publish variant without effect.
                 lovd_errorAdd('effect_reported', 'The \'Affects function (reported)\' field ' .
-                    'may not be "Not classified" when variant status is "Public".');
+                    'may not be "' . $_SETT['var_effect'][0] . '" when variant status is "' . $_SETT['data_status'][STATUS_OK] . '".');
             }
         }
 


### PR DESCRIPTION
Do not allow `effect_reported` to be set to "not classified" when statusid is "Public".

Fixes #213 