### PR TITLE
Various fixes

### DIFF
--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2017-12-01
+ * Modified    : 2018-02-27
  * For LOVD    : 3.0-21
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -703,7 +703,7 @@ class LOVD_API_Submissions {
         }
 
         // Write the LOVD3 output file (and optionally, the JSON data).
-        return $this->writeImportFile($aData, $sInput);
+        return $this->writeImportFile($aData, $sInputClean);
     }
 
 

--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -105,7 +105,7 @@ class LOVD_API_Submissions {
         'Individuals' => array('id', 'panel_size', 'owned_by', 'statusid', 'created_by', 'Individual/Lab_ID', 'Individual/Gender'),
         'Individuals_To_Diseases' => array('individualid', 'diseaseid'),
         'Phenotypes' => array('id', 'diseaseid', 'individualid', 'owned_by', 'statusid', 'created_by', 'Phenotype/Additional'),
-        'Screenings' => array('id', 'individualid', 'owned_by', 'created_by', 'Screening/Template', 'Screening/Technique'),
+        'Screenings' => array('id', 'individualid', 'variants_found', 'owned_by', 'created_by', 'Screening/Template', 'Screening/Technique'),
         'Screenings_To_Genes' => array(),
         'Variants_On_Genome' => array('id', 'allele', 'effectid', 'chromosome', 'position_g_start', 'position_g_end', 'owned_by', 'statusid', 'created_by', 'VariantOnGenome/DNA', 'VariantOnGenome/DBID'),
         'Variants_On_Transcripts' => array('id', 'transcriptid', 'effectid', 'position_c_start', 'position_c_start_intron', 'position_c_end', 'position_c_end_intron', 'VariantOnTranscript/DNA', 'VariantOnTranscript/RNA', 'VariantOnTranscript/Protein'),
@@ -445,6 +445,7 @@ class LOVD_API_Submissions {
                     array(
                         'id' => $nScreeningID,
                         'individualid' => $nIndividualID,
+                        'variants_found' => 1,
                         'owned_by' => $this->zAuth['id'],
                         'created_by' => $this->zAuth['id'],
                         'Screening/Template' => implode(';', array_unique($aTemplates)),

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -321,7 +321,7 @@ class LOVD_CustomViewList extends LOVD_Object {
                     $aSQL['SELECT'] .= ', TRIM(BOTH "?" FROM TRIM(LEADING "c." FROM REPLACE(REPLACE(`VariantOnTranscript/DNA`, ")", ""), "(", ""))) AS vot_clean_dna_change' .
                                        ', GROUP_CONCAT(DISTINCT et.name SEPARATOR ", ") AS vot_effect' .
                                        ', GROUP_CONCAT(DISTINCT NULLIF(uo.name, "") SEPARATOR ", ") AS owned_by_' .
-                                       ', GROUP_CONCAT(DISTINCT CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) SEPARATOR ";;") AS __owner';
+                                       ', GROUP_CONCAT(DISTINCT CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, IF(IFNULL(uo.department, "") = "", "-", uo.department), IF(IFNULL(uo.countryid, "") = "", "-", uo.countryid)) SEPARATOR ";;") AS __owner';
                     // dsg.id GROUP_CONCAT is ascendingly ordered. This is done for the color marking.
                     // In prepareData() the lowest var_statusid is used to determine the coloring.
                     $aSQL['SELECT'] .= ', GROUP_CONCAT(DISTINCT NULLIF(dsg.id, "") ORDER BY dsg.id ASC SEPARATOR ", ") AS var_statusid, GROUP_CONCAT(DISTINCT NULLIF(dsg.name, "") SEPARATOR ", ") AS var_status' .

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -298,8 +298,8 @@ class LOVD_CustomViewList extends LOVD_Object {
                             $aSQL['WHERE'] .= (!$aSQL['WHERE']? '' : ' AND ') . 'vot.id IS NOT NULL';
                             // Then also make sure we group on the VOT's ID, unless we're already grouping on something.
                             if (!$aSQL['GROUP_BY']) {
-                                // t.geneid needs to be included because we order on this as well (otherwise, we could have used t.id).
-                                $aSQL['GROUP_BY'] = 't.geneid, vot.id';
+                                // t.geneid needs to be included because we order on this as well (otherwise, we could have used just t.id).
+                                $aSQL['GROUP_BY'] = 't.geneid, t.id, vot.id';
                             }
                         }
                         // We have no fallback, so we'll easily detect an error if we messed up somewhere.

--- a/src/import.php
+++ b/src/import.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2017-12-11
+ * Modified    : 2018-02-27
  * For LOVD    : 3.0-21
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -266,7 +266,7 @@ if (ACTION == 'schedule' && PATH_COUNT == 1) {
                 $sFileDisplayName = $sFile;
             }
 
-            $nAgeInDays = floor(($tNow - strtotime($aFile['file_date']))/(60*60*24));
+            $sAge = lovd_convertSecondsToTime($tNow - strtotime($aFile['file_date']), 0, true);
             // Build the link for actions for already scheduled files.
             $sAjaxActions = 'onclick="$.get(\'ajax/import_scheduler.php/' . urlencode($sFile) . '?view\').fail(function(){alert(\'Error retrieving actions, please try again later.\');}); return false;"';
             if ($i) {
@@ -314,7 +314,7 @@ if (ACTION == 'schedule' && PATH_COUNT == 1) {
             print('
                   <TD>' . $sDownloadHTML . $sInformationHTML . $sPriorityHTML . $sProcessingHTML . $sErrorsHTML . '
                     <B>' . $sFileDisplayName . '</B><BR>
-                    <SPAN class="S11">' . ($aFile['file_lost']? 'File not found' : $aFile['file_date'] . ' - ' . ($bAPI? 'Submitted' : (LOVD_plus? 'Converted' : 'Created')) . ' ' . $nAgeInDays . ' day' . ($nAgeInDays == 1? '' : 's') . ' ago') . '</SPAN>
+                    <SPAN class="S11">' . ($aFile['file_lost']? 'File not found' : $aFile['file_date'] . ' - ' . ($bAPI? 'Submitted' : (LOVD_plus? 'Converted' : 'Created')) . ' ' . $sAge . ' ago') . '</SPAN>
                   </TD></TR>');
         }
         print('</TABLE></TD>' . "\n");

--- a/src/inc-js-viewlist.php
+++ b/src/inc-js-viewlist.php
@@ -83,6 +83,7 @@ function lovd_AJAX_processViewListHash ()
         $(oForm).find('input[name^="search_"][type!="hidden"]').each(function (i, o) { if (o.value && !Hash[o.name]) { o.value = ""; }});
         $(oForm).find('input[name^="page"]').each(function (i, o) { if (o.value && !Hash[o.name]) { o.value = ""; }});
         $(oForm).find('input[name="order"]').each(function (i, o) { if (o.value && !Hash[o.name]) { o.value = ""; }});
+        $(oForm).find('input[name="MVSCols"]').each(function (i, o) { if (o.value && !Hash[o.name]) { o.value = ""; }});
 
         if (!window.location.hash) {
             // We don't have a hash anymore. This means we went back to the original viewlist. We must reload it, WITHOUT

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2020,10 +2020,13 @@ function lovd_convertIniValueToBytes ($sValue)
 
 
 
-function lovd_convertSecondsToTime ($sValue, $nDecimals = 0)
+function lovd_convertSecondsToTime ($sValue, $nDecimals = 0, $bVerbose = false)
 {
     // This function takes a number of seconds and converts it into whole
     // minutes, hours, days, months or years.
+    // $nDecimals indicates the number of decimals to use in the returned value.
+    // $bVerbose defines whether to use short notation (s, m, h, d, y) or long notation
+    //   (seconds, minutes, hours, days, years).
     // FIXME; Implement proper checks here? Regexp?
 
     $nValue = (int) $sValue;
@@ -2035,10 +2038,12 @@ function lovd_convertSecondsToTime ($sValue, $nDecimals = 0)
 
     $aConversion =
         array(
-            's' => array(60, 'm'),
-            'm' => array(60, 'h'),
-            'h' => array(24, 'd'),
-            'd' => array(265, 'y'),
+            's' => array(60, 'm', 'second'),
+            'm' => array(60, 'h', 'minute'),
+            'h' => array(24, 'd', 'hour'),
+            'd' => array(265, 'y', 'day'),
+            'y' => array(100, 'c', 'year'),
+            'c' => array(100, '', 'century'), // Above is not supported.
         );
 
     foreach ($aConversion as $sUnit => $aConvert) {
@@ -2049,6 +2054,12 @@ function lovd_convertSecondsToTime ($sValue, $nDecimals = 0)
         }
     }
 
-    return round($nValue, $nDecimals) . $sLast;
+    $nValue = round($nValue, $nDecimals);
+    if ($bVerbose) {
+        // Make it "3 years" instead of "3y".
+        return $nValue . ' ' . $aConversion[$sLast][2] . ($nValue == 1? '' : 's');
+    } else {
+        return $nValue . $sLast;
+    }
 }
 ?>


### PR DESCRIPTION
Interface related fixes:
- Fixed bug; In the grouped views, data owners were not shown when the department field was empty.
- Fixed bug; The in_gene view didn't group by transcript, but merely by gene and vot.id.
  - This resulted in unpredictable sorting and the not showing of transcripts that did have variants.
  - Which transcript was shown appeared to be random for the user, and wasn't clear.
  - Now, all VOT entries will be shown.
- Fixed bug; The back button didn't clear the MVS filter, which rendered the view broken when selecting a column without conflicting values.
  - This happened as $bSearch is false at the moment, and thus no VL header is shown.

Submission API related fixes:
- When not sending the cleaned JSON to the archive JSON file, we might not be able to create a file at all.
- Fixed bug; When submitting multiple variants over the API, LOVD always created multiple screenings.
  - Now, LOVD checks if the given screening information matches the previously seen screenings, and will re-use previously seen screenings.
- Fixed bug; API submissions had their screenings set to "no variants found".
  - This causes problems when trying to work with the screenings in LOVD.

Scheduler related fixes:
- Age of files to schedule is now formatted using lovd_convertSecondsToTime().
  - Adapted the function to also be able to show more verbose time ("minutes" instead of "m").
- API files that had been edited sorted at the bottom as they were considered new.
  - Now for API files, the timestamp from the file is used to sort the files.
  - This brings the displayed date and the sorting date in line.