### PR TITLE
Submission API improvements.

### DIFF
--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -570,6 +570,38 @@ class LOVD_API_Submissions {
                     }
                 }
 
+                // Check for comments to process.
+                if (isset($aVariant['comment'])) {
+                    foreach ($aVariant['comment'] as $aEntries) {
+                        if (!is_array($aEntries)) {
+                            $aEntries = array($aEntries);
+                        }
+                        foreach ($aEntries as $aEntry) {
+                            if (!is_array($aEntry)) {
+                                $aEntry = array($aEntry);
+                            }
+                            foreach ($aEntry as $sEntry) {
+                                // Try to link the Remarks column, if active.
+                                if (!isset($aVOG['VariantOnGenome/Remarks']) && $this->addColumn('VariantOnGenome/Remarks')) {
+                                    $aVOG['VariantOnGenome/Remarks'] = '';
+                                }
+
+                                // Use the Remarks column, but don't overwrite an existing value.
+                                if (isset($aVOG['VariantOnGenome/Remarks'])) {
+                                    $aVOG['VariantOnGenome/Remarks'] .= (!$aVOG['VariantOnGenome/Remarks']? '' : '\r\n') . $sEntry;
+                                } else {
+                                    // There is no fallback. I don't like throwing an error,
+                                    //  but I have to if I don't want data to be lost.
+                                    $this->API->nHTTPStatus = 422; // Send 422 Unprocessable Entity.
+                                    $this->API->aResponse['errors'][] = 'VarioML error: Individual #' . ($nIndividualKey + 1) . ': Variant #' . ($nVariantKey + 1) . ': Comment(s) found, but this LOVD doesn\'t have the Remarks column activated. ' .
+                                        'Remove your comment or ask the admin to enable the variant\'s Remarks column: ' . $_SETT['admin']['address_formatted'] . '.';
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // Build the screening. There can be multiple. We choose to, instead of thinking of something real fancy, to just drop everything in one screening.
                 $aTemplates = array();
                 $aTechniques = array();


### PR DESCRIPTION
Some improvements were needed to the submission API to support more data that our users are currently already submitting.
- Added support for sending dbSNP IDs in the submission API.
- Adding support for literature links for the submission API.
  - db_xref pubmed links can now be passed.
    - If only the ID is given, the author name and publication year is retrieved from pubmed.
    - If only the name is given, it's treated as normal text.
    - If both are given, the ID is used for the link and the name as the label.
  - Added mapping from non-standard "literature" element data to the PubMed link.
  - Prevent notices during writing to file, when columns were added later in the file.
- Added support for `genetic_origin` for the submission API.
  - Genetic origin, its source and evidence codes (the latter two are actually affecting the allele field) are now supported.
  - Had to rename the `@term` key in the value mappings array for clarity.
- Added support for pathogenicity comments.
  - If the Remarks column can not be used (not active in LOVD), an error will be thrown.
- Added support for variant comments.
  - If the Remarks column can not be used (not active in LOVD), an error will be thrown.
- Some final edits.
  - Added all VarioML pathogenicity codes, although some as comments.
  - Removed now implemented FIXMEs.
  - Added debugging code (commented), useful for later development.
  - Added some more VarioML features in comments or FIXMEs.