### PR TITLE
Fix submission API issues

### DIFF
--- a/src/ajax/auth_token.php
+++ b/src/ajax/auth_token.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-17
- * Modified    : 2016-11-18
- * For LOVD    : 3.0-18
+ * Modified    : 2017-11-06
+ * For LOVD    : 3.0-21
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -77,6 +77,7 @@ function lovd_reloadUserVE ()
 
 $sFormCreate    = '<FORM id=\'auth_token_create_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>Please select the validity of the token.<BR><SELECT name=\'auth_token_expires\'><OPTION value=\'\'>forever</OPTION><OPTION value=\'604800\'>1 week</OPTION><OPTION value=\'2592000\'>1 month</OPTION><OPTION value=\'7776000\'>3 months</OPTION><OPTION value=\'31536000\'>1 year</OPTION></SELECT></FORM>';
 $sFormRevoke    = '<FORM id=\'auth_token_revoke_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>Are you sure you want to revoke your current API key?</FORM>';
+$sMessageLSDBID = ($_AUTH['level'] != LEVEL_ADMIN? '' : '<B>This LOVD\'s ID: ' . md5($_STAT['signature']) . '</B><BR><BR>');
 $sMessageIntro  = 'Since LOVD 3.0-18, LOVD contains an API that allows for the direct submission of data into the database. This API is currently undocumented and still in beta. To use this API, you\'ll need an API token that serves to authorize you instead of using your username and password in the data file.';
 $sMessageCreate = 'You can create a new token by clicking &quot;Create new token&quot; below. This will revoke any existing tokens, if any. This also allows you to set an expiration to your token; after the expiration date, you will no longer be able to use this token and you will need to renew it.';
 $sMessageRevoke = 'You can also revoke your token completely, without creating a new one, blocking access of this token to the API completely. You can do this by clicking &quot;Revoke token&quot; below.';
@@ -221,7 +222,7 @@ if (ACTION == 'revoke' && POST) {
 if (ACTION == 'view') {
     // View current token and status.
     print('
-    $("#auth_token_dialog").html("' . $sMessageIntro . '<BR>");
+    $("#auth_token_dialog").html("' . $sMessageLSDBID . $sMessageIntro . '<BR>");
     $("#auth_token_dialog").append("' . $sMessageCreate . '<BR>");
     if (bToken) {
         $("#auth_token_dialog").append("' . $sMessageRevoke . '<BR>");

--- a/src/api.php
+++ b/src/api.php
@@ -250,6 +250,9 @@ if ($sDataType == 'variants') {
 } elseif ($sDataType == 'genes') {
     // Listing or simple request on gene symbol.
     // First build query.
+    // FIXME: All transcripts are listed here, ordered by the NCBI ID. However, the variant API chooses the first transcript based on its internal ID and shows only the variants on that one.
+    // FIXME: This causes a bit of a problem since varcache stores the transcripts string with the gene and doesn't know what transcript the variants are on until it reads out the variant list.
+    // FIXME: Decided to solve this for varcache by updating the NM in the database after the variants have been read. Leaving this here for now.
     $sQ = 'SELECT g.id, g.name, g.chromosome, g.chrom_band, (MAX(t.position_g_mrna_start) < MAX(t.position_g_mrna_end)) AS sense, LEAST(MIN(t.position_g_mrna_start), MIN(t.position_g_mrna_end)) AS position_g_mrna_start, GREATEST(MAX(t.position_g_mrna_start), MAX(t.position_g_mrna_end)) AS position_g_mrna_end, g.refseq_genomic, GROUP_CONCAT(DISTINCT t.id_ncbi ORDER BY t.id_ncbi) AS id_ncbi, g.id_entrez, g.created_date, g.updated_date, u.name AS created_by, GROUP_CONCAT(DISTINCT cur.name SEPARATOR ", ") AS curators
            FROM ' . TABLE_GENES . ' AS g LEFT JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (g.id = t.geneid) LEFT JOIN ' . TABLE_USERS . ' AS u ON (g.created_by = u.id) LEFT JOIN ' . TABLE_CURATES . ' AS u2g ON (g.id = u2g.geneid AND u2g.allow_edit = 1) LEFT JOIN ' . TABLE_USERS . ' AS cur ON (u2g.userid = cur.id)
            WHERE 1=1';

--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2016-12-07
- * For LOVD    : 3.0-18
+ * Modified    : 2017-11-06
+ * For LOVD    : 3.0-21
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -503,7 +503,8 @@ class LOVD_API_Submissions {
         if (!$_INI['paths']['data_files']) {
             // There's no way we can do anything with the results, so fail.
             $this->API->aResponse['errors'][] = 'No data file path configured. Without this path, this LOVD API is not able to process files. ' .
-                'Please contact the admin to configure the data file path: ' . $_SETT['admin']['name'] . ' <' . $_SETT['admin']['email'] . '>.';
+                'Please contact the admin to configure the data file path: ' . $_SETT['admin']['name'] . ' <' .
+                str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_SETT['admin']['email'])) . '>.';
             $this->API->nHTTPStatus = 500; // Send 500 Internal Server Error.
             return false;
         }
@@ -601,7 +602,8 @@ class LOVD_API_Submissions {
             // Data file is not meant for this LSDB.
             $this->API->aResponse['errors'][] = 'VarioML error: LSDB ID in file does not match this LSDB. ' .
                 'Submit your file to the correct LSDB, or if sure you want to submit here, ' .
-                'request the LSDB ID from the admin: ' . $_SETT['admin']['name'] . ' <' . $_SETT['admin']['email'] . '>.';
+                'request the LSDB ID from the admin: ' . $_SETT['admin']['name'] . ' <' .
+                str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_SETT['admin']['email'])) . '>.';
             $this->API->nHTTPStatus = 422; // Send 422 Unprocessable Entity.
             return false;
         }
@@ -934,7 +936,8 @@ class LOVD_API_Submissions {
                             if ($aGenes) {
                                 if (!$aGenesExisting) {
                                     $this->API->aResponse['errors'][] = 'VarioML error: Individual #' . $nIndividual . ': Variant #' . $nVariant . ': None of the given genes for this variant are configured in this LOVD. ' .
-                                        'Please request the admin to create them: ' . $_SETT['admin']['name'] . ' <' . $_SETT['admin']['email'] . '>.';
+                                        'Please request the admin to create them: ' . $_SETT['admin']['name'] . ' <' .
+                                        str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_SETT['admin']['email'])) . '>.';
                                 } else {
                                     // Genes do exist. Mention which transcripts can then be used.
                                     $sTranscriptsAvailable = implode(', ', $_DB->query('SELECT id_ncbi FROM ' . TABLE_TRANSCRIPTS . ' WHERE geneid IN (?' . str_repeat(', ?', count($aGenesExisting) - 1) . ') ORDER BY id_ncbi', array($aGenesExisting))->fetchAllColumn());
@@ -944,7 +947,8 @@ class LOVD_API_Submissions {
                             } else {
                                 // No genes were ever given, focus on the transcripts.
                                 $this->API->aResponse['errors'][] = 'VarioML error: Individual #' . $nIndividual . ': Variant #' . $nVariant . ': None of the given transcripts for this variant are configured in this LOVD. ' .
-                                    'Please request the admin to create them: ' . $_SETT['admin']['name'] . ' <' . $_SETT['admin']['email'] . '>.';
+                                    'Please request the admin to create them: ' . $_SETT['admin']['name'] . ' <' .
+                                    str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_SETT['admin']['email'])) . '>.';
                             }
                         } else {
                             // We have at least one matching transcript.

--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -346,7 +346,7 @@ class LOVD_API_Submissions {
                         $aVOT['VariantOnTranscript/DNA'] = $aVariantLevel2['name']['#text'];
 
                         // Fill in the positions. If this fails, this is reason to reject the variant.
-                        $aVariantInfo = lovd_getVariantInfo($aVariantLevel2['name']['#text']);
+                        $aVariantInfo = lovd_getVariantInfo($aVariantLevel2['name']['#text'], $aVOT['transcriptid']);
                         if (!$aVariantInfo) {
                             $this->API->nHTTPStatus = 422; // Send 422 Unprocessable Entity.
                             $this->API->aResponse['errors'][] = 'VarioML error: Individual #' . ($nIndividualKey + 1) . ': Variant #' . ($nVariantKey + 1) . ': SeqChange #' . $nVariantLevel2 . ': Name not understood. ' .

--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2017-11-06
+ * Modified    : 2017-11-07
  * For LOVD    : 3.0-21
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -503,8 +503,7 @@ class LOVD_API_Submissions {
         if (!$_INI['paths']['data_files']) {
             // There's no way we can do anything with the results, so fail.
             $this->API->aResponse['errors'][] = 'No data file path configured. Without this path, this LOVD API is not able to process files. ' .
-                'Please contact the admin to configure the data file path: ' . $_SETT['admin']['name'] . ' <' .
-                str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_SETT['admin']['email'])) . '>.';
+                'Please contact the admin to configure the data file path: ' . $_SETT['admin']['address_formatted'] . '.';
             $this->API->nHTTPStatus = 500; // Send 500 Internal Server Error.
             return false;
         }
@@ -602,8 +601,7 @@ class LOVD_API_Submissions {
             // Data file is not meant for this LSDB.
             $this->API->aResponse['errors'][] = 'VarioML error: LSDB ID in file does not match this LSDB. ' .
                 'Submit your file to the correct LSDB, or if sure you want to submit here, ' .
-                'request the LSDB ID from the admin: ' . $_SETT['admin']['name'] . ' <' .
-                str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_SETT['admin']['email'])) . '>.';
+                'request the LSDB ID from the admin: ' . $_SETT['admin']['address_formatted'] . '.';
             $this->API->nHTTPStatus = 422; // Send 422 Unprocessable Entity.
             return false;
         }
@@ -936,8 +934,7 @@ class LOVD_API_Submissions {
                             if ($aGenes) {
                                 if (!$aGenesExisting) {
                                     $this->API->aResponse['errors'][] = 'VarioML error: Individual #' . $nIndividual . ': Variant #' . $nVariant . ': None of the given genes for this variant are configured in this LOVD. ' .
-                                        'Please request the admin to create them: ' . $_SETT['admin']['name'] . ' <' .
-                                        str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_SETT['admin']['email'])) . '>.';
+                                        'Please request the admin to create them: ' . $_SETT['admin']['address_formatted'] . '.';
                                 } else {
                                     // Genes do exist. Mention which transcripts can then be used.
                                     $sTranscriptsAvailable = implode(', ', $_DB->query('SELECT id_ncbi FROM ' . TABLE_TRANSCRIPTS . ' WHERE geneid IN (?' . str_repeat(', ?', count($aGenesExisting) - 1) . ') ORDER BY id_ncbi', array($aGenesExisting))->fetchAllColumn());
@@ -947,8 +944,7 @@ class LOVD_API_Submissions {
                             } else {
                                 // No genes were ever given, focus on the transcripts.
                                 $this->API->aResponse['errors'][] = 'VarioML error: Individual #' . $nIndividual . ': Variant #' . $nVariant . ': None of the given transcripts for this variant are configured in this LOVD. ' .
-                                    'Please request the admin to create them: ' . $_SETT['admin']['name'] . ' <' .
-                                    str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_SETT['admin']['email'])) . '>.';
+                                    'Please request the admin to create them: ' . $_SETT['admin']['address_formatted'] . '.';
                             }
                         } else {
                             // We have at least one matching transcript.

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2017-10-09
- * For LOVD    : 3.0-20
+ * Modified    : 2017-11-06
+ * For LOVD    : 3.0-21
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -379,7 +379,7 @@ class LOVD_Object {
         }
 
         // Check all fields that we receive for data type and maximum length.
-        // No longer to this through $aForm, because when importing,
+        // No longer do this through $aForm, because when importing,
         //  we do have data to check but no $aForm entry linked to it.
         foreach ($aData as $sFieldname => $sFieldvalue) {
 
@@ -790,7 +790,7 @@ class LOVD_Object {
             // Analyzing the SELECT. This is quite difficult as we can have simple SELECTs but also really complicated ones,
             // such as GROUP_CONCAT() or subselects. These should all be parsed and needed tables should be identified.
             //                    t.* || t.col                    [t.col || "value" || (t.col ... val) || FUNCTION() || CASE ... END] AS alias
-            if (preg_match_all('/(([a-z0-9_]+)\.(?:\*|[a-z0-9_]+)|(?:(?:([a-z0-9_]+)\.[a-z0-9_]+|".*"|[A-Z_]*\(.+\)|CASE .+ END) AS +([a-z0-9_]+|`[A-Za-z0-9_\/]+`)))(?:,|$)/U', $aSQL['SELECT'], $aRegs)) {
+            if (preg_match_all('/(([a-z0-9_]+)\.(?:\*|[a-z0-9_]+)|(?:(?:([a-z0-9_]+)\.[a-z0-9_]+|".*"|[A-Z_]*\(.+\)|CASE .+ END)\s+AS\s+([A-Za-z0-9_]+|`[A-Za-z0-9_\/]+`)))(?:,|$)/Us', $aSQL['SELECT'], $aRegs)) {
                 for ($i = 0; $i < count($aRegs[0]); $i ++) {
                     // First we'll store the column information, later we'll loop though it to see which tables they refer to.
                     // 1: entire SELECT string incl. possible alias;
@@ -855,7 +855,7 @@ class LOVD_Object {
                     // OK, this really shouldn't happen. Either the column wasn't a
                     // category we recognized, or the SQL was too complicated?
                     // Let's log this.
-                    lovd_writeLog('Error', 'LOVD-Lib', 'LOVD_Object::getRowCountForViewList() - Function identified custom column category ' . $sCategory . ', but couldn\'t find corresponding table alias in query.' . "\n" . 'URL: ' . preg_replace('/^' . preg_quote(rtrim(lovd_getInstallURL(false), '/'), '/') . '/', '', $_SERVER['REQUEST_URI']) . "\n" . 'From: ' . $aSQL['FROM']);
+                    lovd_writeLog('Error', 'LOVD-Lib', 'LOVD_Object::' . __FUNCTION__ . '() - Function identified custom column category ' . $sCategory . ', but couldn\'t find corresponding table alias in query.' . "\n" . 'URL: ' . preg_replace('/^' . preg_quote(rtrim(lovd_getInstallURL(false), '/'), '/') . '/', '', $_SERVER['REQUEST_URI']) . "\n" . 'From: ' . $aSQL['FROM']);
                 }
             }
         }

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2017-10-17
- * For LOVD    : 3.0-20
+ * Modified    : 2017-11-07
+ * For LOVD    : 3.0-21
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -688,6 +688,8 @@ if (!defined('NOT_INSTALLED')) {
         } else {
             $_SETT['admin'] = array('name' => '', 'email' => ''); // We must define the keys first, or the order of the keys will not be correct.
             list($_SETT['admin']['name'], $_SETT['admin']['email']) = $_DB->query('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ? AND id > 0 ORDER BY id ASC', array(LEVEL_ADMIN))->fetchRow();
+            // Add a cleaned email address, because perhaps the admin has multiple addresses.
+            $_SETT['admin']['address_formatted'] = $_SETT['admin']['name'] . ' <' . str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_SETT['admin']['email'])) . '>';
         }
 
         // Switch gene.

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -4,12 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-20
- * Modified    : 2016-06-17
- * For LOVD    : 3.0-16
+ * Modified    : 2017-11-06
+ * For LOVD    : 3.0-21
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -101,7 +101,7 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
             $sMessage = 'Dear ' . $zData['name'] . ',' . "\n\n" .
                         'Your password from your LOVD account has been reset, as requested. Your new, randomly generated, password can be found below. Please log in to LOVD and choose a new password.' . "\n\n" .
                         'Below is a copy of your updated account information.' . "\n\n" .
-                        'If you did not request a new password, you can disregard this message. Your old password will continue to function normally. However, you may then want to report this email to the Database administrator ' . $_SETT['admin']['name'] . ', email: ' . $_SETT['admin']['email'] . ', who can investigate possible misuse of the system.' . "\n\n";
+                        'If you did not request a new password, you can disregard this message. Your old password will continue to function normally. However, you may then want to report this email to the Database administrator ' . $_SETT['admin']['name'] . ', email: ' . str_replace(array("\r\n", "\r", "\n"), ' or ', trim($_SETT['admin']['email'])) . ', who can investigate possible misuse of the system.' . "\n\n";
 
             // Add the location of the database, so that the user can just click the link.
             if ($_CONF['location_url']) {


### PR DESCRIPTION
Fix submission API issues.
- Display the admin's email address better when it's multiple addresses.
- Added LSDB ID to Admin's Auth Token dialog.
  - This way the Admin can find out which ID the clients need to use to start submitting data into the LOVD.
- Fixed bug; 3'UTR variants were not accepted.
  - lovd_getVariantInfo() should be run passing the transcript ID in such cases.
- Fixed query errors coming from LOVD_Object::getRowCountForViewList().
  - This function tries to calculate the row count for each VL query, without having to use MySQL's SQL_CALC_FOUND_ROWS().
  - It takes the VL query and simplifies it as much as possible, removing unused selects, joins and sorts, and then getting the COUNT(*).
  - Searches cause query errors in this function where newlines are placed in the query definition, and aliases with capitals were not supported. Updated the query matcher so it handles this well.