### PR TITLE
Fix/confirming variants

### DIFF
--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -1949,7 +1949,7 @@ Using the longest transcript has the advantage of being able to annotate all exo
 As said, LOVD3 allows you to use more than one transcript per gene.
 Good examples that justify using multiple transcripts in LOVD, is when different transcripts are expressed in different tissues,
  when changes in different transcripts cause different phenotypes, or when different research groups focus on different transcripts
- (for example, when no transcript is availabile that contains all exons).
+ (for example, when no transcript is available that contains all exons).
 
 
 

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2018-01-26
- * For LOVD    : 3.0-21
+ * Modified    : 2018-08-09
+ * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -2818,7 +2818,7 @@ FROptions
                                 ' onclick="javascript:window.location.href=this.getAttribute(\'data-href\');"')
                         ) . '>');
                 if ($aOptions['show_options']) {
-                    print("\n" . '          <TD align="center" class="checkbox" onclick="cancelParentEvent(event);"><INPUT id="check_' . $zData['row_id'] . '" class="checkbox" type="checkbox" name="check_' . $zData['row_id'] . '" onclick="lovd_recordCheckChanges(this, \'' . $sViewListID . '\');"' . (in_array($zData['row_id'], $aSessionViewList['checked'])? ' checked' : '') . '></TD>');
+                    print("\n" . '          <TD align="center" class="checkbox" onclick="cancelParentEvent(event);"><INPUT id="check_' . $zData['row_id'] . '" class="checkbox" type="checkbox" name="check_' . $zData['row_id'] . '" onclick="lovd_recordCheckChanges(this, \'' . $sViewListID . '\'); event.stopPropagation();"' . (in_array($zData['row_id'], $aSessionViewList['checked'])? ' checked' : '') . '></TD>');
                 }
                 foreach ($this->aColumnsViewList as $sField => $aCol) {
                     if (in_array($sField, $aOptions['cols_to_skip'])) {

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -648,6 +648,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
     $_GET['search_screeningids'] .= ' !' . $nID;
     require ROOT_PATH . 'class/object_genome_variants.php';
     $_DATA = new LOVD_GenomeVariant();
+    $_DATA->setRowLink('Screenings_' . $nID . '_confirmVariants', 'javascript:$(\'#check_{{ID}}\').trigger(\'click\'); return false;');
     $aVLOptions = array(
         'cols_to_skip' => array('id_', 'chromosome'),
         'track_history' => false,

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -560,14 +560,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
             }
         }
 
-        // Mandatory fields.
-        if (empty($_POST['password'])) {
-            lovd_errorAdd('password', 'Please fill in the \'Enter your password for authorization\' field.');
-        } elseif (!lovd_verifyPassword($_POST['password'], $_AUTH['password'])) {
-            // User had to enter his/her password for authorization.
-            lovd_errorAdd('password', 'Please enter your correct password for authorization.');
-        }
-
         if (!lovd_error()) {
             $_DB->beginTransaction();
 
@@ -664,8 +656,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
     // Array which will make up the form table.
     $aForm = array(
                     array('POST', '', '', '', '0%', '0', '100%'),
-                    array('', '', 'print', 'Enter your password for authorization'),
-                    array('', '', 'password', 'password', 20),
                     array('', '', 'print', '<INPUT type="submit" value="Save variant list" onclick="lovd_AJAX_viewListSubmit(\'Screenings_' . $nID . '_confirmVariants\', function () { $(\'#confirmVariants\').submit(); }); return false;">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<INPUT type="submit" value="Cancel" onclick="window.location.href=\'' . lovd_getInstallURL() . 'variants?create&amp;target=' . $nID . '\'; return false;" style="border : 1px solid #FF4422;">'),
                   );
     lovd_viewForm($aForm);

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2017-11-20
- * For LOVD    : 3.0-21
+ * Modified    : 2018-08-09
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -547,9 +547,11 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
     if (POST) {
         lovd_errorClean();
 
-        // Preventing notices...
         // $_SESSION['viewlists']['Screenings_' . $nID . '_confirmVariants']['checked'] stores the IDs of the variants that are supposed to be present in TABLE_SCR2VAR.
-        if (isset($_SESSION['viewlists']['Screenings_' . $nID . '_confirmVariants']['checked'])) {
+        if (empty($_SESSION['viewlists']['Screenings_' . $nID . '_confirmVariants']['checked'])) {
+            // No variants selected.
+            lovd_errorAdd('', 'Please select at least one variant to confirm.');
+        } else {
             // Check if all checked variants are actually from this individual.
             $aDiff = array_diff($_SESSION['viewlists']['Screenings_' . $nID . '_confirmVariants']['checked'], $aVariantsIndividual);
             if (!empty($aDiff)) {
@@ -587,6 +589,9 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
             $_DB->commit();
             unset($_SESSION['viewlists']['Screenings_' . $nID . '_confirmVariants']);
 
+            // Write to log...
+            lovd_writeLog('Event', LOG_EVENT, 'Updated the list of variants confirmed with screening #' . $nID);
+
             // Get genes which are modified only when linked variant is marked or public.
             $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                   'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
@@ -596,9 +601,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
                 // Change updated date for genes
                 lovd_setUpdatedDate($aGenes);
             }
-
-            // Write to log...
-            lovd_writeLog('Event', LOG_EVENT, 'Updated the list of variants confirmed with screening #' . $nID);
 
             if ($bSubmit) {
                 if (!isset($aSubmit['confirmedVariants'][$nID])) {

--- a/tests/selenium_tests/admin_tests/confirm_variant_to_IVA_individual.php
+++ b/tests/selenium_tests/admin_tests/confirm_variant_to_IVA_individual.php
@@ -53,7 +53,6 @@ class ConfirmVariantToIVAIndividualTest extends LOVDSeleniumWebdriverBaseTestCas
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/screenings\/0000000003[\s\S]confirmVariants$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::id("check_0000000141"));
         $element->click();
-        $this->enterValue(WebDriverBy::xpath("//td/input[@type='password']"), "test1234");
         $element = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Save variant list']"));
         $element->click();
 

--- a/tests/selenium_tests/collaborator_tests/confirm_variant_to_CMT_individual.php
+++ b/tests/selenium_tests/collaborator_tests/confirm_variant_to_CMT_individual.php
@@ -54,7 +54,6 @@ class ConfirmVariantToCMTIndividualTest extends LOVDSeleniumWebdriverBaseTestCas
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/screenings\/0000000002[\s\S]confirmVariants$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::id("check_0000000001"));
         $element->click();
-        $this->enterValue(WebDriverBy::xpath("//td/input[@type='password']"), "test1234");
         $element = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Save variant list']"));
         $element->click();
 

--- a/tests/selenium_tests/curator_tests/confirm_variant_to_CMT_individual.php
+++ b/tests/selenium_tests/curator_tests/confirm_variant_to_CMT_individual.php
@@ -85,7 +85,6 @@ class ConfirmVariantToCMTIndividualTest extends LOVDSeleniumWebdriverBaseTestCas
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/screenings\/0000000002[\s\S]confirmVariants$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::id("check_0000000001"));
         $element->click();
-        $this->enterValue(WebDriverBy::xpath("//td/input[@type='password']"), "test1234");
         $element = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Save variant list']"));
         $element->click();
 

--- a/tests/selenium_tests/manager_tests/confirm_variant_to_CMT_individual.php
+++ b/tests/selenium_tests/manager_tests/confirm_variant_to_CMT_individual.php
@@ -85,7 +85,6 @@ class ConfirmVariantToCMTIndividualTest extends LOVDSeleniumWebdriverBaseTestCas
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/screenings\/0000000002[\s\S]confirmVariants$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::id("check_0000000001"));
         $element->click();
-        $this->enterValue(WebDriverBy::xpath("//td/input[@type='password']"), "test1234");
         $element = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Save variant list']"));
         $element->click();
 

--- a/tests/selenium_tests/submitter_tests/confirm_variant_to_CMT_individual.php
+++ b/tests/selenium_tests/submitter_tests/confirm_variant_to_CMT_individual.php
@@ -54,7 +54,6 @@ class ConfirmVariantToCMTIndividualTest extends LOVDSeleniumWebdriverBaseTestCas
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/screenings\/0000000002[\s\S]confirmVariants$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::id("check_0000000001"));
         $element->click();
-        $this->enterValue(WebDriverBy::xpath("//td/input[@type='password']"), "test1234");
         $element = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Save variant list']"));
         $element->click();
 


### PR DESCRIPTION
Fix issues with confirming variants.
- Fixed bug; When confirming variants with a different screening, but not selecting any variants, a query error occured.
  - The query error was triggered when selecting the genes that needed to get their updated date edited.
  - This query error also prevented the action to be logged.
  - Moved the logging up so any error in that query will never disturb the event logging.
- When confirming variants with another screening, clicking the row no longer forwards to that variant.
  - It now captures the click and switches the row's checkbox.
- Confirming a variant no longer requires a password.
  - Fixed tests that would fail now that the password is no longer requested.

Closes #289.