### PR TITLE
Revert Travis build to use older version of Chrome and chromedriver.

### DIFF
--- a/tests/travis/setup/setup_chrome.sh
+++ b/tests/travis/setup/setup_chrome.sh
@@ -2,10 +2,12 @@
 
 # Installation of chrome on Travis' trusty machines.
 # Based on: http://blog.500tech.com/setting-up-travis-ci-to-run-tests-on-latest-google-chrome-version/
-export CHROME_BIN=/usr/bin/google-chrome
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
-sudo apt-get update
-sudo apt-get install -y libappindicator1 fonts-liberation
-wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-sudo dpkg -i google-chrome*.deb
+
+# Fixme: uncomment lines below to use latest stable Chrome browser for testing
+#export CHROME_BIN=/usr/bin/google-chrome
+#sudo apt-get update
+#sudo apt-get install -y libappindicator1 fonts-liberation
+#wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+#sudo dpkg -i google-chrome*.deb

--- a/tests/travis/setup/setup_selenium_server.sh
+++ b/tests/travis/setup/setup_selenium_server.sh
@@ -6,7 +6,11 @@
 ## When the selenium server is not started this script exits 1. And in Travis the tests will fail.
 serverUrl='http://127.0.0.1:4444'
 serverFile=selenium-server-standalone-2.53.1.jar
-chromeDriverVersion=`curl http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+
+# Download chromedriver.
+# Fixme: uncomment following line and remove "=2.24" line to use latest release.
+#chromeDriverVersion=`curl http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
+chromeDriverVersion=2.24
 chromeDriverSrc=http://chromedriver.storage.googleapis.com/${chromeDriverVersion}/chromedriver_linux64.zip
 
 phpVersion=`php -v`


### PR DESCRIPTION
Temporary changes to get correct versions of browser and driver that are able to work together. Look at the Fixmes to undo these changes and resume to the latest versions of both the browser and the driver.