### PR TITLE
Fixed the variant position calculation

### DIFF
--- a/src/ajax/map_variants.php
+++ b/src/ajax/map_variants.php
@@ -122,6 +122,8 @@ function lovd_mapVariantToTranscripts (&$aVariant, $aTranscripts)
 
         // Loop the transcripts and map the variant to them.
         foreach ($aTranscripts as $aTranscript) {
+            // FIXME: When manually mapping transcripts, the numberConversion is just called once, and lovd_getVariantInfo() subsequently for the position fields.
+            // That's probably more efficient than mappingInfo a bunch of times.
             if (empty($aTranscript['id_ncbi'])) {
                 // A transcript without accession number is encountered. Invalid arguments, return false.
                 return false;
@@ -147,6 +149,13 @@ function lovd_mapVariantToTranscripts (&$aVariant, $aTranscripts)
             foreach ($aVariantsOnTranscripts[$sVariant] as $sVariantOnTranscript) {
                 if (substr($sVariantOnTranscript, 0, strlen($aTranscript['id_ncbi'])) == $aTranscript['id_ncbi']) {
                     // Got the variant description relative to this transcript.
+                    // 2017-09-22; 3.0-20; The mappingInfo module call does not sort the positions, and as such the "start" and "end" can be in the "wrong" order.
+                    $bSense = ($aMappingInfo['startmain'] < $aMappingInfo['endmain'] || ($aMappingInfo['startmain'] == $aMappingInfo['endmain'] && ($aMappingInfo['startoffset'] < $aMappingInfo['endoffset'] || $aMappingInfo['startoffset'] == $aMappingInfo['endoffset'])));
+                    if (!$bSense) {
+                        list($aMappingInfo['startmain'], $aMappingInfo['endmain']) = array($aMappingInfo['endmain'], $aMappingInfo['startmain']);
+                        list($aMappingInfo['startoffset'], $aMappingInfo['endoffset']) = array($aMappingInfo['endoffset'], $aMappingInfo['startoffset']);
+                    }
+
                     $aReturn[$aTranscript['id_ncbi']] =
                          array(
                                 // NOTE that is this array is changed, and the order or the number of arguments changes, then also in other places the code needs to be modified, because this array is manipulated directly using its numeric keys.

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -56,6 +56,8 @@
  * Let screening page show linked variants, even when `variants_found` flag is
    not set.
    Closes #242: "Display of screening with linked variants".
+ * Fixed bug; When automatically mapping variants of genes on the antisense
+   strand, the variant positions were stored in the wrong order.
 
 
 /**************************

--- a/src/import.php
+++ b/src/import.php
@@ -783,10 +783,10 @@ if (POST) {
             if ($sCurrentSection == 'Phenotypes') {
                 if ($aLine['diseaseid'] !== '') {
                     // Get the phenotype object for the given disease.
-                    if (!isset($aSection['objects'][(int)$aLine['diseaseid']])) {
-                        $aSection['objects'][(int)$aLine['diseaseid']] = new LOVD_Phenotype($aLine['diseaseid']);
+                    if (!isset($aSection['objects'][(int) $aLine['diseaseid']])) {
+                        $aSection['objects'][(int) $aLine['diseaseid']] = new LOVD_Phenotype($aLine['diseaseid']);
                     }
-                    $aSection['object'] =& $aSection['objects'][(int)$aLine['diseaseid']];
+                    $aSection['object'] =& $aSection['objects'][(int) $aLine['diseaseid']];
                 } else {
                     // For phenotypes without disease (invalid data), make sure there's no object
                     // set from previous lines.

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,15 +4,15 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-09-22
+ * Modified    : 2017-09-29
  * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
  *               Zuotian Tatum <Z.Tatum@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -677,8 +677,8 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                 list($_POST['position_g_start'], $_POST['position_g_end'], $_POST['type']) =
                     array($aResponse['position_start'], $aResponse['position_end'], $aResponse['type']);
             } else {
-                $_POST['position_g_start'] = NULL;
-                $_POST['position_g_end'] = NULL;
+                $_POST['position_g_start'] = 0;
+                $_POST['position_g_end'] = 0;
                 $_POST['type'] = NULL;
             }
 
@@ -2438,14 +2438,14 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
                     list($_POST['position_g_start'], $_POST['position_g_end'], $_POST['type']) =
                         array($aResponse['position_start'], $aResponse['position_end'], $aResponse['type']);
                 } else {
-                    $_POST['position_g_start'] = NULL;
-                    $_POST['position_g_end'] = NULL;
+                    $_POST['position_g_start'] = 0;
+                    $_POST['position_g_end'] = 0;
                     $_POST['type'] = NULL;
                 }
 
                 // Remove the MAPPING_NOT_RECOGNIZED and MAPPING_DONE flags if the VariantOnGenome/DNA field changes.
                 $_POST['mapping_flags'] = $zData['mapping_flags'] & ~(MAPPING_NOT_RECOGNIZED | MAPPING_DONE);
-                if ($_POST['position_g_start'] === null) {
+                if (!$_POST['position_g_start']) {
                     // We couldn't get a position, mapping will fail.
                     $_POST['mapping_flags'] |= MAPPING_NOT_RECOGNIZED;
                 }

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-08-09
- * For LOVD    : 3.0-19
+ * Modified    : 2017-09-22
+ * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -670,18 +670,13 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
             // Prepare values.
             $_POST['effectid'] = $_POST['effect_reported'] . ($_AUTH['level'] >= LEVEL_CURATOR? $_POST['effect_concluded'] : substr($_SETT['var_effect_default'], -1));
 
-            require ROOT_PATH . 'class/soap_client.php';
-            $_Mutalyzer = new LOVD_SoapClient();
-            try {
-                // NM is chosen at random, but we need to provide one just so we can get to the variant type.
-                $oOutput = @$_Mutalyzer->mappingInfo(array('LOVD_ver' => $_SETT['system']['version'], 'build' => $_CONF['refseq_build'], 'accNo' => 'NM_001100.3', 'variant' => $_POST['VariantOnGenome/DNA']))->mappingInfoResult;
-                if (isset($oOutput->errorcode)) {
-                    throw new Exception();
-                }
-                $_POST['position_g_start'] = $oOutput->start_g;
-                $_POST['position_g_end'] = $oOutput->end_g;
-                $_POST['type'] = $oOutput->mutationType;
-            } catch (Exception $e) {
+            // 2017-09-22; 3.0-20; Replacing the old SOAP call to Mutalyzer with our new lovd_getVariantInfo() function.
+            // Don't bother with a fallback, this thing is more solid than Mutalyzer's service.
+            $aResponse = lovd_getVariantInfo($_POST['VariantOnGenome/DNA']);
+            if ($aResponse) {
+                list($_POST['position_g_start'], $_POST['position_g_end'], $_POST['type']) =
+                    array($aResponse['position_start'], $aResponse['position_end'], $aResponse['type']);
+            } else {
                 $_POST['position_g_start'] = NULL;
                 $_POST['position_g_end'] = NULL;
                 $_POST['type'] = NULL;
@@ -699,18 +694,20 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                 $_POST['id'] = $nID;
                 foreach($_POST['aTranscripts'] as $nTranscriptID => $aTranscript) {
                     if (!empty($_POST[$nTranscriptID . '_VariantOnTranscript/DNA']) && strlen($_POST[$nTranscriptID . '_VariantOnTranscript/DNA']) >= 6) {
-                        try {
-                            $oOutput = $_Mutalyzer->mappingInfo(array('LOVD_ver' => $_SETT['system']['version'], 'build' => $_CONF['refseq_build'], 'accNo' => $aTranscript[0], 'variant' => $_POST[$nTranscriptID . '_VariantOnTranscript/DNA']))->mappingInfoResult;
-                            if (isset($oOutput->errorcode)) {
-                                throw new Exception();
-                            }
-                            $_POST[$nTranscriptID . '_position_c_start'] = $oOutput->startmain;
-                            $_POST[$nTranscriptID . '_position_c_start_intron'] = $oOutput->startoffset;
-                            $_POST[$nTranscriptID . '_position_c_end'] = $oOutput->endmain;
-                            $_POST[$nTranscriptID . '_position_c_end_intron'] = $oOutput->endoffset;
-                        } catch (SoapFault $e) {
-                            lovd_soapError($e);
-                        } catch (Exception $e) {} // Pass when we get a "nice" Soap Error (variant not recognized, for instance).
+                        // 2017-09-22; 3.0-20; Replacing the old SOAP call to Mutalyzer with our new lovd_getVariantInfo() function.
+                        // Don't bother with a fallback, this thing is more solid than Mutalyzer's service.
+                        $aResponse = lovd_getVariantInfo($_POST[$nTranscriptID . '_VariantOnTranscript/DNA'], $aTranscript[0]);
+                        if ($aResponse) {
+                            $_POST[$nTranscriptID . '_position_c_start'] = $aResponse['position_start'];
+                            $_POST[$nTranscriptID . '_position_c_start_intron'] = $aResponse['position_start_intron'];
+                            $_POST[$nTranscriptID . '_position_c_end'] = $aResponse['position_end'];
+                            $_POST[$nTranscriptID . '_position_c_end_intron'] = $aResponse['position_end_intron'];
+                        } else {
+                            $_POST[$nTranscriptID . '_position_c_start'] = 0;
+                            $_POST[$nTranscriptID . '_position_c_start_intron'] = 0;
+                            $_POST[$nTranscriptID . '_position_c_end'] = 0;
+                            $_POST[$nTranscriptID . '_position_c_end_intron'] = 0;
+                        }
                     }
                     if (empty($_POST[$nTranscriptID . '_position_c_start'])) {
                         // Variant not recognized, or no DNA given and thus no Soap call done.
@@ -2432,20 +2429,15 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
                 $_POST['statusid'] = STATUS_MARKED;
             }
 
-            require ROOT_PATH . 'class/soap_client.php';
-            $_Mutalyzer = new LOVD_SoapClient();
             if ($_POST['VariantOnGenome/DNA'] != $zData['VariantOnGenome/DNA'] || $zData['position_g_start'] == NULL) {
                 $aFieldsGenome = array_merge($aFieldsGenome, array('position_g_start', 'position_g_end', 'type', 'mapping_flags'));
-                try {
-                    // NM is chosen at random, but we need to provide one just so we can get to the variant type.
-                    $oOutput = @$_Mutalyzer->mappingInfo(array('LOVD_ver' => $_SETT['system']['version'], 'build' => $_CONF['refseq_build'], 'accNo' => 'NM_001100.3', 'variant' => $_POST['VariantOnGenome/DNA']))->mappingInfoResult;
-                    if (isset($oOutput->errorcode)) {
-                        throw new Exception();
-                    }
-                    $_POST['position_g_start'] = $oOutput->start_g;
-                    $_POST['position_g_end'] = $oOutput->end_g;
-                    $_POST['type'] = $oOutput->mutationType;
-                } catch (Exception $e) {
+                // 2017-09-22; 3.0-20; Replacing the old SOAP call to Mutalyzer with our new lovd_getVariantInfo() function.
+                // Don't bother with a fallback, this thing is more solid than Mutalyzer's service.
+                $aResponse = lovd_getVariantInfo($_POST['VariantOnGenome/DNA']);
+                if ($aResponse) {
+                    list($_POST['position_g_start'], $_POST['position_g_end'], $_POST['type']) =
+                        array($aResponse['position_start'], $aResponse['position_end'], $aResponse['type']);
+                } else {
                     $_POST['position_g_start'] = NULL;
                     $_POST['position_g_end'] = NULL;
                     $_POST['type'] = NULL;
@@ -2481,29 +2473,20 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
             if ($bGene) {
                 foreach($_POST['aTranscripts'] as $nTranscriptID => $aTranscript) {
                     if (!empty($_POST[$nTranscriptID . '_VariantOnTranscript/DNA']) && ($_POST[$nTranscriptID . '_VariantOnTranscript/DNA'] != $zData[$nTranscriptID . '_VariantOnTranscript/DNA'] || $zData[$nTranscriptID . '_position_c_start'] === NULL)) {
-                        if (strlen($_POST[$nTranscriptID . '_VariantOnTranscript/DNA']) < 6) {
+                        // 2017-09-22; 3.0-20; Replacing the old SOAP call to Mutalyzer with our new lovd_getVariantInfo() function.
+                        // Don't bother with a fallback, this thing is more solid than Mutalyzer's service.
+                        // Normally we'd check for a minimum length of 6 characters, but the function is fast anyway.
+                        $aResponse = lovd_getVariantInfo($_POST[$nTranscriptID . '_VariantOnTranscript/DNA'], $aTranscript[0]);
+                        if ($aResponse) {
+                            $_POST[$nTranscriptID . '_position_c_start'] = $aResponse['position_start'];
+                            $_POST[$nTranscriptID . '_position_c_start_intron'] = $aResponse['position_start_intron'];
+                            $_POST[$nTranscriptID . '_position_c_end'] = $aResponse['position_end'];
+                            $_POST[$nTranscriptID . '_position_c_end_intron'] = $aResponse['position_end_intron'];
+                        } else {
                             $_POST[$nTranscriptID . '_position_c_start'] = 0;
                             $_POST[$nTranscriptID . '_position_c_start_intron'] = 0;
                             $_POST[$nTranscriptID . '_position_c_end'] = 0;
                             $_POST[$nTranscriptID . '_position_c_end_intron'] = 0;
-                        } else {
-                            try {
-                                $oOutput = $_Mutalyzer->mappingInfo(array('LOVD_ver' => $_SETT['system']['version'], 'build' => $_CONF['refseq_build'], 'accNo' => $aTranscript[0], 'variant' => $_POST[$nTranscriptID . '_VariantOnTranscript/DNA']))->mappingInfoResult;
-                                if (isset($oOutput->errorcode)) {
-                                    throw new Exception();
-                                }
-                                $_POST[$nTranscriptID . '_position_c_start'] = $oOutput->startmain;
-                                $_POST[$nTranscriptID . '_position_c_start_intron'] = $oOutput->startoffset;
-                                $_POST[$nTranscriptID . '_position_c_end'] = $oOutput->endmain;
-                                $_POST[$nTranscriptID . '_position_c_end_intron'] = $oOutput->endoffset;
-                            } catch (SoapFault $e) {
-                                lovd_soapError($e);
-                            } catch (Exception $e) {
-                                $_POST[$nTranscriptID . '_position_c_start'] = 0;
-                                $_POST[$nTranscriptID . '_position_c_start_intron'] = 0;
-                                $_POST[$nTranscriptID . '_position_c_end'] = 0;
-                                $_POST[$nTranscriptID . '_position_c_end_intron'] = 0;
-                            }
                         }
                     } else {
                         $_POST[$nTranscriptID . '_position_c_start'] = $zData[$nTranscriptID . '_position_c_start'];
@@ -2927,19 +2910,17 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'map') {
                             if (!empty($sVariant) && preg_match('/^' . preg_quote($zTranscript['id_ncbi']) . ':([cn]\..+)$/', $sVariant, $aMatches)) {
                                 // Call the mappingInfo module of mutalyzer to get the start & stop positions of this variant on the transcript.
                                 $aMapping = array();
-                                try {
-                                    $oOutput = $_Mutalyzer->mappingInfo(array('LOVD_ver' => $_SETT['system']['version'], 'build' => $_CONF['refseq_build'], 'accNo' => $zTranscript['id_ncbi'], 'variant' => $aMatches[1]))->mappingInfoResult;
-                                    if (isset($oOutput->errorcode)) {
-                                        throw new Exception();
-                                    }
+                                // 2017-09-22; 3.0-20; Replacing the old SOAP call to Mutalyzer with our new lovd_getVariantInfo() function.
+                                // Don't bother with a fallback, this thing is more solid than Mutalyzer's service.
+                                $aResponse = lovd_getVariantInfo($aMatches[1], $zTranscript['id_ncbi']);
+                                if ($aResponse) {
                                     $aMapping = array(
-                                        'position_c_start' => $oOutput->startmain,
-                                        'position_c_start_intron' => $oOutput->startoffset,
-                                        'position_c_end' => $oOutput->endmain,
-                                        'position_c_end_intron' => $oOutput->endoffset,
+                                        'position_c_start' => $aResponse['position_start'],
+                                        'position_c_start_intron' => $aResponse['position_start_intron'],
+                                        'position_c_end' => $aResponse['position_end'],
+                                        'position_c_end_intron' => $aResponse['position_end_intron'],
                                     );
-                                } catch (Exception $e) {}
-                                if (!$aMapping) {
+                                } else {
                                     $aMapping = array(
                                         'position_c_start' => 0,
                                         'position_c_start_intron' => 0,


### PR DESCRIPTION
Fixed the variant position calculation:
- Replaced all calls to Mutalyzer's mappingInfo that were not also mapping requests by calls to the lovd_getVariantInfo() function.
- Fixed bug; When automatically mapping variants of genes on the antisense strand, the variant positions were stored in the wrong order.

Closes #58.