### PR TITLE
Fix issue with search params when using browser back button.

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -62,6 +62,9 @@
    Closes #261: "Additional variant effect values".
  * Fixed bug; When automatically mapping variants of genes on the antisense
    strand, the variant positions were stored in the wrong order.
+ * Fixed bug; Some search arguments in viewlists got lost when using the 
+   browser's back button.
+   Closes #292: "Fix issue with search params when using browser back button."
 
 
 /**************************

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -62,8 +62,8 @@
    Closes #261: "Additional variant effect values".
  * Fixed bug; When automatically mapping variants of genes on the antisense
    strand, the variant positions were stored in the wrong order.
- * Fixed bug; Some search arguments in viewlists got lost when using the 
-   browser's back button.
+ * Fixed bug; Sometimes search arguments in data listings got lost when using
+   the browser's back button.
    Closes #292: "Fix issue with search params when using browser back button."
 
 

--- a/src/inc-js-viewlist.php
+++ b/src/inc-js-viewlist.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-29
- * Modified    : 2017-06-06
+ * Modified    : 2017-10-04
  * For LOVD    : 3.0-19
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -79,7 +79,8 @@ function lovd_AJAX_processViewListHash ()
         }
 
         // Values which are NO LONGER in the Hash (added search term, then back button) need to be removed!!!
-        $(oForm).find('input[name^="search_"]').each(function (i, o) { if (o.value && !Hash[o.name]) { o.value = ""; }});
+        // Only for visible search fields (hidden search inputs are set by server).
+        $(oForm).find('input[name^="search_"][type!="hidden"]').each(function (i, o) { if (o.value && !Hash[o.name]) { o.value = ""; }});
         $(oForm).find('input[name^="page"]').each(function (i, o) { if (o.value && !Hash[o.name]) { o.value = ""; }});
         $(oForm).find('input[name="order"]').each(function (i, o) { if (o.value && !Hash[o.name]) { o.value = ""; }});
 

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-23
- * Modified    : 2017-08-09
+ * Modified    : 2017-10-04
  * For LOVD    : 3.0-20
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -46,7 +46,7 @@ if ($_AUTH) {
 if (PATH_COUNT == 1 && !ACTION) {
     // URL: /phenotypes
     // Not supported, forward user to disease-specific overview.
-    header('Location: ' . lovd_getInstallURL() . $_PE[0] . '/disease');
+    header('Location: ' . lovd_getInstallURL() . $_PE[0] . '/disease?search_phenotypes=' . urlencode('!0'));
     exit;
 }
 
@@ -65,7 +65,6 @@ if (PATH_COUNT == 2 && $_PE[1] == 'disease' && !ACTION) {
     require ROOT_PATH . 'class/object_diseases.php';
     $_DATA = new LOVD_Disease();
     $sViewListID = 'Diseases_for_Phenotype_VL';
-    $_GET['search_phenotypes'] = '!0';
     $_DATA->setRowLink($sViewListID, CURRENT_PATH . '/' . $_DATA->sRowID);
     $_DATA->viewList($sViewListID);
 


### PR DESCRIPTION
* Let javascript handler of search args in URL hash ignore hidden search fields.
* Do not set search argument for page `/phenotypes/disease` in GET array directly, but in URL of redirect.
* Fixes #292