### PR TITLE
Various small fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,6 @@ notifications:
   email:
    recipients:
       - I.F.A.C.Fokkema@lumc.nl
-      - M.Kroon@lumc.nl
    on_success: never
    ## [always|never|change] # default: change
    on_failure: always

--- a/src/__function_list.txt
+++ b/src/__function_list.txt
@@ -185,11 +185,6 @@
 4.0.0 var_dump
 4.0.0 while
 4.0.2 wordwrap
-4.0.0 xml_get_error_code
-4.0.0 xml_parse_into_struct
-4.0.0 xml_parser_create
-4.0.0 xml_parser_free
-4.0.0 xml_parser_set_option
 
 5.0.0 file() with FILE_IGNORE_NEW_LINES.
 5.0.0 microtime() ondersteunt argument true.

--- a/src/ajax/viewlist.php
+++ b/src/ajax/viewlist.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-02-18
- * Modified    : 2018-01-16
- * For LOVD    : 3.0-21
+ * Modified    : 2018-08-09
+ * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -82,6 +82,7 @@ if ($sObject == 'Custom_ViewList' && (!isset($sObjectID) || !in_array($sObjectID
             array(
                 'VariantOnGenome,Scr2Var,VariantOnTranscript', // Variants on I and S VEs.
                 'Transcript,VariantOnTranscript,VariantOnGenome', // IN_GENE.
+                'Transcript,VariantOnTranscript,VariantOnGenome,Screening,Individual', // LOVD-wide full data view (external viewer).
                 'VariantOnTranscript,VariantOnGenome', // Gene-specific variant view.
                 'VariantOnTranscriptUnique,VariantOnGenome', // Gene-specific unique variant view.
                 'VariantOnTranscript,VariantOnGenome,Screening,Individual', // Gene-specific full data view.

--- a/src/ajax/viewlist.php
+++ b/src/ajax/viewlist.php
@@ -95,6 +95,8 @@ if ($sObject == 'Custom_ViewList' && (!isset($sObjectID) || !in_array($sObjectID
 if ($_AUTH['level'] < LEVEL_MANAGER && (!empty($_AUTH['curates']) || !empty($_AUTH['collaborates']))) {
     if ($sObject == 'Column') {
         lovd_isAuthorized('gene', $_AUTH['curates']); // Any gene will do.
+    } elseif ($sObject == 'Individual' && isset($_REQUEST['search_genes_searched']) && preg_match('/^="([^"]+)"$/', $_REQUEST['search_genes_searched'], $aRegs)) {
+        lovd_isAuthorized('gene', $aRegs[1]); // Authorize for the gene currently searched (it currently restricts the view).
     } elseif ($sObject == 'Transcript' && isset($_REQUEST['search_geneid']) && preg_match('/^="([^"]+)"$/', $_REQUEST['search_geneid'], $aRegs)) {
         lovd_isAuthorized('gene', $aRegs[1]); // Authorize for the gene currently searched (it currently restricts the view).
     } elseif ($sObject == 'Shared_Column' && isset($_REQUEST['object_id'])) {

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2017-12-04
- * For LOVD    : 3.0-21
+ * Modified    : 2018-08-09
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -137,7 +137,6 @@ $aRequired =
                 'PHP_functions' =>
                      array(
                             'mb_detect_encoding',
-                            'xml_parser_create', // We could also look for libxml constants?
                             'openssl_seal',      // We could also look for openssl constants?
                           ),
                 'PHP_classes' =>

--- a/src/install/index.php
+++ b/src/install/index.php
@@ -140,7 +140,7 @@ if ($_GET['step'] == 0 && defined('NOT_INSTALLED')) {
     $bPHP = ($sPHPVers >= $aRequired['PHP']);
     $sPHP = '<IMG src="gfx/mark_' . (int) $bPHP . '.png" alt="" width="11" height="11">&nbsp;PHP : ' . $sPHPVers . ' (' . $aRequired['PHP'] . ' required)';
 
-    // 2012-02-01; 3.0-beta-02; Added check for xml_parser_create(), easily allowing other PHP functions to be checked also.
+    // Check for certain PHP functions from optional libraries, such as mbstring and SSL.
     $bPHPFunctions = true;
     $bPHPClasses = true;
     $sPHPRequirements = '';


### PR DESCRIPTION
Various small fixes.
- Added the external viewer's LOVD-wide full data view.
  - Rights must be added in the ajax/viewlist file.
- Removed remnants of mentions of the XML library that we used to use.
- Prevent bounces by removing Mark's email address, as it's not active anymore.
- Fixed bug; Curators would lose non-public individuals on their gene's Individuals listing when sorting or searching the listing.
  - The authorization wasn't loaded in the ajax script that shows the data.