### PR TITLE
Remove lingering phenotype objects set during import.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -44,6 +44,10 @@
    unclassified."
  * Removed redundant "View" in all page titles. E.g. "View all genes" became
    "All genes".
+ * Fixed bug; Importing a phenotype entry without specifiying a disease ID
+   resulted in a fatal error.
+   Closes #245: "Import file parsing fails with a fatal error when the diseaseid
+   field is left empty for a phenotype record".
 
 
 /**************************

--- a/src/import.php
+++ b/src/import.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2017-09-01
+ * Modified    : 2017-09-13
  * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -826,6 +826,12 @@ if (POST) {
                     $aSection['object'] =& $aSection['objects'][$sGene];
                 }
             }
+            if ($sCurrentSection == 'Variants_On_Transcripts' && !$sGene) {
+                // For VOTs without a valid transcriptid (invalid data), make sure there's no object
+                // set from previous lines.
+                $aSection['object'] = null;
+                $bGeneInDB = $bTranscriptInDB = false;
+            }
 
             // Special actions for section Columns.
             if ($sCurrentSection == 'Columns') {
@@ -851,20 +857,7 @@ if (POST) {
             // Build the form, necessary for field-specific actions (currently for checkboxes only).
             // Exclude section Genes, because it is not allowed to import this section, it is not necessary to run the getForm().
             if (isset($aSection['object']) && is_object($aSection['object']) && $sCurrentSection != 'Genes') {
-                $aForm = array();
-                switch ($sCurrentSection) {
-                    case 'Phenotypes':
-                        $aForm = $aSection['objects'][(int) $aLine['diseaseid']]->getForm();
-                        break;
-                    case 'Variants_On_Transcripts':
-                        // Only get $aForm when we're sure we've got an object. We might not, which happens if we don't have a valid transcriptid.
-                        if (isset($aSection['objects'][$sGene])) {
-                            $aForm = $aSection['objects'][$sGene]->getForm();
-                        }
-                        break;
-                    default:
-                        $aForm = $aSection['object']->getForm();
-                }
+                $aForm = $aSection['object']->getForm();
                 lovd_setEmptyCheckboxFields($aForm);
             }
 

--- a/src/import.php
+++ b/src/import.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2017-02-15
- * For LOVD    : 3.0-19
+ * Modified    : 2017-09-01
+ * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -780,11 +780,18 @@ if (POST) {
             }
 
             // For shared objects, load the correct object.
-            if ($sCurrentSection == 'Phenotypes' && $aLine['diseaseid'] !== '') {
-                if (!isset($aSection['objects'][(int) $aLine['diseaseid']])) {
-                    $aSection['objects'][(int) $aLine['diseaseid']] = new LOVD_Phenotype($aLine['diseaseid']);
+            if ($sCurrentSection == 'Phenotypes') {
+                if ($aLine['diseaseid'] !== '') {
+                    // Get the phenotype object for the given disease.
+                    if (!isset($aSection['objects'][(int)$aLine['diseaseid']])) {
+                        $aSection['objects'][(int)$aLine['diseaseid']] = new LOVD_Phenotype($aLine['diseaseid']);
+                    }
+                    $aSection['object'] =& $aSection['objects'][(int)$aLine['diseaseid']];
+                } else {
+                    // For phenotypes without disease (invalid data), make sure there's no object
+                    // set from previous lines.
+                    $aSection['object'] = null;
                 }
-                $aSection['object'] =& $aSection['objects'][(int) $aLine['diseaseid']];
             }
             $sGene = '';
             if ($sCurrentSection == 'Variants_On_Transcripts' && $aLine['transcriptid']) {

--- a/tests/selenium_tests/import_tests/false_insert_import.php
+++ b/tests/selenium_tests/import_tests/false_insert_import.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016
- * Modified    : 2016-07-13
- * For LOVD    : 3.0-17
+ * Modified    : 2017-09-18
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2016-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -96,7 +96,6 @@ class FalseInsertImportTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertTrue((bool)preg_match('/^[\s\S]*Error \(Variants_On_Transcripts, line 97\): The field \'position_c_start\' must contain an integer, "abc" does not match\.[\s\S]*$/', $bodyText));
         $this->assertTrue((bool)preg_match('/^[\s\S]*Error \(Variants_On_Transcripts, line 98\): Transcript "00022" does not exist in the database and is not defined in this import file\.[\s\S]*$/', $bodyText));
         $this->assertTrue((bool)preg_match('/^[\s\S]*Error \(Variants_On_Transcripts, line 98\): Genomic Variant "0000000003" does not exist in the database and is not defined in this import file\.[\s\S]*$/', $bodyText));
-        $this->assertTrue((bool)preg_match('/^[\s\S]*Error \(Variants_On_Transcripts, line 98\): The field \'position_c_start\' must contain an integer, "abc" does not match\.[\s\S]*$/', $bodyText));
         $this->assertTrue((bool)preg_match('/^[\s\S]*Error \(Variants_On_Transcripts, line 98\): The gene belonging to this variant entry is yet to be inserted into the database\. First create the gene and set up the custom columns, then import the variants\.[\s\S]*$/', $bodyText));
         $this->assertTrue((bool)preg_match('/^[\s\S]*Error \(Screenings_To_Variants, line 105\): ID "3|1" already defined at line 104\.[\s\S]*$/', $bodyText));
         $this->assertTrue((bool)preg_match('/^[\s\S]*Error \(Screenings_To_Variants, line 106\): Screening "0000000022" does not exist in the database and is not defined in this import file\.[\s\S]*$/', $bodyText));


### PR DESCRIPTION
* Fix #245 by making sure that a phenotype object set during parsing of
  a previous line is removed when field `diseaseid` is empty, in order
  to avoid that the wrong phenotype object is used in later processing
  of the current input line.

Fixes #245