### PR TITLE
Fixed bug; The color coding was visible for the public.

### DIFF
--- a/src/2Do.txt
+++ b/src/2Do.txt
@@ -22,6 +22,8 @@ To debug: XDEBUG_PROFILE=1
 
 Prioritize:
 ===========
+In form fields (SELECTs?) set style="max-width:400px" or so?
+
 Columns we no longer use that can be removed:
 - TABLE_GENES/allow_index_wiki
 - TABLE_TRANSCRIPTS/id_mutalyzer

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-15
- * Modified    : 2017-09-29
- * For LOVD    : 3.0-20
+ * Modified    : 2017-11-30
+ * For LOVD    : 3.0-21
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -820,23 +820,6 @@ class LOVD_CustomViewList extends LOVD_Object {
 
         // Makes sure it's an array and htmlspecialchars() all the values.
         $zData = parent::prepareData($zData, $sView);
-
-        // Mark all statusses from Marked and lower; Marked will be red, all others gray.
-        // In the VariantOnTranscriptUnique view the var_statusid can contain multiple IDs, these IDs are separated by a ",".
-        // PHP always takes the first integer-like part of a string when a string and an integer are compared.
-        // But to avoid problems in the future, only the first character is compared.
-        // We disable this feature in LOVD+.
-        $bVarStatus = (!LOVD_plus && !empty($zData['var_statusid']) && substr($zData['var_statusid'], 0, 1) <= STATUS_MARKED);
-        $bIndStatus = (!LOVD_plus && !empty($zData['ind_statusid']) && $zData['ind_statusid'] <= STATUS_MARKED);
-
-        if ($bVarStatus && $bIndStatus) {
-            $nStatus = min(substr($zData['var_statusid'], 0, 1), $zData['ind_statusid']);
-            $zData['class_name'] = ($nStatus == STATUS_MARKED? 'marked' : 'del');
-        } elseif ($bVarStatus) {
-            $zData['class_name'] = (substr($zData['var_statusid'], 0, 1) == STATUS_MARKED? 'marked' : 'del');
-        } elseif ($bIndStatus) {
-            $zData['class_name'] = ($zData['ind_statusid'] == STATUS_MARKED? 'marked' : 'del');
-        }
 
         // Replace rs numbers with dbSNP links.
         if (!empty($zData['VariantOnGenome/dbSNP'])) {

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2017-09-28
- * For LOVD    : 3.0-20
+ * Modified    : 2017-11-30
+ * For LOVD    : 3.0-21
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -105,9 +105,6 @@ class LOVD_GenomeVariant extends LOVD_Custom {
                                           'e.name AS effect, ' .
                                           'uo.name AS owned_by_, ' .
                                           'CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) AS _owner, ' .
-                                ($_AUTH['level'] >= LEVEL_COLLABORATOR?
-                                          'CASE vog.statusid WHEN ' . STATUS_MARKED . ' THEN "marked" WHEN ' . STATUS_HIDDEN .' THEN "del" WHEN ' . STATUS_PENDING .' THEN "del" END AS class_name,'
-                                        : '') .
                                           'ds.name AS status';
         $this->aSQLViewList['FROM']     = TABLE_VARIANTS . ' AS vog ' .
                                 // Added so that Curators and Collaborators can view the variants for which they have viewing rights in the genomic variant viewlist.

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2017-08-14
- * For LOVD    : 3.0-20
+ * Modified    : 2017-11-30
+ * For LOVD    : 3.0-21
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -102,8 +102,6 @@ class LOVD_Individual extends LOVD_Custom {
                                           'COUNT(DISTINCT ' . ($_AUTH['level'] >= LEVEL_COLLABORATOR? 's2v.variantid' : 'vog.id') . ') AS variants_, ' . // Counting s2v.variantid will not include the limit opposed to vog in the join's ON() clause.
                                           'uo.name AS owned_by_, ' .
                                           'CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) AS _owner, ' .
-                                          ($_AUTH['level'] < LEVEL_COLLABORATOR? '' :
-                                              'CASE ds.id WHEN ' . STATUS_MARKED . ' THEN "marked" WHEN ' . STATUS_HIDDEN .' THEN "del" WHEN ' . STATUS_PENDING .' THEN "del" END AS class_name,') .
                                           'ds.name AS status';
 
         // Construct list of user IDs for current user and users who share access with him.

--- a/src/class/object_phenotypes.php
+++ b/src/class/object_phenotypes.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2016-07-20
- * For LOVD    : 3.0-17
+ * Modified    : 2017-11-30
+ * For LOVD    : 3.0-21
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -81,9 +81,6 @@ class LOVD_Phenotype extends LOVD_Custom {
 
         // SQL code for viewing the list of phenotypes
         $this->aSQLViewList['SELECT']   = 'p.*, ' .
-                                        ($_AUTH['level'] >= LEVEL_COLLABORATOR?
-                                          'CASE p.statusid WHEN ' . STATUS_MARKED . ' THEN "marked" WHEN ' . STATUS_HIDDEN .' THEN "del" WHEN ' . STATUS_PENDING .' THEN "del" END AS class_name,'
-                                        : '') .
                                           'ds.name AS status, ' .
                                           'uo.name AS owned_by_, ' .
                                           'CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) AS _owner';

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2017-08-04
- * For LOVD    : 3.0-20
+ * Modified    : 2017-11-30
+ * For LOVD    : 3.0-21
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -96,8 +96,7 @@ class LOVD_Screening extends LOVD_Custom {
                                           's.id AS screeningid, ' .
                                           'IF(s.variants_found = 1 AND COUNT(s2v.variantid) = 0, -1, COUNT(DISTINCT ' . ($_AUTH['level'] >= LEVEL_COLLABORATOR? 's2v.variantid' : 'vog.id') . ')) AS variants_found_, ' .
                                           'GROUP_CONCAT(DISTINCT s2g.geneid SEPARATOR ", ") AS genes, ' .
-                                          ($_AUTH['level'] < LEVEL_COLLABORATOR? '' :
-                                              'CASE i.statusid WHEN ' . STATUS_MARKED . ' THEN "marked" WHEN ' . STATUS_HIDDEN .' THEN "del" END AS class_name, ') .
+                                          'i.statusid, ' .
                                           'uo.name AS owned_by_, ' .
                                           'CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) AS _owner';
         $this->aSQLViewList['FROM']     = TABLE_SCREENINGS . ' AS s ' .

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2017-11-30
+ * Modified    : 2017-12-11
  * For LOVD    : 3.0-21
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1290,31 +1290,29 @@ class LOVD_Object {
                     $zData['analysis_by_'] = '<SPAN class="custom_link" onmouseover="lovd_showToolTip(\'' . addslashes('<TABLE border=0 cellpadding=0 cellspacing=0 width=350 class=S11><TR><TH valign=top>User&nbsp;ID</TH><TD>' . ($_AUTH['level'] < LEVEL_MANAGER? $nID : '<A href=users/' . $nID . '>' . $nID . '</A>') . '</TD></TR><TR><TH valign=top>Name</TH><TD>' . $sName . '</TD></TR><TR><TH valign=top>Email&nbsp;address</TH><TD>' . str_replace("\r\n", '<BR>', lovd_hideEmail($sEmail)) . '</TD></TR><TR><TH valign=top>Institute</TH><TD>' . $sInstitute . '</TD></TR><TR><TH valign=top>Department</TH><TD>' . $sDepartment . '</TD></TR><TR><TH valign=top>Country</TH><TD>' . $sCountryID . '</TD></TR></TABLE>') . '\', this);">' . $sName . '</SPAN>';
                 }
             }
+            // Determine minimum status for all data in current VL row.
+            $nRowStatus = STATUS_OK;
             // Status coloring will only be done, when we have authorization.
             // Instead of having the logic in separate objects and the custom VL object, put it together here.
             // In LOVD+, we disable the feature of coloring hidden and marked data, since all data is hidden.
             if (!LOVD_plus && $_AUTH['level'] >= LEVEL_COLLABORATOR) {
-                // Mark row according to the lowest status; Marked is red; lower will be gray.
-                // NOTE: Do we need to worry about adding values here that are defaults?
-                // I'd rather not copy $zData...
-                $zData += array(
-                    'statusid' => STATUS_OK,
-                    'var_statusid' => STATUS_OK,
-                    'ind_statusid' => STATUS_OK,
-                );
-                // The individual's status can be empty, if there is none,
-                //  but that doesn't mean it's non-public.
-                $zData['ind_statusid'] = ($zData['ind_statusid']?: STATUS_OK);
-                // In the VariantOnTranscriptUnique view the var_statusid can contain multiple IDs, these IDs are separated by a ",".
-                // PHP always takes the first integer-like part of a string when a string and an integer are compared.
-                // But to avoid problems in the future, only the first character is compared.
-                $nStatus = min($zData['statusid'], substr($zData['var_statusid'], 0, 1), $zData['ind_statusid']);
-                $zData['class_name'] = '';
-                if ($nStatus <= STATUS_MARKED) {
-                    $zData['class_name'] = ($nStatus == STATUS_MARKED ? 'marked' : 'del');
+                // Loop through possible status fields, always keep the minimum.
+                foreach (array('statusid', 'var_statusid', 'ind_statusid') as $sField) {
+                    if (!empty($zData[$sField])) {
+                        // In the VariantOnTranscriptUnique view the var_statusid can contain multiple IDs, separated by ",".
+                        // PHP always takes the first integer-like part of a string when converting to an integer.
+                        // But to avoid problems in the future, only the first character is compared.
+                        $nRowStatus = min($nRowStatus, (int) substr($zData[$sField], 0, 1));
+                    }
                 }
-            } else {
-                $zData['class_name'] = '';
+            }
+
+            // Mark row according to the lowest status; Marked is red; lower will be gray.
+            $zData['class_name'] = '';
+            if ($nRowStatus == STATUS_MARKED) {
+                $zData['class_name'] = 'marked';
+            } elseif ($nRowStatus < STATUS_MARKED) {
+                $zData['class_name'] = 'del';
             }
 
         } else {


### PR DESCRIPTION
Fixed bug; The color coding was visible for the public.
- Color coding based on the variant's status should not be shown to the public, also because they don't see the status column.
- Made sure the color coding was done only for users >= LEVEL_COLLABORATOR.
- Also made sure the color coding logic was in one place only, instead of copied in many different files.
- Color coding is based on the lowest set status (unique variant view and view with variant and patient data in one row).