### PR TITLE
Feat/additional variant effects

### DIFF
--- a/src/2Do.txt
+++ b/src/2Do.txt
@@ -22,8 +22,12 @@ To debug: XDEBUG_PROFILE=1
 
 Prioritize:
 ===========
+Columns we no longer use that can be removed:
+- TABLE_GENES/allow_index_wiki
+- TABLE_TRANSCRIPTS/id_mutalyzer
+- TABLE_USERS/reference
+
 \item[$\circ$] LSDB list: Adding data from dead LSDBs: Brenda?
-\item[$\circ$] Really implement the deletion range recognition. Store inner positions, if 4 given.
 
 Website:
 - Create search interface w/ Ajax for ww query service, but in a secure way, so it can't be abused.

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -55,7 +55,7 @@
    Closes #242: "Display of screening with linked variants".
  * New effect categories for variants that affect protein function but are
    either not associated with the individual's disease phenotype or not
-   associated with any known phenotype.
+   associated with any known disease phenotype.
    Closes #261: "Additional variant effect values".
 
 

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -53,6 +53,10 @@
  * Let screening page show linked variants, even when `variants_found` flag is
    not set.
    Closes #242: "Display of screening with linked variants".
+ * New effect categories for variants that affect protein function but are
+   either not associated with the individual's disease phenotype or not
+   associated with any known phenotype.
+   Closes #261: "Additional variant effect values".
 
 
 /**************************

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -549,7 +549,7 @@ class LOVD_CustomViewList extends LOVD_Object {
                                         'view' => array('Effect', 70),
                                         'db'   => array('eg.name', 'ASC', true),
                                         'legend' => array('The variant\'s effect on a protein\'s function, in the format Reported/Curator concluded; ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
-                                                          'The variant\'s effect on a protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
+                                                          'The variant\'s effect on a protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known disease phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
                               ));
                     if (in_array('VariantOnTranscript', $aObjects) || in_array('VariantOnTranscriptUnique', $aObjects)) {
                         unset($this->aColumnsViewList['vog_effect']);

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -591,7 +591,7 @@ class LOVD_CustomViewList extends LOVD_Object {
                                         'view' => array('Effect', 70),
                                         'db'   => array('et.name', 'ASC', true),
                                         'legend' => array('The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
-                                                          'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
+                                                          'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
                               ));
                     // Only show the gene symbol when we have Scr2Var included, because these are the Individual- and Screening-specific views.
                     // FIXME: Perhaps it would be better to always show this column with VOT, but then hide it in all views that don't need it.
@@ -616,7 +616,7 @@ class LOVD_CustomViewList extends LOVD_Object {
                                         'view' => array('Effect', 70),
                                         'db'   => array('et.name', 'ASC', true),
                                         'legend' => array('The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
-                                                          'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
+                                                          'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
                                 'vot_reported' => array(
                                         'view' => array('Reported', 70, 'style="text-align : right;"'),
                                         'db'   => array('vot_reported', 'ASC', 'INT_UNSIGNED'),

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-15
- * Modified    : 2017-06-19
- * For LOVD    : 3.0-19
+ * Modified    : 2017-09-28
+ * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -591,7 +591,7 @@ class LOVD_CustomViewList extends LOVD_Object {
                                         'view' => array('Effect', 70),
                                         'db'   => array('et.name', 'ASC', true),
                                         'legend' => array('The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
-                                                          'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
+                                                          'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known disease phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
                               ));
                     // Only show the gene symbol when we have Scr2Var included, because these are the Individual- and Screening-specific views.
                     // FIXME: Perhaps it would be better to always show this column with VOT, but then hide it in all views that don't need it.
@@ -616,7 +616,7 @@ class LOVD_CustomViewList extends LOVD_Object {
                                         'view' => array('Effect', 70),
                                         'db'   => array('et.name', 'ASC', true),
                                         'legend' => array('The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
-                                                          'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
+                                                          'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known disease phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
                                 'vot_reported' => array(
                                         'view' => array('Reported', 70, 'style="text-align : right;"'),
                                         'db'   => array('vot_reported', 'ASC', 'INT_UNSIGNED'),

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2017-08-14
+ * Modified    : 2017-09-28
  * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -164,7 +164,7 @@ class LOVD_GenomeVariant extends LOVD_Custom {
                                     'view' => array('Effect', 70),
                                     'db'   => array('e.name', 'ASC', true),
                                     'legend' => array('The variant\'s effect on a protein\'s function, in the format Reported/Curator concluded; ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
-                                                      'The variant\'s effect on a protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
+                                                      'The variant\'s effect on a protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known disease phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
                         'allele_' => array(
                                     'view' => array('Allele', 120),
                                     'db'   => array('a.name', 'ASC', true),

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -123,7 +123,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom {
                                     'view' => array('Affects function', 70),
                                     'db'   => array('e.name', 'ASC', true),
                                     'legend' => array('The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
-                                                      'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
+                                                      'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
                       ),
                  $this->buildViewList(),
                  array(

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-12
- * Modified    : 2017-04-20
- * For LOVD    : 3.0-18
+ * Modified    : 2017-09-28
+ * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -123,7 +123,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom {
                                     'view' => array('Affects function', 70),
                                     'db'   => array('e.name', 'ASC', true),
                                     'legend' => array('The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
-                                                      'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
+                                                      'The variant\'s effect on the protein\'s function, in the format Reported/Curator concluded; \'+\' indicating the variant affects function, \'+?\' probably affects function, \'+*\' affects function, not associated with individual\'s disease phenotype, \'#\' affects function, not associated with any known disease phenotype, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect not classified.')),
                       ),
                  $this->buildViewList(),
                  array(

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2017-09-20
+ * Modified    : 2017-09-27
  * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -175,7 +175,7 @@ $_SETT = array(
                             5 => 'Effect unknown',
                             9 => 'Affects function',
                             8 => 'Affects function, not associated with individual\'s disease phenotype',
-                            6 => 'Affects function, not associated with any known phenotype',
+                            6 => 'Affects function, not associated with any known disease phenotype',
                             7 => 'Probably affects function',
                             3 => 'Probably does not affect function',
                             1 => 'Does not affect function',

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2017-07-20
+ * Modified    : 2017-09-20
  * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -144,7 +144,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-19a',
+                            'version' => '3.0-19b',
                           ),
                 'user_levels' =>
                      array(
@@ -174,6 +174,8 @@ $_SETT = array(
                             0 => 'Not classified', // Submitter cannot select this.
                             5 => 'Effect unknown',
                             9 => 'Affects function',
+                            8 => 'Affects function, not associated with individual\'s disease phenotype',
+                            6 => 'Affects function, not associated with any known phenotype',
                             7 => 'Probably affects function',
                             3 => 'Probably does not affect function',
                             1 => 'Does not affect function',

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2017-07-20
+ * Modified    : 2017-09-20
  * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -597,6 +597,14 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                             MODIFY settings TEXT',
                     ),
                  '3.0-19a' => array('INSERT INTO ' . TABLE_SOURCES . ' VALUES ("hpo_disease", "http://compbio.charite.de/hpoweb/showterm?disease=OMIM:{{ ID }}")'),
+                 '3.0-19b' => array('INSERT INTO ' . TABLE_EFFECT . ' VALUES ("06", "./#"), 
+                     ("08", "./+*"), ("16", "-/#"), ("18", "-/+*"), ("36", "-?/#"), 
+                     ("38", "-?/+*"), ("56", "?/#"), ("58", "?/+*"), ("60", "#/."), ("61", "#/-"),
+                     ("63", "#/-?"), ("65", "#/?"), ("66", "#/#"), ("67", "#/+?"), ("68", "#/+*"),
+                     ("69", "#/+"), ("76", "+?/#"), ("78", "+?/+*"), ("80", "+*/."), 
+                     ("81", "+*/-"), ("83", "+*/-?"), ("85", "+*/?"), ("86", "+*/#"), 
+                     ("87", "+*/+?"), ("88", "+*/+*"), ("89", "+*/+"), ("96", "+/#"), 
+                     ("98", "+/+*");'),
              );
 
     if ($sCalcVersionDB < lovd_calculateVersion('3.0-alpha-01')) {

--- a/src/install/inc-sql-variant_effect.php
+++ b/src/install/inc-sql-variant_effect.php
@@ -4,12 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-04-13
- * Modified    : 2014-06-16
- * For LOVD    : 3.0-11
+ * Modified    : 2017-09-20
+ * For LOVD    : 3.0-20
  *
- * Copyright   : 2004-2014 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               M. Kroon <m.kroon@lumc.nl>
  *
  *
  * This file is part of LOVD.
@@ -29,43 +30,39 @@
  *
  *************/
 
+// List symbols denoting variant effect values as listed in $_SETT['var_effect'].
+// Fixme: consider joining info in array below with $_SETT['var_effect'].
+$aEffectSymbols = array(
+    0 => '.',   // Not classified
+    1 => '-',   // Does not affect function
+    3 => '-?',  // Probably does not affect function
+    5 => '?',   // Effect unknown
+    6 => '#',   // Variant affects function but was not associated with any known disease phenotype
+    7 => '+?',  // Probably affects function
+    8 => '+*',  // Variant affects function but was not associated with this individual's disease phenotype
+    9 => '+',   // Affects function
+);
+
+// Create symbols for binary combinations of variant effect symbols (i.e.
+// reported effect and concluded effect).
+$aEffectNames = array();
+foreach ($aEffectSymbols as $k1 => $v1) {
+    foreach ($aEffectSymbols as $k2 => $v2) {
+        $aEffectNames[(string) $k1 . (string) $k2] = $v1 . '/' . $v2;
+    }
+}
+
+// Generate string of variant effect symbols to be used as part of SQL insert
+// statement.
+$sEffectValuesSQL = join(', ', array_map(
+    function ($sID, $sName) {
+        return '("' . $sID . '", "' . $sName . '")';
+    },
+    array_keys($aEffectNames), $aEffectNames)
+);
+
 $aVariantEffectSQL =
          array(
-                'INSERT INTO ' . TABLE_EFFECT . ' VALUES("00", "./."),
-                                                        ("01", "./-"),
-                                                        ("03", "./-?"),
-                                                        ("05", "./?"),
-                                                        ("07", "./+?"),
-                                                        ("09", "./+"),
-                                                        ("10", "-/."),
-                                                        ("11", "-/-"),
-                                                        ("13", "-/-?"),
-                                                        ("15", "-/?"),
-                                                        ("17", "-/+?"),
-                                                        ("19", "-/+"),
-                                                        ("30", "-?/."),
-                                                        ("31", "-?/-"),
-                                                        ("33", "-?/-?"),
-                                                        ("35", "-?/?"),
-                                                        ("37", "-?/+?"),
-                                                        ("39", "-?/+"),
-                                                        ("50", "?/."),
-                                                        ("51", "?/-"),
-                                                        ("53", "?/-?"),
-                                                        ("55", "?/?"),
-                                                        ("57", "?/+?"),
-                                                        ("59", "?/+"),
-                                                        ("70", "+?/."),
-                                                        ("71", "+?/-"),
-                                                        ("73", "+?/-?"),
-                                                        ("75", "+?/?"),
-                                                        ("77", "+?/+?"),
-                                                        ("79", "+?/+"),
-                                                        ("90", "+/."),
-                                                        ("91", "+/-"),
-                                                        ("93", "+/-?"),
-                                                        ("95", "+/?"),
-                                                        ("97", "+/+?"),
-                                                        ("99", "+/+")',
+                'INSERT INTO ' . TABLE_EFFECT . ' VALUES ' . $sEffectValuesSQL,
               );
 ?>

--- a/tests/selenium_tests/submitter_tests/add_variant_only_described_on_genomic_level_to_CMT_individual.php
+++ b/tests/selenium_tests/submitter_tests/add_variant_only_described_on_genomic_level_to_CMT_individual.php
@@ -33,7 +33,7 @@ class AddVariantOnlyDescribedOnGenomicLevelToCMTIndividualTest extends LOVDSelen
 
         $this->enterValue(WebDriverBy::name("VariantOnGenome/Reference"), "{PMID:Fokkema et al (2011):21520333}");
         $this->enterValue(WebDriverBy::name("VariantOnGenome/Frequency"), "11/10000");
-        $option = $this->driver->findElement(WebDriverBy::xpath('//select[@name="effect_reported"]/option[text()="Effect unknown"]'));
+        $option = $this->driver->findElement(WebDriverBy::xpath('//select[@name="effect_reported"]/option[text()="Affects function, not associated with any known phenotype"]'));
         $option->click();
         $element = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Create variant entry']"));
         $element->click();

--- a/tests/selenium_tests/submitter_tests/add_variant_only_described_on_genomic_level_to_CMT_individual.php
+++ b/tests/selenium_tests/submitter_tests/add_variant_only_described_on_genomic_level_to_CMT_individual.php
@@ -33,7 +33,7 @@ class AddVariantOnlyDescribedOnGenomicLevelToCMTIndividualTest extends LOVDSelen
 
         $this->enterValue(WebDriverBy::name("VariantOnGenome/Reference"), "{PMID:Fokkema et al (2011):21520333}");
         $this->enterValue(WebDriverBy::name("VariantOnGenome/Frequency"), "11/10000");
-        $option = $this->driver->findElement(WebDriverBy::xpath('//select[@name="effect_reported"]/option[text()="Affects function, not associated with any known phenotype"]'));
+        $option = $this->driver->findElement(WebDriverBy::xpath('//select[@name="effect_reported"]/option[text()="Affects function, not associated with any known disease phenotype"]'));
         $option->click();
         $element = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Create variant entry']"));
         $element->click();


### PR DESCRIPTION
New variant effect IDs "#" and "+\*". 

* Added new codes and descriptions to $_SETT['var_effect']. 
* Updated legend in 3 viewlists. 
* Modified submitter test to use new effect ID. 
* New way of generating reported/concluded effect symbol combinations. 
* Added new effect symbol combinations to SQL upgrade.

Fixes #261 