### PR TITLE
Remove "View " part from page titles

### DIFF
--- a/src/announcements.php
+++ b/src/announcements.php
@@ -4,11 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-08-26
- * Modified    : 2016-08-26
- * For LOVD    : 3.0-17
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -45,7 +46,7 @@ if (PATH_COUNT == 1 && !ACTION) {
     // URL: /announcements
     // View all entries.
 
-    define('PAGE_TITLE', 'View system announcements');
+    define('PAGE_TITLE', 'System announcements');
     $_T->printHeader();
     $_T->printTitle();
 
@@ -69,7 +70,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     // View specific entry.
 
     $nID = sprintf('%05d', $_PE[1]);
-    define('PAGE_TITLE', 'View announcement #' . $nID);
+    define('PAGE_TITLE', 'Announcement #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -31,6 +31,8 @@
    Closes #98: "Configurable homepage".
  * Fixed bug; The variant mapper gets stuck when encountering variants with no
    position set.
+ * Removed redundant "View" in all page titles. E.g. "View all genes" became
+   "All genes".
 
 
 /**************************

--- a/src/columns.php
+++ b/src/columns.php
@@ -4,12 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-03-04
- * Modified    : 2016-12-07
- * For LOVD    : 3.0-18
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -115,7 +115,7 @@ if (PATH_COUNT > 2 && !ACTION) {
     unset($aCol[0]); // 'columns';
     $sColumnID = implode('/', $aCol);
 
-    define('PAGE_TITLE', 'View custom data column ' . $sColumnID);
+    define('PAGE_TITLE', 'Custom data column ' . $sColumnID);
     $_T->printHeader();
     $_T->printTitle();
 

--- a/src/diseases.php
+++ b/src/diseases.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-07-27
- * Modified    : 2016-09-01
- * For LOVD    : 3.0-17
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -52,7 +52,7 @@ if (PATH_COUNT == 1 && !ACTION) {
         $sGene = $_GET['search_genes_'];
     }
 
-    define('PAGE_TITLE', 'View all diseases' . (isset($sGene)? ' associated with gene ' . $sGene : ''));
+    define('PAGE_TITLE', 'All diseases' . (isset($sGene)? ' associated with gene ' . $sGene : ''));
     $_T->printHeader();
     $_T->printTitle();
 
@@ -84,7 +84,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     // View specific entry.
 
     $nID = sprintf('%05d', $_PE[1]);
-    define('PAGE_TITLE', 'View disease #' . $nID);
+    define('PAGE_TITLE', 'Disease #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 
@@ -148,7 +148,7 @@ if (PATH_COUNT == 2 && !ctype_digit($_PE[1]) && !ACTION) {
     $aDiseases = $_DB->query('SELECT id FROM ' . TABLE_DISEASES . ' WHERE symbol = ?', array($sID))->fetchAllColumn();
     $n = count($aDiseases);
     if (!$n) {
-        define('PAGE_TITLE', 'View disease');
+        define('PAGE_TITLE', 'Disease');
         $_T->printHeader();
         $_T->printTitle();
         lovd_showInfoTable('No such ID!', 'stop');
@@ -560,7 +560,7 @@ if (PATH_COUNT == 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && !ACTION) 
     // View enabled columns for this disease.
 
     $nID = sprintf('%05d', $_PE[1]);
-    define('PAGE_TITLE', 'View enabled custom data columns for disease #' . $nID);
+    define('PAGE_TITLE', 'Enabled custom data columns for disease #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 
@@ -597,7 +597,7 @@ if (PATH_COUNT > 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && !ACTION) {
     $aCol = $_PE;
     unset($aCol[0], $aCol[1], $aCol[2]); // 'diseases/00001/columns';
     $sColumnID = implode('/', $aCol);
-    define('PAGE_TITLE', 'View settings for custom data column ' . $sColumnID . ' for ' . $sUnit . ' #' . $sParentID);
+    define('PAGE_TITLE', 'Settings for custom data column ' . $sColumnID . ' for ' . $sUnit . ' #' . $sParentID);
     $_T->printHeader();
     $_T->printTitle();
 

--- a/src/genes.php
+++ b/src/genes.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2017-03-06
- * For LOVD    : 3.0-19
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -143,7 +143,7 @@ if (PATH_COUNT == 1 && !ACTION) {
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
-    define('PAGE_TITLE', 'View all genes');
+    define('PAGE_TITLE', 'All genes');
     $_T->printHeader();
     $_T->printTitle();
 
@@ -164,7 +164,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
     // View specific entry.
 
     $sID = rawurldecode($_PE[1]);
-    define('PAGE_TITLE', 'View ' . $sID . ' gene homepage');
+    define('PAGE_TITLE', $sID . ' gene homepage');
     $_T->printHeader();
     $_T->printTitle();
     lovd_printGeneHeader();
@@ -1111,7 +1111,7 @@ if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
     // View enabled columns for this gene.
 
     $sID = rawurldecode($_PE[1]);
-    define('PAGE_TITLE', 'View enabled custom data columns for gene ' . $sID);
+    define('PAGE_TITLE', 'Enabled custom data columns for gene ' . $sID);
     $_T->printHeader();
     $_T->printTitle();
 
@@ -1148,7 +1148,7 @@ if (PATH_COUNT > 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])
     $aCol = $_PE;
     unset($aCol[0], $aCol[1], $aCol[2]); // 'genes/DMD/columns';
     $sColumnID = implode('/', $aCol);
-    define('PAGE_TITLE', 'View settings for custom data column ' . $sColumnID . ' for ' . $sUnit . ' ' . $sParentID);
+    define('PAGE_TITLE', 'Settings for custom data column ' . $sColumnID . ' for ' . $sUnit . ' ' . $sParentID);
     $_T->printHeader();
     $_T->printTitle();
 

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2016-10-28
- * For LOVD    : 3.0-18
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -68,7 +68,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
-    define('PAGE_TITLE', 'View all individuals' . (isset($sGene)? ' with variants in gene ' . $sGene : ''));
+    define('PAGE_TITLE', 'All individuals' . (isset($sGene)? ' with variants in gene ' . $sGene : ''));
     $_T->printHeader();
     $_T->printTitle();
 
@@ -96,7 +96,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     // View specific entry.
 
     $nID = sprintf('%08d', $_PE[1]);
-    define('PAGE_TITLE', 'View individual #' . $nID);
+    define('PAGE_TITLE', 'Individual #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 

--- a/src/links.php
+++ b/src/links.php
@@ -4,12 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-04-19
- * Modified    : 2013-01-23
- * For LOVD    : 3.0-02
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2013 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -46,7 +47,7 @@ if (PATH_COUNT == 1 && !ACTION) {
     // URL: /links
     // View all entries.
 
-    define('PAGE_TITLE', 'View custom links');
+    define('PAGE_TITLE', 'Custom links');
     $_T->printHeader();
     $_T->printTitle();
 
@@ -70,7 +71,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     // View specific entry.
 
     $nID = sprintf('%03d', $_PE[1]);
-    define('PAGE_TITLE', 'View custom link #' . $nID);
+    define('PAGE_TITLE', 'Custom link #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 

--- a/src/logs.php
+++ b/src/logs.php
@@ -4,12 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-26
- * Modified    : 2013-02-28
- * For LOVD    : 3.0-03
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2013 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -41,7 +42,7 @@ if ($_AUTH) {
 // URL: /logs
 // View all log entries.
 
-define('PAGE_TITLE', 'View system log entries');
+define('PAGE_TITLE', 'System log entries');
 $_T->printHeader();
 $_T->printTitle();
 

--- a/src/pedigree.php
+++ b/src/pedigree.php
@@ -4,11 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-12-22
- * Modified    : 2012-04-24
- * For LOVD    : 3.0-beta-04
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2012 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -47,7 +48,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1])) {
     // FIXME; should check for the existence of the correct needed custom columns.
 
     $nID = sprintf('%08d', $_PE[1]);
-    define('PAGE_TITLE', 'View pedigree for individual #' . $nID);
+    define('PAGE_TITLE', 'Pedigree for individual #' . $nID);
     $_T->printHeader(false);
     $_T->printTitle();
 

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-23
- * Modified    : 2016-10-14
- * For LOVD    : 3.0-18
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -82,7 +82,7 @@ if (PATH_COUNT == 3 && $_PE[1] == 'disease' && ctype_digit($_PE[2]) && !ACTION) 
     // View all phenotype entries for a certain disease.
 
     $nDiseaseID = sprintf('%05d', $_PE[2]);
-    define('PAGE_TITLE', 'View phenotypes for disease #' . $nDiseaseID);
+    define('PAGE_TITLE', 'Phenotypes for disease #' . $nDiseaseID);
     $_T->printHeader();
     $_T->printTitle();
 
@@ -105,7 +105,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     // View specific entry.
 
     $nID = sprintf('%010d', $_PE[1]);
-    define('PAGE_TITLE', 'View phenotype #' . $nID);
+    define('PAGE_TITLE', 'Phenotype #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 

--- a/src/references.php
+++ b/src/references.php
@@ -4,12 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-03-11
- * Modified    : 2016-09-26
- * For LOVD    : 3.0-17-patch-02
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2015 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Daan Asscheman <D.Asscheman@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -115,7 +116,7 @@ if (PATH_COUNT >= 2 && (substr($aPathElements[1], 0, 4) == 'DOI:' || substr($aPa
         exit;
     }
 
-    define('PAGE_TITLE', 'View data for reference: ' . $aPathElements[1]);
+    define('PAGE_TITLE', 'Data for reference: ' . $aPathElements[1]);
     $_T->printHeader();
     $_T->printTitle();
 
@@ -180,7 +181,7 @@ if ($bImage) {
     exit;
 }
 
-define('PAGE_TITLE', 'View data for reference: ' . $aPathElements[1]);
+define('PAGE_TITLE', 'Data for reference: ' . $aPathElements[1]);
 $_T->printHeader();
 $_T->printTitle();
 

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2016-12-05
- * For LOVD    : 3.0-18
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -65,7 +65,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
         }
     }
 
-    define('PAGE_TITLE', 'View all screenings' . (isset($sGene)? ' for gene ' . $sGene : ''));
+    define('PAGE_TITLE', 'All screenings' . (isset($sGene)? ' for gene ' . $sGene : ''));
     $_T->printHeader();
     $_T->printTitle();
 
@@ -91,7 +91,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     // View specific entry.
 
     $nID = sprintf('%010d', $_PE[1]);
-    define('PAGE_TITLE', 'View screening #' . $nID);
+    define('PAGE_TITLE', 'Screening #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 

--- a/src/transcripts.php
+++ b/src/transcripts.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-01-25
- * For LOVD    : 3.0-19
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -55,7 +55,7 @@ if (!ACTION && (empty($_PE[1]) || preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldec
         $_GET['search_geneid'] = '="' . $sGene . '"';
         lovd_isAuthorized('gene', $sGene);
     }
-    define('PAGE_TITLE', 'View all transcripts' . ($sGene? ' of gene ' . $sGene : ''));
+    define('PAGE_TITLE', 'All transcripts' . ($sGene? ' of gene ' . $sGene : ''));
     $_T->printHeader();
     $_T->printTitle();
     if ($sGene) {
@@ -83,7 +83,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     // View specific entry.
 
     $nID = sprintf('%08d', $_PE[1]);
-    define('PAGE_TITLE', 'View transcript #' . $nID);
+    define('PAGE_TITLE', 'Transcript #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 
@@ -127,7 +127,7 @@ if (PATH_COUNT == 2 && !ctype_digit($_PE[1]) && !ACTION) {
     if ($nID = $_DB->query('SELECT id FROM ' . TABLE_TRANSCRIPTS . ' WHERE id_ncbi = ?', array($sID))->fetchColumn()) {
         header('Location: ' . lovd_getInstallURL() . $_PE[0] . '/' . $nID);
     } else {
-        define('PAGE_TITLE', 'View transcript');
+        define('PAGE_TITLE', 'Transcript');
         $_T->printHeader();
         $_T->printTitle();
         lovd_showInfoTable('No such ID!', 'stop');

--- a/src/users.php
+++ b/src/users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2017-06-16
- * For LOVD    : 3.0-19
+ * Modified    : 2017-08-09
+ * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -53,7 +53,7 @@ if (PATH_COUNT == 1 && !ACTION) {
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
-    define('PAGE_TITLE', 'View user accounts');
+    define('PAGE_TITLE', 'User accounts');
     $_T->printHeader();
     $_T->printTitle();
 
@@ -78,7 +78,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     // View specific entry.
 
     $nID = sprintf('%05d', $_PE[1]);
-    define('PAGE_TITLE', 'View user account #' . $nID);
+    define('PAGE_TITLE', 'User account #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-06-28
+ * Modified    : 2017-08-09
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -84,7 +84,7 @@ if (!ACTION && (empty($_PE[1]) ||
     require_once ROOT_PATH . 'class/object_genome_variants.php';
     $_DATA = new LOVD_GenomeVariant();
     $aColsToHide = array('allele_');
-    $sTitle = 'View all genomic variants';
+    $sTitle = 'All genomic variants';
 
     // Set conditions on viewlist if a region is specified (e.g. chr3:20-200000)
     if (isset($aRegionArgs)) {
@@ -128,7 +128,7 @@ if (PATH_COUNT == 2 && $_PE[1] == 'in_gene' && !ACTION) {
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
-    define('PAGE_TITLE', 'View all variants affecting transcripts');
+    define('PAGE_TITLE', 'All variants affecting transcripts');
     $_T->printHeader();
     $_T->printTitle();
 
@@ -149,7 +149,7 @@ if (PATH_COUNT == 3 && $_PE[1] == 'upload' && ctype_digit($_PE[2]) && !ACTION) {
     // View all genomic variant entries that were submitted in the given upload.
 
     $nID = sprintf('%015d', $_PE[2]);
-    define('PAGE_TITLE', 'View genomic variants from upload #' . $nID);
+    define('PAGE_TITLE', 'Genomic variants from upload #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 
@@ -224,10 +224,10 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
     }
 
     if ($bUnique) {
-        define('PAGE_TITLE', 'View unique variants in gene ' . $sGene);
+        define('PAGE_TITLE', 'Unique variants in gene ' . $sGene);
         $sViewListID = 'CustomVL_VOTunique_VOG_' . $sGene;
     } else {
-        define('PAGE_TITLE', 'View all transcript variants in gene ' . $sGene);
+        define('PAGE_TITLE', 'All transcript variants in gene ' . $sGene);
         $sViewListID = 'CustomVL_VOT_VOG_' . $sGene;
     }
     $_T->printHeader();
@@ -294,7 +294,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     // View specific entry.
 
     $nID = sprintf('%010d', $_PE[1]);
-    define('PAGE_TITLE', 'View genomic variant #' . $nID);
+    define('PAGE_TITLE', 'Genomic variant #' . $nID);
     $_T->printHeader();
     $_T->printTitle();
 

--- a/tests/selenium_tests/access_sharing_tests/access_sharing_submitter.php
+++ b/tests/selenium_tests/access_sharing_tests/access_sharing_submitter.php
@@ -104,7 +104,7 @@ class AccessSharingSubmitterTest extends LOVDSeleniumWebdriverBaseTestCase
         // Try (successfully) to access individual.
         $this->driver->get(ROOT_URL . '/src/individuals/' . $sIndividualID);
         $header = $this->driver->findElement(WebDriverBy::xpath('//h2[@class="LOVD"]'));
-        $this->assertEquals($header->getText(), 'View individual #' . $sIndividualID);
+        $this->assertEquals($header->getText(), 'Individual #' . $sIndividualID);
         $nonpubFieldHead = $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"]/tbody/tr[4]/th'));
         $this->assertEquals($nonpubFieldHead->getText(), 'Remarks (non public)');
     }

--- a/tests/selenium_tests/admin_tests/add_summary_variant_located_within_gene.php
+++ b/tests/selenium_tests/admin_tests/add_summary_variant_located_within_gene.php
@@ -10,7 +10,7 @@ class AddSummaryVariantLocatedWithinGeneTest extends LOVDSeleniumWebdriverBaseTe
     {
 
         // Wait for page redirect.
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View individual"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Individual"));
 
         // Mouse hover over Submit tab, to make 'submit new data' link visible.
         $tabElement = $this->driver->findElement(WebDriverBy::xpath("//img[@id='tab_submit']"));
@@ -110,7 +110,7 @@ class AddSummaryVariantLocatedWithinGeneTest extends LOVDSeleniumWebdriverBaseTe
         $this->assertContains("Successfully processed your submission and sent an email notification to the relevant curator", $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
 
         // wait for page redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertRegExp("/src\/variants\/\d{10}/", $this->driver->getCurrentURL());
     }

--- a/tests/selenium_tests/admin_tests/add_summary_variant_only_described_on_genomic_level.php
+++ b/tests/selenium_tests/admin_tests/add_summary_variant_only_described_on_genomic_level.php
@@ -51,7 +51,7 @@ class AddSummaryVariantOnlyDescribedOnGenomicLevelTest extends LOVDSeleniumWebdr
         $this->assertTrue((bool)preg_match('/^Successfully processed your submission and sent an email notification to the relevant curator[\s\S]*$/', $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
         // wait for page redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertContains("/src/variants/0000000169", $this->driver->getCurrentURL());
     }

--- a/tests/selenium_tests/admin_tests/delete_gene_IVD.php
+++ b/tests/selenium_tests/admin_tests/delete_gene_IVD.php
@@ -26,7 +26,7 @@ class DeleteGeneIVDTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertEquals("Successfully deleted the gene information entry!", $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
 
         // Wait for page redirect.
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View all genes"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("All genes"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/genes$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/admin_tests/post_finish_add_phenotype_info_to_IVA_individual.php
+++ b/tests/selenium_tests/admin_tests/post_finish_add_phenotype_info_to_IVA_individual.php
@@ -32,7 +32,7 @@ class PostFinishAddPhenotypeInfoToIVAIndividualTest extends LOVDSeleniumWebdrive
         $this->assertTrue((bool)preg_match('/^Successfully processed your submission and sent an email notification to the relevant curator[\s\S]*$/', $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
         // Wait for page redirect.
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View phenotype"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Phenotype"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/phenotypes\/0000000003$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/admin_tests/post_finish_add_variant_located_within_gene_to_IVA_individual.php
+++ b/tests/selenium_tests/admin_tests/post_finish_add_variant_located_within_gene_to_IVA_individual.php
@@ -76,7 +76,7 @@ class PostFinishAddVariantLocatedWithinTest extends LOVDSeleniumWebdriverBaseTes
         $this->assertTrue((bool)preg_match('/^Successfully processed your submission and sent an email notification to the relevant curator[\s\S]*$/', $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
         // Wait for page redirect.
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertContains("/src/variants/0000000334", $this->driver->getCurrentURL());
     }

--- a/tests/selenium_tests/admin_tests/post_finish_add_variant_only_described_on_genomic_level_to_IVA_individual.php
+++ b/tests/selenium_tests/admin_tests/post_finish_add_variant_only_described_on_genomic_level_to_IVA_individual.php
@@ -50,7 +50,7 @@ class PostFinishAddVariantOnlyDescribedOnGenomicLevelToIVAIndividualTest extends
         $this->assertTrue((bool)preg_match('/^Successfully processed your submission and sent an email notification to the relevant curator[\s\S]*$/', $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
         // wait for page redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000333$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/collaborator_tests/create_disease_CMT.php
+++ b/tests/selenium_tests/collaborator_tests/create_disease_CMT.php
@@ -30,7 +30,7 @@ class CreateDiseaseCMTTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertEquals("Successfully created the disease information entry!", $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View disease"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Disease"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/diseases\/00001$/', $this->driver->getCurrentURL()));
 

--- a/tests/selenium_tests/collaborator_tests/finish_individual_diagnosed_with_CMT.php
+++ b/tests/selenium_tests/collaborator_tests/finish_individual_diagnosed_with_CMT.php
@@ -15,7 +15,7 @@ class FinishIndividualDiagnosedWithCMTTest extends LOVDSeleniumWebdriverBaseTest
         
         $this->assertTrue((bool)preg_match('/^Successfully processed your submission and sent an email notification to the relevant curator[\s\S]*$/', $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View individual"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Individual"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/individuals\/00000001$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/collaborator_tests/post_finish_add_phenotype_info_to_CMT_individual.php
+++ b/tests/selenium_tests/collaborator_tests/post_finish_add_phenotype_info_to_CMT_individual.php
@@ -39,7 +39,7 @@ class PostFinishAddPhenotypeInfoToCMTIndividualTest extends LOVDSeleniumWebdrive
         $this->assertTrue((bool)preg_match('/^Successfully processed your submission and sent an email notification to the relevant curator[\s\S]*$/', $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View phenotype"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Phenotype"));
         
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/phenotypes\/0000000002$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/collaborator_tests/post_finish_add_screening_to_CMT_individual.php
+++ b/tests/selenium_tests/collaborator_tests/post_finish_add_screening_to_CMT_individual.php
@@ -8,7 +8,7 @@ class PostFinishAddScreeningToCMTIndividualTest extends LOVDSeleniumWebdriverBas
 {
     public function testPostFinishAddScreeningToCMTIndividual()
     {
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000004$/', $this->driver->getCurrentURL()));
 

--- a/tests/selenium_tests/collaborator_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
+++ b/tests/selenium_tests/collaborator_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
@@ -9,7 +9,7 @@ class PostFinishAddVariantLocatedWithinGeneToCMTTest extends LOVDSeleniumWebdriv
     public function testPostFinishAddVariantLocatedWithinGeneToCMT()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000003$/', $this->driver->getCurrentURL()));
 

--- a/tests/selenium_tests/curator_tests/add_summary_variant_only_described_on_genomic_level.php
+++ b/tests/selenium_tests/curator_tests/add_summary_variant_only_described_on_genomic_level.php
@@ -9,7 +9,7 @@ class AddSummaryVariantOnlyDescribedOnGenomicLevelTest extends LOVDSeleniumWebdr
     public function testAddSummaryVariantOnlyDescribedOnGenomicLevel()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000003$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::id("tab_submit"));

--- a/tests/selenium_tests/curator_tests/create_disease_CMT.php
+++ b/tests/selenium_tests/curator_tests/create_disease_CMT.php
@@ -26,7 +26,7 @@ class CreateDiseaseCMTTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertEquals("Successfully created the disease information entry!", $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View disease"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Disease"));
         
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/diseases\/00001$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/curator_tests/finish_individual_diagnosed_with_CMT.php
+++ b/tests/selenium_tests/curator_tests/finish_individual_diagnosed_with_CMT.php
@@ -16,7 +16,7 @@ class FinishIndividualDiagnosedWithCMTTest extends LOVDSeleniumWebdriverBaseTest
         $this->assertTrue((bool)preg_match('/^Successfully processed your submission and sent an email notification to the relevant curator[\s\S]*$/', $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View individual"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Individual"));
         
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/individuals\/00000001$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/curator_tests/post_finish_add_phenotype_info_to_CMT_individual.php
+++ b/tests/selenium_tests/curator_tests/post_finish_add_phenotype_info_to_CMT_individual.php
@@ -43,7 +43,7 @@ class PostFinishAddPhenotypeInfoToCMTIndividualTest extends LOVDSeleniumWebdrive
         
         $this->assertTrue((bool)preg_match('/^Successfully processed your submission and sent an email notification to the relevant curator[\s\S]*$/', $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View phenotype"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Phenotype"));
         
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/phenotypes\/0000000002$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/curator_tests/post_finish_add_screening_to_CMT_individual.php
+++ b/tests/selenium_tests/curator_tests/post_finish_add_screening_to_CMT_individual.php
@@ -9,7 +9,7 @@ class PostFinishAddScreeningToCMTIndividualTest extends LOVDSeleniumWebdriverBas
     public function testPostFinishAddScreeningToCMTIndividual()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000006$/', $this->driver->getCurrentURL()));
 

--- a/tests/selenium_tests/curator_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
+++ b/tests/selenium_tests/curator_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
@@ -9,7 +9,7 @@ class PostFinishAddVariantLocatedWithinGeneToCMTIndividualTest extends LOVDSelen
     public function testPostFinishAddVariantLocatedWithinGeneToCMTIndividual()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000005$/', $this->driver->getCurrentURL()));
 

--- a/tests/selenium_tests/manager_tests/add_summary_variant_only_described_on_genomic_level.php
+++ b/tests/selenium_tests/manager_tests/add_summary_variant_only_described_on_genomic_level.php
@@ -9,7 +9,7 @@ class AddSummaryVariantOnlyDescribedOnGenomicLevelTest extends LOVDSeleniumWebdr
     public function testAddSummaryVariantOnlyDescribedOnGenomicLevel()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertContains("/src/variants/0000000166", $this->driver->getCurrentURL());
         $element = $this->driver->findElement(WebDriverBy::id("tab_submit"));

--- a/tests/selenium_tests/manager_tests/add_summary_variant_seatlleseq_file.php
+++ b/tests/selenium_tests/manager_tests/add_summary_variant_seatlleseq_file.php
@@ -38,7 +38,7 @@ class AddSummaryVariantSeatlleseqFileTest extends LOVDSeleniumWebdriverBaseTestC
     public function testAddSummaryVariantSeatlleseqFile()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertContains("/src/variants/0000000167", $this->driver->getCurrentURL());
         $element = $this->driver->findElement(WebDriverBy::id("tab_submit"));

--- a/tests/selenium_tests/manager_tests/add_summary_variant_vcf_file.php
+++ b/tests/selenium_tests/manager_tests/add_summary_variant_vcf_file.php
@@ -38,7 +38,7 @@ class AddSummaryVariantVCFFileTest extends LOVDSeleniumWebdriverBaseTestCase
     public function testAddSummaryVariantVCFFile()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $element = $this->driver->findElement(WebDriverBy::id("tab_submit"));
         $element->click();

--- a/tests/selenium_tests/manager_tests/create_announcement_readonly.php
+++ b/tests/selenium_tests/manager_tests/create_announcement_readonly.php
@@ -31,7 +31,7 @@ class CreateAnnouncementReadOnly extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertEquals($sAnnouncement, $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
 
         // Wait for redirect...
-        $this->waitUntil(WebDriverExpectedCondition::titleContains('View announcement'));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains('Announcement'));
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/announcements\/\d{5}$/', $this->driver->getCurrentURL()));
     }
 }

--- a/tests/selenium_tests/manager_tests/create_disease_CMT.php
+++ b/tests/selenium_tests/manager_tests/create_disease_CMT.php
@@ -23,7 +23,7 @@ class CreateDiseaseCMTTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertEquals("Successfully created the disease information entry!", $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View disease"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Disease"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/diseases\/00001$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/manager_tests/delete_gene_GJB.php
+++ b/tests/selenium_tests/manager_tests/delete_gene_GJB.php
@@ -31,7 +31,7 @@ class DeleteGeneGJBTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertEquals("Successfully deleted the gene information entry!", $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View all genes"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("All genes"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/genes$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/manager_tests/finish_individual_diagnosed_with_CMT.php
+++ b/tests/selenium_tests/manager_tests/finish_individual_diagnosed_with_CMT.php
@@ -16,7 +16,7 @@ class FinishIndividualDiagnosedWithCMTTest extends LOVDSeleniumWebdriverBaseTest
         $this->assertTrue((bool)preg_match('/^Successfully processed your submission and sent an email notification to the relevant curator[\s\S]*$/', $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View individual"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Individual"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/individuals\/00000001$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/manager_tests/post_finish_add_phenotype_info_to_CMT_individual.php
+++ b/tests/selenium_tests/manager_tests/post_finish_add_phenotype_info_to_CMT_individual.php
@@ -39,7 +39,7 @@ class PostFinishAddPhenotypeInfoToCMTTest extends LOVDSeleniumWebdriverBaseTestC
         $this->assertTrue((bool)preg_match('/^Successfully processed your submission and sent an email notification to the relevant curator[\s\S]*$/', $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View phenotype"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Phenotype"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/phenotypes\/0000000002$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/manager_tests/post_finish_add_screening_to_CMT_individual.php
+++ b/tests/selenium_tests/manager_tests/post_finish_add_screening_to_CMT_individual.php
@@ -9,7 +9,7 @@ class PostFinishAddScreeningToCMTTest extends LOVDSeleniumWebdriverBaseTestCase
     public function testPostFinishAddScreeningToCMT()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertContains("/src/variants/0000000332", $this->driver->getCurrentURL());
         $element = $this->driver->findElement(WebDriverBy::id("tab_individuals"));

--- a/tests/selenium_tests/manager_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
+++ b/tests/selenium_tests/manager_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
@@ -9,7 +9,7 @@ class PostFinishAddVariantLocatedWithinGeneToCMTTest extends LOVDSeleniumWebdriv
     public function testPostFinishAddVariantLocatedWithinGeneToCMT()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertContains("/src/variants/0000000331", $this->driver->getCurrentURL());
         $element = $this->driver->findElement(WebDriverBy::id("tab_screenings"));

--- a/tests/selenium_tests/shared_tests/create_gene_GJB.php
+++ b/tests/selenium_tests/shared_tests/create_gene_GJB.php
@@ -62,7 +62,7 @@ class CreateGeneGJBTest extends LOVDSeleniumWebdriverBaseTestCase
         $element->click();
         $this->assertEquals("Successfully created the gene information entry!", $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
 
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View GJB1 gene"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("GJB1 gene homepage"));
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/genes\/GJB1$/', $this->driver->getCurrentURL()));
     }
 }

--- a/tests/selenium_tests/submitter_tests/create_disease_CMT.php
+++ b/tests/selenium_tests/submitter_tests/create_disease_CMT.php
@@ -31,7 +31,7 @@ class CreateDiseaseCMTTest extends LOVDSeleniumWebdriverBaseTestCase
             $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View disease"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Disease"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/diseases\/00001$/', $this->driver->getCurrentURL()));
 

--- a/tests/selenium_tests/submitter_tests/finish_individual_diagnosed_with_CMT.php
+++ b/tests/selenium_tests/submitter_tests/finish_individual_diagnosed_with_CMT.php
@@ -17,7 +17,7 @@ class FinishIndividualDiagnosedWithCMTTest extends LOVDSeleniumWebdriverBaseTest
             $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View individual"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Individual"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/individuals\/00000001$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/submitter_tests/post_finish_add_phenotype_info_to_CMT_individual.php
+++ b/tests/selenium_tests/submitter_tests/post_finish_add_phenotype_info_to_CMT_individual.php
@@ -40,7 +40,7 @@ class PostFinishAddPhenotypeInfoToCMTIndividualTest extends LOVDSeleniumWebdrive
             $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText()));
 
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View phenotype"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Phenotype"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/phenotypes\/0000000002$/', $this->driver->getCurrentURL()));
     }

--- a/tests/selenium_tests/submitter_tests/post_finish_add_screening_to_CMT_individual.php
+++ b/tests/selenium_tests/submitter_tests/post_finish_add_screening_to_CMT_individual.php
@@ -9,7 +9,7 @@ class PostFinishAddScreeningToCMTIndividualTest extends LOVDSeleniumWebdriverBas
     public function testPostFinishAddScreeningToCMTIndividual()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000004$/', $this->driver->getCurrentURL()));
 

--- a/tests/selenium_tests/submitter_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
+++ b/tests/selenium_tests/submitter_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
@@ -9,7 +9,7 @@ class PostFinishAddVariantLocatedWithinGeneToCMTIndividualTest extends LOVDSelen
     public function testPostFinishAddVariantLocatedWithinGeneToCMTIndividual()
     {
         // Wait for redirect
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("View genomic variant"));
+        $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000003$/', $this->driver->getCurrentURL()));
 


### PR DESCRIPTION
Removes "View " part from all page titles, not only the genes page as mentioned in the issue.

Fixes #206 