### PR TITLE
Added missing viewlist object required by LOVD_external

### DIFF
--- a/src/ajax/viewlist.php
+++ b/src/ajax/viewlist.php
@@ -85,6 +85,7 @@ if ($sObject == 'Custom_ViewList' && (!isset($sObjectID) || !in_array($sObjectID
                 'VariantOnTranscript,VariantOnGenome', // Gene-specific variant view.
                 'VariantOnTranscriptUnique,VariantOnGenome', // Gene-specific unique variant view.
                 'VariantOnTranscript,VariantOnGenome,Screening,Individual', // Gene-specific full data view.
+                'Transcript,VariantOnTranscript,VariantOnGenome,Screening,Individual',  // Full data view (LOVD_external viewFullData)
                 'Gene,Transcript,DistanceToVar')))) { // Map variant to transcript.
     die(AJAX_DATA_ERROR);
 }


### PR DESCRIPTION
- "Transcript,VariantOnTranscript,VariantOnGenome,Screening,Individual"
is used in LOVD_external but wasn't in the available viewlist objects