### PR TITLE
Fixed bug; Submitters could submit data without a variant effect by disabling all transcripts of the gene they selected.

### DIFF
--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2018-01-31
- * For LOVD    : 3.0-21
+ * Modified    : 2018-04-13
+ * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -371,13 +371,26 @@ class LOVD_GenomeVariant extends LOVD_Custom {
      'authorization' => array('Enter your password for authorization', '', 'password', 'password', 20),
                       ));
 
+        // Check if we actually have any transcripts enabled. When creating a variant, the user may disable them.
+        // We need to know for the variant effect fields.
+        $nTranscripts = 0;
+        if (ACTION == 'create') {
+            foreach (array_keys($_POST['aTranscripts']) as $nTranscriptID) {
+                if (empty($_POST['ignore_' . $nTranscriptID])) {
+                    $nTranscripts ++;
+                }
+            }
+        } elseif (!empty($_POST['aTranscripts'])) {
+            $nTranscripts = count($_POST['aTranscripts']);
+        }
+
         if (ACTION == 'create' || (ACTION == 'publish' && GET)) {
             // When creating, or when publishing without any changes, unset the authorization.
             unset($this->aFormData['authorization']);
         }
         if ($_AUTH['level'] < LEVEL_CURATOR) {
             unset($this->aFormData['effect_concluded'], $this->aFormData['general_skip'], $this->aFormData['general'], $this->aFormData['general_hr1'], $this->aFormData['owner'], $this->aFormData['status'], $this->aFormData['general_hr2']);
-        } elseif (is_array($_DATA) && !empty($_DATA['Transcript'])) {
+        } elseif ($nTranscripts) {
             // Determine whether to show the `effect_concluded` field.
             // When a variant is linked to one or more transcripts, its effect
             //  on the genomic level will be determined by the "worst" effect on the
@@ -407,7 +420,7 @@ class LOVD_GenomeVariant extends LOVD_Custom {
         }
 
         // Determine whether to show the `effect_reported` field.
-        if (is_array($_DATA) && !empty($_DATA['Transcript'])) {
+        if ($nTranscripts) {
             // When a variant is linked to one or more transcripts, its effect
             //  on the genomic level will be determined by the "worst" effect on the
             //  transcript levels. Only if the currently set effect is non-concordant

--- a/src/variants.php
+++ b/src/variants.php
@@ -707,6 +707,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
         require ROOT_PATH . 'class/object_transcript_variants.php';
         $_DATA['Transcript'][$sGene] = new LOVD_TranscriptVariant($sGene);
         // This is done so that fetchDBID can have this information and can give a better prediction.
+        // buildForm() also uses it to check some things.
         $_POST['aTranscripts'] = $_DATA['Transcript'][$sGene]->aTranscripts;
         $_POST['chromosome'] = $_DB->query('SELECT chromosome FROM ' . TABLE_GENES . ' WHERE id = ?', array($sGene))->fetchColumn();
     }


### PR DESCRIPTION
Fixed bug; Submitters could submit data without a variant effect by disabling all transcripts of the gene they selected.
- Now, we take into account which transcripts have been disabled when we check if transcripts are being used.