### PR TITLE
Make the LOVD2-style API return JSON on request

### DIFF
--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -5,7 +5,7 @@
 % To convert the manual to an html file use: pdf2htmlEX --zoom 1.3 --embed-css 2 manual.pdf
 
 %%%%% SETTINGS FOR THE TITLE PAGE %%%%%
-\setLOVDversion{3.0-21}
+\setLOVDversion{3.0-22}
 \title{LOVD 3.0 user manual \\\vskip 0.2cm Build \LOVDversion}
 \author{Ivo F.A.C. Fokkema \\ Daan Asscheman}
 \setpointercolor{red}
@@ -3995,6 +3995,14 @@ LOVD3 contains an LOVD2-style data retrieval API, useful for simple queries and 
 
 
 \section{Data retrieval API}
+\begin{wrapfigure}[4]{r}{8cm}
+  \vspace{-25pt}
+  \begin{leftbar}
+    Required level: None\\
+    Available from: LOVD 3.0 Build 01\\
+    JSON support: LOVD 3.0 Build 22
+  \end{leftbar}
+\end{wrapfigure}
 Just like LOVD2 (from version 2.0-22, released October 5th 2009), LOVD3 includes a simple
  webservice enabling simple queries or listing of variant data (not patient data).
 This API only shows very basic information and can therefore not be disabled.
@@ -4005,7 +4013,8 @@ Examples of possibilities are searching on a gene symbol, getting the list of av
  or on a per-gene basis, list all variants or search for a certain variant or DNA location.
 Even though LOVD3 is not gene-based like LOVD2 was, we have decided to keep the same
  gene-centered design of the API to make sure LOVD2 and LOVD3 can be queried alike.
-The output it creates is an Atom 1.0 feed with the LOVD information in plain text.
+The output it creates is either an Atom 1.0 feed with the LOVD information in plain text, or a
+ \href{http://www.json.org/}{JSON} file.
 
 A more advanced API will be included in LOVD3 later, allowing the querying of variants genome-wide
  and getting more detailed information out of LOVD, such as patient and phenotype data.
@@ -4018,7 +4027,7 @@ This API will be configurable, so submitters decide for themselves under
 \begin{warntable}
   These terms of service and fair use policy are applicable to \emph{all} APIs present on the LOVD site
    and any LOVD installations hosted by the Leiden University Medical Center, recognizable by domain names ending
-   by .lovd.nl, .lumc.nl or .liacs.nl.
+   by .lovd.nl or .lumc.nl.
   Other servers hosting LOVDs may also have terms of service in place.
   If in doubt, try to contact the party hosting the LOVD installation.
 \end{warntable}
@@ -4037,6 +4046,8 @@ This API will be configurable, so submitters decide for themselves under
 
 
 \subsection{Format}
+Since 3.0-22, the LOVD2-style API allows for JSON data to be returned.
+The original format, also still available in 3.0-22, is an Atom feed, and is still the standard.
 When searching for genes, an Atom feed is returned with zero or more entries.
 When requesting a specific entry, just the Atom entry is returned.
 The Atom format is described in detail on \href{http://en.wikipedia.org/wiki/Atom_(standard)}{Wikipedia}.
@@ -4046,7 +4057,7 @@ Other formats as a `payload' of the Atom entries are not available.
 
 The new LOVD3 API (release date unavailable) will probably support multiple formats, such as
  \href{http://www.varioml.org/}{VarioML} and \href{http://www.json.org/}{JSON},
- most likely not wrapped in Atom feeds, since this API serves a different purpose.
+ and will not support Atom feeds, since this API serves a different purpose.
 
 \subsubsection{Genes}
 \begin{figure}[ht]
@@ -4058,27 +4069,27 @@ The new LOVD3 API (release date unavailable) will probably support multiple form
   <title>
     Results for your query of the database
   </title>
-  <link rel="alternate" type="text/html" href="http://databases.lovd.nl/shared/"/>
-  <link rel="self" type="application/atom+xml" href="http://databases.lovd.nl/shared/api/rest/genes"/>
-  <updated>2014-01-14T12:20:24+01:00</updated>
+  <link rel="alternate" type="text/html" href="https://databases.lovd.nl/shared/"/>
+  <link rel="self" type="application/atom+xml" href="https://databases.lovd.nl/shared/api/rest/genes"/>
+  <updated>2018-04-17T20:15:10+02:00</updated>
   <id>tag:databases.lovd.nl,2012-05-02:web01:shared/REST_api</id>
-  <generator uri="http://www.LOVD.nl/" version="3.0-09">
+  <generator uri="http://www.LOVD.nl/" version="3.0-21">
     Leiden Open Variation Database
   </generator>
   <rights>Copyright (c), the curators of this database</rights>
   <entry xmlns="http://www.w3.org/2005/Atom">
     <title>IVD</title>
-    <link rel="alternate" type="text/html" href="http://databases.lovd.nl/shared/genes/IVD"/>
-    <link rel="self" type="application/atom+xml" href="http://d...lovd.nl/shared/api/rest/genes/IVD"/>
+    <link rel="alternate" type="text/html" href="https://databases.lovd.nl/shared/genes/IVD"/>
+    <link rel="self" type="application/atom+xml" href="https://d...lovd.nl/shared/api/rest/genes/IVD"/>
     <id>tag:databases.lovd.nl,2011-04-05:IVD</id>
     <author>
-      <name>Gerard Schaafsma</name>
+      <name>Gerard C.P. Schaafsma</name>
     </author>
     <contributor>
       <name>Ivo F.A.C. Fokkema</name>
     </contributor>
     <published>2011-04-05T16:04:49+02:00</published>
-    <updated>2013-03-11T15:30:41+01:00</updated>
+    <updated>2017-08-07T13:40:16+02:00</updated>
     <content type="text">
       id:IVD
       entrez_id:3712
@@ -4095,10 +4106,48 @@ The new LOVD3 API (release date unavailable) will probably support multiple form
 </feed>
     \end{verbatim}
   \caption{%
-    Example LOVD API output format.
-    The two longest lines have been shortened to fit this page.
+    Example LOVD API output, in the default Atom format.
+    The longest line has been shortened to fit this page.
     This example output of a search on gene symbol returns the IVD gene and its basic information.
-    Source: \href{http://databases.lovd.nl/shared/api/rest/genes?search_symbol=IVD}
+    Source: \href{https://databases.lovd.nl/shared/api/rest/genes?search_symbol=IVD}
+     {LOVD3 shared installation}.}
+  \end{shaded}
+\end{figure}
+
+\begin{figure}[ht]
+  \begin{shaded}
+    \scriptsize
+    \begin{verbatim}
+[
+  {
+    "id":"IVD",
+    "entrez_id":"3712",
+    "symbol":"IVD",
+    "name":"isovaleryl-CoA dehydrogenase",
+    "chromosome":"15",
+    "chromosome_location":"15q14-q15",
+    "position_start":"chr15:40697686",
+    "position_end":"chr15:40713512",
+    "refseq_genomic":"NG_011986.1",
+    "refseq_mrna":[
+      "NM_001159508.1",
+      "NM_002225.3"
+    ],
+    "refseq_build":"hg19",
+    "created_by":"Gerard C.P. Schaafsma",
+    "created_date":"2011-04-05T16:04:49+02:00",
+    "curators":[
+      "Ivo F.A.C. Fokkema"
+    ],
+    "updated_date":"2017-08-07T13:40:16+02:00"
+  }
+]
+    \end{verbatim}
+  \caption{%
+    Example LOVD API output, in the JSON format, of the same API search result as the previous figure.
+    Note the slight differences in the data returned; the JSON format adds the chromosome field,
+     returns all transcripts associated with the gene in question, and stores the curator information in an array.
+    Source: \href{https://databases.lovd.nl/shared/api/rest/genes?search_symbol=IVD&format=application/json}
      {LOVD3 shared installation}.}
   \end{shaded}
 \end{figure}
@@ -4107,17 +4156,21 @@ The gene information shared through the API consists of the official gene symbol
  the gene's Entrez ID (\textbf{entrez\_id}), the gene's official name (\textbf{name}), the chromosome band
  (\textbf{chromosome\_location}) and exact locations (\textbf{position\_start}, \textbf{position\_end},
  not always available), its genomic reference sequence (\textbf{refseq\_genomic}), first transcript added
- (\textbf{refseq\_mrna}) and the code of the reference sequence build that the genomic positions are based on
- (\textbf{refseq\_build}).
+ (\textbf{refseq\_mrna}, all transcripts when using JSON) and the code of the
+ reference sequence build that the genomic positions are based on (\textbf{refseq\_build}).
+The JSON data has slightly more fields (\textbf{created\_by}, \textbf{created\_date}, \textbf{curators},
+ \textbf{updated\_date}), which are also available in the Atom entry itself (not the plain text payload).
 \vskip \baselineskip
 
 The official gene symbol is mentioned twice, because in LOVD2 multiple databases could exist for the same gene by
  setting a suffix on the gene symbol; there the `id' field could have a different value than the `symbol' field.
 Having two fields for the gene symbol is retained in the API to keep the format between LOVD3 and LOVD2 consistent.
 
-Please note, also for consistency with the LOVD2 API, that the `refseq\_mrna' field can
+Please note, also for consistency with the LOVD2 API, that in the Atom entry, the `refseq\_mrna' field can
  contain only one value whilst in LOVD3 one gene can contain multiple transcripts.
-The LOVD API shows only the first transcript added to the gene.
+The Atom entry shows only the first transcript, sorted on their NCBI ID.
+The JSON data shows all transcripts.
+\clearpage
 
 \subsubsection{Variants}
 \begin{figure}[ht]
@@ -4163,7 +4216,7 @@ The LOVD API shows only the first transcript added to the gene.
 </feed>
     \end{verbatim}
   \caption{%
-    Example LOVD API output format.
+    Example LOVD API output, in the default Atom format.
     The three longest lines have been shortened to fit this page.
     This example output of a search on DB ID returns one variant in the IVD gene and its basic information.
     Source: \href{http://databases.lovd.nl/shared/api/rest/variants/IVD?search_Variant/DBID=IVD_000001}
@@ -4171,19 +4224,65 @@ The LOVD API shows only the first transcript added to the gene.
   \end{shaded}
 \end{figure}
 
+\begin{figure}[ht]
+  \begin{shaded}
+    \scriptsize
+    \begin{verbatim}
+[
+  {
+    "symbol":"IVD",
+    "id":"0000000563",
+    "position_mRNA":[
+      "NM_002225.3:c.860"
+    ],
+    "position_genomic":"chr15:g.40707154",
+    "Variant\/DNA":[
+      "NM_002225.3:c.860G>A"
+    ],
+    "Variant\/DBID":"IVD_000001",
+    "Times_reported":"1",
+    "owned_by":[
+      "Ivo F.A.C. Fokkema"
+    ],
+    "created_by":[
+      "Gerard C.P. Schaafsma"
+    ],
+    "created_date":"2011-04-06T16:20:25+02:00",
+    "edited_date":"2017-03-28T16:27:49+02:00"
+  }
+]
+    \end{verbatim}
+  \caption{%
+    Example LOVD API output, in the JSON format, of the same API search result as the previous figure.
+    Note the slight differences in the data returned; the JSON format adds the data owner(s), the data creator(s),
+     the dates the data was created and last updated and
+     returns all transcripts associated with the variant in question, storing the data in an array.
+     The genomic position is formatted slightly differently.
+    Source:
+     \href{http://databases.lovd.nl/shared/api/rest/variants/IVD?search_Variant/DBID=IVD_000001&format=application/json}
+     {LOVD3 shared installation}.}
+  \end{shaded}
+\end{figure}
+
 The variant information shared through the API consists of the official gene symbol of the selected gene
  (\textbf{symbol}), the variant's internal ID (\textbf{id}), the variant's position relative to the transcript in
- HGVS-like format (\textbf{position\_mRNA}), the variant's genomic position (\textbf{position\_genomic}), the DNA
- field in HGVS format, HTML encoded to not break XML parsers (\textbf{Variant/DNA}), the variant's DBID value
- (\textbf{Variant/DBID}) and the panel size of the individual of the variant entry (\textbf{Times\_reported}).
+ HGVS-like format (\textbf{position\_mRNA}), the variant's genomic position in HGVS-like format
+ (\textbf{position\_genomic}), the DNA field in HGVS format, HTML encoded in the Atom format to not break XML parsers
+ (\textbf{Variant/DNA}), the variant's DBID value (\textbf{Variant/DBID}) and the panel size of the individual of the
+ variant entry (\textbf{Times\_reported}).
+The JSON data has slightly more fields (\textbf{owned\_by}, \textbf{created\_by}, \textbf{created\_date},
+ \textbf{edited\_date}), which are also available in the Atom entry itself (not the plain text payload).
+Also, the JSON data will list the variant's position and the variant's DNA change
+ on transcript level for all transcripts that the variant is mapped on.
 \vskip \baselineskip
 
-If the variant could not be interpreted by Mutalyzer, the position fields will contain a question mark.
+If the variant could not be interpreted, the position fields will contain a question mark.
 The difference between the `id' field and the `Variant/DBID' field is that the first is the ID of the variant
  observation, whilst the latter is the ID unique for this variant, but shared for each observation.
 It is used link back to LOVD from genome browsers, for instance.
 When variant observations are grouped together, the `Times\_reported' field
  will contain the sum of the values of all observations together.
+\clearpage
 
 
 
@@ -4193,6 +4292,7 @@ When variant observations are grouped together, the `Times\_reported' field
 A full list of options for this API is included below.
 Please note that although ``rest.php'' is included in all the URLs, simply ``rest'' will work also.
 However, for LOVD2 installations, this does not always work, and as such the extension is included.
+To obtain JSON output, add the `\texttt{format=application/json}' flag to all URLs.
 
 \subsubsection{Genes}
 \begin{description}

--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -427,15 +427,12 @@ When a gene is selected (shown in the page header),
 When no gene is selected, the default page of the screenings tab shows all screenings.
 When a gene is selected (shown in the page header),
  the default page of the screenings tab shows all screenings that screened for variants in the selected gene.
+\clearpage
 
 \begin{description}
   \item [View all screenings] \hfill \\
   This view shows all the screenings in the database.
   You can click on a screening to view its details.
-\end{description}
-
-% We'll have to separate the description lists, because somehow it keeps wrapping around the figure otherwise.
-\begin{description}
   \item [View all screenings for a gene] \hfill \\
   This view displays all screenings that screened for variants in the currently selected gene.
   You can click on a screening to view its details.
@@ -1208,13 +1205,6 @@ Curators do not require a separate submitter account; they can use their curator
 
 \hypertarget{sec:submitter_register}{}
 \section{Registering a new account}
-\begin{wrapfigure}[3]{r}{8cm} % Only wrap for 3 lines
-  \vspace{-25pt}
-  \begin{leftbar}
-    Required level: None (public)\\
-    Available from: LOVD 3.0 Build 01
-  \end{leftbar}
-\end{wrapfigure}
 \begin{warntable}
 Please note that you do \textbf{NOT} need to register to view the data available in the database.
 You only need an account for submitting new variant data.
@@ -1227,6 +1217,13 @@ The major difference between registration and direct creation of a new account b
 The registration form is protected using a \emph{reCAPTCHA} module, which makes sure the form can only be used by humans, and not by spam bots.
 \vskip \baselineskip
 
+\begin{wrapfigure}[3]{r}{8cm} % Only wrap for 3 lines
+  \vspace{-25pt}
+  \begin{leftbar}
+    Required level: None (public)\\
+    Available from: LOVD 3.0 Build 01
+  \end{leftbar}
+\end{wrapfigure}
 To register a new submitter account, click the ``Register as submitter'' link on the top right corner of the screen, next to the ``Log in'' link.
 First, you are asked to provide an ORCID ID, if you have one.
 \href{http://about.orcid.org/}{ORCID} provides a persistent digital identifier that distinguishes you from every other researcher and,
@@ -3193,7 +3190,8 @@ When this line is not included in the file that is imported, LOVD cannot process
   Please NOTE that spreadsheets are well known for introducing errors in importing/exporting
    text files, due to automatic interpretation of the values.
   When using a spreadsheet program to edit a downloaded file,
-   format all cells to "Text" \textbf{before} importing/pasting the downloaded data.\\
+   format all cells to "Text" \textbf{before} importing/pasting the downloaded data.
+  \vskip \baselineskip
 
   Also some cases have been reported where MS Excel removed contents of large text fields (> 255 characters).
 \end{warntable}
@@ -4070,7 +4068,7 @@ The new LOVD3 API (release date unavailable) will probably support multiple form
     Results for your query of the database
   </title>
   <link rel="alternate" type="text/html" href="https://databases.lovd.nl/shared/"/>
-  <link rel="self" type="application/atom+xml" href="https://databases.lovd.nl/shared/api/rest/genes"/>
+  <link rel="self" type="application/atom+xml" href="http://databases.lovd.nl/shared/api/rest/genes"/>
   <updated>2018-04-17T20:15:10+02:00</updated>
   <id>tag:databases.lovd.nl,2012-05-02:web01:shared/REST_api</id>
   <generator uri="http://www.LOVD.nl/" version="3.0-21">
@@ -4079,8 +4077,8 @@ The new LOVD3 API (release date unavailable) will probably support multiple form
   <rights>Copyright (c), the curators of this database</rights>
   <entry xmlns="http://www.w3.org/2005/Atom">
     <title>IVD</title>
-    <link rel="alternate" type="text/html" href="https://databases.lovd.nl/shared/genes/IVD"/>
-    <link rel="self" type="application/atom+xml" href="https://d...lovd.nl/shared/api/rest/genes/IVD"/>
+    <link rel="alternate" type="text/html" href="http://databases.lovd.nl/shared/genes/IVD"/>
+    <link rel="self" type="application/atom+xml" href="http://d...lovd.nl/shared/api/rest/genes/IVD"/>
     <id>tag:databases.lovd.nl,2011-04-05:IVD</id>
     <author>
       <name>Gerard C.P. Schaafsma</name>
@@ -4642,9 +4640,10 @@ Depending on whether or not LOVD has found that there is an update available,\
 \begin{center}
 \begin{tabular}{ | p{0.8cm} p{10cm} | }
   \hline
-  \parbox[c]{1em}{\includegraphics[width=0.8cm]{lovd_update_newer.png}} & There is an update available. \\
-  \parbox[c]{1em}{\includegraphics[width=0.8cm]{lovd_update_newest.png}} & There is no update available. \\
-  \parbox[c]{1em}{\includegraphics[width=0.8cm]{lovd_update_error.png}} & There was an error while checking for updates. \\
+  \parbox[c]{1.9em}{\includegraphics[width=0.8cm]{lovd_update_newer.png}} & There is an update available. \\
+  \parbox[c]{1.9em}{\includegraphics[width=0.8cm]{lovd_update_newest.png}} & There is no update available. \\
+  \parbox[c]{1.9em}{\includegraphics[width=0.8cm]{lovd_update_error.png}} &
+   There was an error while checking for updates. \\
   \hline
 \end{tabular}
 \end{center}

--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -4067,7 +4067,7 @@ The new LOVD3 API (release date unavailable) will probably support multiple form
   <title>
     Results for your query of the database
   </title>
-  <link rel="alternate" type="text/html" href="https://databases.lovd.nl/shared/"/>
+  <link rel="alternate" type="text/html" href="http://databases.lovd.nl/shared/"/>
   <link rel="self" type="application/atom+xml" href="http://databases.lovd.nl/shared/api/rest/genes"/>
   <updated>2018-04-17T20:15:10+02:00</updated>
   <id>tag:databases.lovd.nl,2012-05-02:web01:shared/REST_api</id>
@@ -4107,7 +4107,7 @@ The new LOVD3 API (release date unavailable) will probably support multiple form
     Example LOVD API output, in the default Atom format.
     The longest line has been shortened to fit this page.
     This example output of a search on gene symbol returns the IVD gene and its basic information.
-    Source: \href{https://databases.lovd.nl/shared/api/rest/genes?search_symbol=IVD}
+    Source: \href{http://databases.lovd.nl/shared/api/rest/genes?search_symbol=IVD}
      {LOVD3 shared installation}.}
   \end{shaded}
 \end{figure}
@@ -4182,9 +4182,9 @@ The JSON data shows all transcripts.
   </title>
   <link rel="alternate" type="text/html" href="http://databases.lovd.nl/shared/"/>
   <link rel="self" type="application/atom+xml" href="http://...lovd.nl/shared/api/rest/variants/IVD"/>
-  <updated>2013-03-11T15:30:41+01:00</updated>
+  <updated>2017-08-07T13:40:16+02:00</updated>
   <id>tag:databases.lovd.nl,2012-05-02:web01:shared/REST_api</id>
-  <generator uri="http://www.LOVD.nl/" version="3.0-09">
+  <generator uri="http://www.LOVD.nl/" version="3.0-21">
     Leiden Open Variation Database
   </generator>
   <rights>Copyright (c), the curators of this database</rights>
@@ -4192,15 +4192,15 @@ The JSON data shows all transcripts.
     <title>IVD:c.860G&gt;A</title>
     <link rel="alternate" type="text/html" href="http://...?search_VariantOnGenome/DBID=IVD_000001"/>
     <link rel="self" type="application/atom+xml" href="http://.../api/rest/variants/IVD/0000000563"/>
-    <id>tag:databases.lovd.nl,1970-01-01:IVD/0000000563</id>
+    <id>tag:databases.lovd.nl,2011-04-06:IVD/0000000563</id>
     <author>
-      <name>Unknown</name>
+      <name>Gerard C.P. Schaafsma</name>
     </author>
     <contributor>
-      <name>Unknown</name>
+      <name>Ivo F.A.C. Fokkema</name>
     </contributor>
-    <published>1970-01-01T00:00:00+01:00</published>
-    <updated>1970-01-01T00:00:00+01:00</updated>
+    <published>2011-04-06T16:20:25+02:00</published>
+    <updated>2017-03-28T16:27:49+02:00</updated>
     <content type="text">
       symbol:IVD
       id:0000000563

--- a/src/api.php
+++ b/src/api.php
@@ -448,8 +448,8 @@ if ($sDataType == 'variants') {
             'Times_reported' => $zData['Times'],
             'owned_by' => explode(';', $zData['_owned_by']),
             'created_by' => explode(';', $zData['_created_by']),
-            'created_date' => $zData['created_date'],
-            'edited_date' => $zData['edited_date'],
+            'created_date' => date('c', strtotime($zData['created_date'])),
+            'edited_date' => date('c', strtotime($zData['edited_date'])),
         );
 
         if ($bUnique && FORMAT == 'application/json') {
@@ -554,9 +554,9 @@ if ($sDataType == 'variants') {
             'refseq_mrna' => explode(';', $zData['id_ncbi']),
             'refseq_build' => $_CONF['refseq_build'],
             'created_by' => $zData['created_by'],
-            'created_date' => $zData['created_date'],
+            'created_date' => date('c', strtotime($zData['created_date'])),
             'curators' => explode(';', $zData['curators']),
-            'updated_date' => $zData['updated_date'],
+            'updated_date' => date('c', strtotime($zData['updated_date'])),
         );
 
         return $aReturn;

--- a/src/api.php
+++ b/src/api.php
@@ -28,7 +28,7 @@
  *  3.0-beta-10  /api/rest.php/genes?search_position=chrX
  *  3.0-beta-10  /api/rest.php/genes?search_position=chrX:3200000
  *  3.0-beta-10  /api/rest.php/genes?search_position=chrX:3200000_4000000&position_match=exact|exclusive|partial
- *  3.0-22       /api/rest.php/*****?format=text/json   (JSON output for whole LOVD2-style API)
+ *  3.0-22       /api/rest.php/*****?format=application/json   (JSON output for whole LOVD2-style API)
  *  3.0-18 (v1)  /api/v#/submissions (POST) (/v# is optional)
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/

--- a/src/api.php
+++ b/src/api.php
@@ -505,8 +505,11 @@ if ($sDataType == 'variants') {
 
         $sContent = '';
         $zData['Variant/DNA'] = htmlspecialchars($zData['Variant/DNA']);
-        $zData['effect_reported'] = implode(',', $zData['effect_reported']);
-        $zData['effect_concluded'] = implode(',', $zData['effect_concluded']);
+        if (!empty($_GET['show_variant_effect'])) {
+            // Optionally, add the variant effect to the output.
+            $zData['effect_reported'] = implode(',', $zData['effect_reported']);
+            $zData['effect_concluded'] = implode(',', $zData['effect_concluded']);
+        }
         foreach ($aFieldsAtomContent as $sKey) {
             $sContent .= $sKey . ':' . $zData[$sKey] . "\n";
         }

--- a/src/api.php
+++ b/src/api.php
@@ -464,8 +464,8 @@ if ($sDataType == 'variants') {
             $aReturn = array_merge(
                 $aReturn,
                 array(
-                    'effect_reported' => implode(',', lovd_mapCodeToDescription(explode(';', $zData['effect_reported']), $_SETT['var_effect_api'])),
-                    'effect_concluded' => implode(',', lovd_mapCodeToDescription(explode(';', $zData['effect_concluded']), $_SETT['var_effect_api'])),
+                    'effect_reported' => lovd_mapCodeToDescription(explode(';', $zData['effect_reported']), $_SETT['var_effect_api']),
+                    'effect_concluded' => lovd_mapCodeToDescription(explode(';', $zData['effect_concluded']), $_SETT['var_effect_api']),
                 )
             );
         }
@@ -502,6 +502,8 @@ if ($sDataType == 'variants') {
 
         $sContent = '';
         $zData['Variant/DNA'] = htmlspecialchars($zData['Variant/DNA']);
+        $zData['effect_reported'] = implode(',', $zData['effect_reported']);
+        $zData['effect_concluded'] = implode(',', $zData['effect_concluded']);
         foreach ($aFieldsAtomContent as $sKey) {
             $sContent .= $sKey . ':' . $zData[$sKey] . "\n";
         }

--- a/src/api.php
+++ b/src/api.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-11-08
- * Modified    : 2018-04-17
+ * Modified    : 2018-04-18
  * For LOVD    : 3.0-22
  *
  * Supported URIs:
@@ -475,6 +475,9 @@ if ($sDataType == 'variants') {
 
     if (FORMAT == 'application/json') {
         // Dump JSON and die.
+        if ($sFeedType == 'entry') {
+            $aData = $aData[0];
+        }
         die(json_encode($aData));
     }
 
@@ -561,6 +564,9 @@ if ($sDataType == 'variants') {
 
     if (FORMAT == 'application/json') {
         // Dump JSON and die.
+        if ($sFeedType == 'entry') {
+            $aData = $aData[0];
+        }
         die(json_encode($aData));
     }
 

--- a/src/api.php
+++ b/src/api.php
@@ -431,7 +431,7 @@ if ($sDataType == 'variants') {
             'updated_date' => $zData['edited_date'],
         );
 
-        if ($bUnique) {
+        if ($bUnique && FORMAT == 'application/json') {
             unset($aReturn['id']);
         }
 

--- a/src/api.php
+++ b/src/api.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-11-08
- * Modified    : 2018-04-16
+ * Modified    : 2018-04-17
  * For LOVD    : 3.0-22
  *
  * Supported URIs:
@@ -176,7 +176,7 @@ if ($sDataType == 'variants') {
         // Normal API output; Atom feed with one entry per variant.
         // First build query.
         // Note that the MIN()s and MAX()es don't mean much if $bUnique is false, since we'll group by the vog.id anyway.
-        $sQ = 'SELECT MIN(vog.id) AS id, MAX(vot.position_c_start) AS position_c_start, MAX(vot.position_c_start_intron) AS position_c_start_intron, MAX(vot.position_c_end) AS position_c_end, MAX(vot.position_c_end_intron) AS position_c_end_intron, MAX(vog.position_g_start) AS position_g_start, MAX(vog.position_g_end) AS position_g_end, GROUP_CONCAT(DISTINCT LEFT(vog.effectid, 1) SEPARATOR ";") AS effect_reported, GROUP_CONCAT(DISTINCT RIGHT(vog.effectid, 1) SEPARATOR ";") AS effect_concluded, vot.`VariantOnTranscript/DNA`, vog.`VariantOnGenome/DBID`, SUM(IFNULL(i.panel_size, 1)) AS Times
+        $sQ = 'SELECT MIN(vog.id) AS id, MAX(vot.position_c_start) AS position_c_start, MAX(vot.position_c_start_intron) AS position_c_start_intron, MAX(vot.position_c_end) AS position_c_end, MAX(vot.position_c_end_intron) AS position_c_end_intron, MAX(vog.position_g_start) AS position_g_start, MAX(vog.position_g_end) AS position_g_end, GROUP_CONCAT(DISTINCT LEFT(vog.effectid, 1) SEPARATOR ";") AS effect_reported, GROUP_CONCAT(DISTINCT RIGHT(vog.effectid, 1) SEPARATOR ";") AS effect_concluded, vot.`VariantOnTranscript/DNA`, vog.`VariantOnGenome/DBID`, MIN(vog.created_date) AS created_date, MAX(IFNULL(vog.edited_date, vog.created_date)) AS edited_date, SUM(IFNULL(i.panel_size, 1)) AS Times
                FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_VARIANTS . ' AS vog USING (id) LEFT JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (vog.id = s2v.variantid) LEFT JOIN ' . TABLE_SCREENINGS . ' AS s ON (s2v.screeningid = s.id) LEFT JOIN ' . TABLE_INDIVIDUALS . ' AS i ON (s.individualid = i.id AND i.statusid >= ' . STATUS_MARKED . ')
                WHERE vot.transcriptid = ' . $nRefSeqID . ' AND vog.statusid >= ' . STATUS_MARKED;
         $bSearching = false;
@@ -426,9 +426,9 @@ if ($sDataType == 'variants') {
             'Variant/DBID' => $zData['Variant/DBID'],
             'Times_reported' => $zData['Times'],
             'created_by' => 'Unknown', // FIXME: Fetch from table.
-            'created_date' => '1970-01-01 00:00:00', // FIXME: Why empty?
+            'created_date' => $zData['created_date'],
             'edited_by' => 'Unknown', // FIXME: Fetch from table.
-            'updated_date' => '1970-01-01 00:00:00', // FIXME: Why empty?
+            'updated_date' => $zData['edited_date'],
         );
 
         if ($bUnique) {

--- a/src/api.php
+++ b/src/api.php
@@ -275,7 +275,7 @@ if ($sDataType == 'variants') {
     // FIXME: All transcripts are listed here, ordered by the NCBI ID. However, the variant API chooses the first transcript based on its internal ID and shows only the variants on that one.
     // FIXME: This causes a bit of a problem since varcache stores the transcripts string with the gene and doesn't know what transcript the variants are on until it reads out the variant list.
     // FIXME: Decided to solve this for varcache by updating the NM in the database after the variants have been read. Leaving this here for now.
-    $sQ = 'SELECT g.id, g.name, g.chromosome, g.chrom_band, (MAX(t.position_g_mrna_start) < MAX(t.position_g_mrna_end)) AS sense, LEAST(MIN(t.position_g_mrna_start), MIN(t.position_g_mrna_end)) AS position_g_mrna_start, GREATEST(MAX(t.position_g_mrna_start), MAX(t.position_g_mrna_end)) AS position_g_mrna_end, g.refseq_genomic, GROUP_CONCAT(DISTINCT t.id_ncbi ORDER BY t.id_ncbi SEPARATOR ";") AS id_ncbi, g.id_entrez, g.created_date, g.updated_date, u.name AS created_by, GROUP_CONCAT(DISTINCT cur.name SEPARATOR ", ") AS curators
+    $sQ = 'SELECT g.id, g.name, g.chromosome, g.chrom_band, (MAX(t.position_g_mrna_start) < MAX(t.position_g_mrna_end)) AS sense, LEAST(MIN(t.position_g_mrna_start), MIN(t.position_g_mrna_end)) AS position_g_mrna_start, GREATEST(MAX(t.position_g_mrna_start), MAX(t.position_g_mrna_end)) AS position_g_mrna_end, g.refseq_genomic, GROUP_CONCAT(DISTINCT t.id_ncbi ORDER BY t.id_ncbi SEPARATOR ";") AS id_ncbi, g.id_entrez, g.created_date, g.updated_date, u.name AS created_by, GROUP_CONCAT(DISTINCT cur.name SEPARATOR ";") AS curators
            FROM ' . TABLE_GENES . ' AS g LEFT JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (g.id = t.geneid) LEFT JOIN ' . TABLE_USERS . ' AS u ON (g.created_by = u.id) LEFT JOIN ' . TABLE_CURATES . ' AS u2g ON (g.id = u2g.geneid AND u2g.allow_edit = 1) LEFT JOIN ' . TABLE_USERS . ' AS cur ON (u2g.userid = cur.id)
            WHERE 1=1';
 
@@ -555,7 +555,7 @@ if ($sDataType == 'variants') {
             'refseq_build' => $_CONF['refseq_build'],
             'created_by' => $zData['created_by'],
             'created_date' => $zData['created_date'],
-            'curators' => $zData['curators'],
+            'curators' => explode(';', $zData['curators']),
             'updated_date' => $zData['updated_date'],
         );
 
@@ -582,7 +582,7 @@ if ($sDataType == 'variants') {
         }
         $sAltURL             = ($_CONF['location_url']? $_CONF['location_url'] : lovd_getInstallURL()) . 'genes/' . $zData['id'];
         $sID                 = 'tag:' . $_SERVER['HTTP_HOST'] . ',' . substr($zData['created_date'], 0, 10) . ':' . $zData['id'];
-        $sContributors       = htmlspecialchars($zData['curators']);
+        $sContributors       = htmlspecialchars(implode(', ', $zData['curators']));
         $sContent = '';
         $zData['refseq_mrna'] = implode(',', $zData['refseq_mrna']);
         foreach ($aFieldsAtomContent as $sKey) {

--- a/src/class/feeds.php
+++ b/src/class/feeds.php
@@ -164,7 +164,7 @@ class Feed {
                 $sContentType = 'text';
             }
             $sEntry = str_replace('{{ ENTRY_CONTENT_TYPE }}', $sContentType, $sEntry);
-            $sEntry = str_replace('{{ ENTRY_CONTENT }}', str_replace("\n", "\n      ", $sContent), $sEntry);
+            $sEntry = str_replace('{{ ENTRY_CONTENT }}', str_replace("\n", "\n      ", trim($sContent)), $sEntry);
         } else {
             $sEntry = preg_replace('/.+[\r\n]{1,2}.+{{ ENTRY_CONTENT }}.*[\r\n]{1,2}.+[\r\n]{1,2}/', '', $sEntry); // This removes the entire line plus the ones directly before and after.
         }

--- a/src/class/feeds.php
+++ b/src/class/feeds.php
@@ -4,11 +4,11 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-11-09
- * Modified    : 2014-01-15
- * For LOVD    : 3.0-10
+ * Modified    : 2018-04-18
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2014 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -185,13 +185,16 @@ class Feed {
     function formatDate ($t)
     {
         // Formats dates (timestamp or formatted) to the format needed for the Atom format.
-        if (!preg_match('/^[0-9]+$/', $t)) {
+        if (preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\+[0-9]{2}:[0-9]{2}$/', $t)) {
+            // Already looks good.
+            return $t;
+        }
+        if (!ctype_digit($t)) {
             // Not a timestamp, change to timestamp.
             $t = strtotime($t); // Just assume this works.
         }
 
-        $sDate = date('Y-m-d\TH:i:sO', $t);
-        $sDate = substr($sDate, 0, -2) . ':00'; // Needs to be done, because we need +02:00 instead of +0200 (= 'P' in PHP/5.1.3)
+        $sDate = date('c', $t);
         return($sDate);
     }
 

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -75,6 +75,7 @@ $_SERVER['SCRIPT_NAME'] = lovd_cleanDirName(str_replace('\\', '/', $_SERVER['SCR
 // Our output formats: text/html by default.
 $aFormats = array('text/html', 'text/plain'); // Key [0] is default. Other values may not always be allowed. It is checked in the Template class' printHeader() and in Objects::viewList().
 if (lovd_getProjectFile() == '/api.php') {
+    $aFormats[] = 'application/json';
     $aFormats[] = 'text/bed';
 } elseif (lovd_getProjectFile() == '/import.php' && substr($_SERVER['QUERY_STRING'], 0, 25) == 'autoupload_scheduled_file') {
     // Set format to text/plain only when none is requested.


### PR DESCRIPTION
Make the LOVD2-style API return JSON on request.
- Sending the `format=application/json` variable in the `GET` query string will make the API return JSON.
- Also, added created and edited dates for variants to the API.
- Variant API now returns created_by and owned_by fields.
  - JSON will return these as arrays.
  - Atom will return these as authors and contributors.
- Explode variant effects for JSON output.
- When requesting an entry by its ID, the JSON data will not return an array of entries, but just one entry.
  - This is more in line with how the Atom API was returning an Atom entry instead of a feed.
- JSON sends the curators of a gene also in an array.
- JSON dates are also ISO 8601 format.
  - Updated the Atom's Feed class a bit to not always convert dates anymore and simplified some code.
- Let variant positions be handled by MySQL now, no longer PHP code.
  - This allows for multiple variant positions to be shown when using the JSON output.
  - This is useful for LOVD3 instances having multiple transcripts.
- The JSON output will now show all VOT/DNA fields associated with the variant.
  - For that, we needed to collect the transcript IDs as well, only for JSON output.
  - The Atom feed's output has not changed.
- Updated manual.
  - Included the JSON example outputs.
  - Explained differences in output and data returned.
  - Explained how to use it.
  - Fix minor parse errors in the manual. 

Closes #348.