### PR TITLE
Fixed bug; Colleagues couldn't be assigned with MySQL's default strict mode.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -45,6 +45,8 @@
  * Removed redundant "View" in all page titles. E.g. "View all genes" became
    "All genes".
  * Fixed bug; Colleagues couldn't be assigned with MySQL's default strict mode.
+   Closes #283: "Can not add colleagues that are not allowed to edit with
+   MySQL's strict mode enabled".
 
 
 /**************************

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -44,6 +44,7 @@
    unclassified."
  * Removed redundant "View" in all page titles. E.g. "View all genes" became
    "All genes".
+ * Fixed bug; Colleagues couldn't be assigned with MySQL's default strict mode.
 
 
 /**************************

--- a/src/inc-lib-users.php
+++ b/src/inc-lib-users.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-04-21
- * Modified    : 2016-06-23
- * For LOVD    : 3.0-16
+ * Modified    : 2017-09-08
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2014-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2014-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
@@ -312,7 +312,9 @@ function lovd_setColleagues ($sUserID, $sUserFullname, $sUserInsititute, $sUserE
         $aData = array(); // Arguments for query.
         foreach ($aColleagues as $aColleague) {
             $aColleagueIDs[] = $aColleague['id'];
-            array_push($aData, $sUserID, $aColleague['id'], $aColleague['allow_edit']);
+            // Make sure you turn "allow_edit" into an integer, as false will be an
+            //  empty string and strict MySQL doesn't like that for an integer column.
+            array_push($aData, $sUserID, $aColleague['id'], (int) $aColleague['allow_edit']);
         }
 
         $_DB->query('INSERT INTO ' . TABLE_COLLEAGUES .


### PR DESCRIPTION
This is a minor fix; it's just type casting the value before it's sent to MySQL.

Fixes #283.