### PR TITLE
Fix broken HGNC links

### DIFF
--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2018-08-09
+ * Modified    : 2019-01-22
  * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -149,7 +149,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-21',
+                            'version' => '3.0-21b',
                           ),
                 'user_levels' =>
                      array(

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -483,7 +483,7 @@ if (!class_exists('PDO')) {
 } else {
     // PDO available, check if we have the requested database driver.
     if (!in_array($_INI['database']['driver'], PDO::getAvailableDrivers())) {
-        $sDriverName = $aConfigValues['database']['driver']['values'][$_INI['database']['driver']];
+        $sDriverName = $_INI['database']['driver']; // We used to be able to get to the formatted name, but no more.
         lovd_displayError('Init', 'This PHP installation does not have ' . $sDriverName . ' support for PDO installed. Without it, LOVD will not function. Please install ' . $sDriverName . ' support for PHP PDO.');
     }
 }

--- a/src/inc-lib-genes.php
+++ b/src/inc-lib-genes.php
@@ -99,7 +99,7 @@ function lovd_getGeneInfoFromHGNC ($sHgncId, $bRecursion = false)
                     if ($aOutput['response']['numFound'] == 1 && $bRecursion) {
                         // 2014-08-06; 3.0-11; HGNC *again* changed their output, and once again we need to adapt quickly.
                         $nHGNCID = preg_replace('/[^0-9]+/', '', $aOutput['response']['docs'][0]['hgnc_id']);
-                        return lovd_getGeneInfoFromHGNC ($nHGNCID, $bRecursion);
+                        return lovd_getGeneInfoFromHGNC($nHGNCID, $bRecursion);
                     } elseif (function_exists('lovd_errorAdd')) {
                         $sSymbols = '';
                         for ($i = 0; $i < $aOutput['response']['numFound']; $i ++) {
@@ -117,7 +117,7 @@ function lovd_getGeneInfoFromHGNC ($sHgncId, $bRecursion = false)
                             if ($aOutput['response']['numFound'] == 1 && $bRecursion) {
                                 // 2014-08-06; 3.0-11; HGNC *again* changed their output, and once again we need to adapt quickly.
                                 $nHGNCID = preg_replace('/[^0-9]+/', '', $aOutput['response']['docs'][0]['hgnc_id']);
-                                return lovd_getGeneInfoFromHGNC ($nHGNCID, $bRecursion);
+                                return lovd_getGeneInfoFromHGNC($nHGNCID, $bRecursion);
                             } elseif (function_exists('lovd_errorAdd')) {
                                 $sSymbols = '';
                                 for ($i = 0; $i < $aOutput['response']['numFound']; $i ++) {

--- a/src/inc-lib-genes.php
+++ b/src/inc-lib-genes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-01-25
- * Modified    : 2018-03-09
- * For LOVD    : 3.0-21
+ * Modified    : 2019-01-22
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -284,7 +284,7 @@ function lovd_getGeneInfoFromHgncOld ($sHgncId, $aCols, $bRecursion = false)
             $aColumns[] = 'gd_app_name';
         }
     }
-    $aHgncFile = lovd_php_file('http://www.genenames.org/cgi-bin/download?' . $sColumns . 'status_opt=2&where=' . $sWhere . '&order_by=gd_app_sym_sort&limit=&format=text&submit=submit');
+    $aHgncFile = lovd_php_file('https://www.genenames.org/cgi-bin/download/custom?' . $sColumns . 'status=Approved&status=Entry%20Withdrawn&where=' . $sWhere . '&order_by=gd_app_sym_sort&format=text&submit=submit');
 
     // If the HGNC is having database problems, we get an HTML page.
     if (empty($aHgncFile) || stripos(implode($aHgncFile), '<html') !== false) {

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2017-12-04
- * For LOVD    : 3.0-20
+ * Modified    : 2019-01-22
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.NL>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -628,6 +628,9 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                      // Weird, but much simpler... so, oh well. All chromosomes got updated one version, except M.
                      'UPDATE ' . TABLE_CHROMOSOMES . ' SET hg38_id_ncbi = CONCAT(LEFT(hg19_id_ncbi, 10), (TRIM(LEADING "." FROM RIGHT(hg19_id_ncbi, 2))+1)) WHERE name != "M"',
                      'UPDATE ' . TABLE_CHROMOSOMES . ' SET hg38_id_ncbi = hg19_id_ncbi WHERE name = "M"',
+                 ),
+                 '3.0-21b' => array(
+                     'UPDATE ' . TABLE_SOURCES . ' SET url = "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:{{ ID }}" WHERE id = "hgnc"',
                  ),
              );
 

--- a/src/install/inc-sql-sources.php
+++ b/src/install/inc-sql-sources.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-23
- * Modified    : 2017-07-24
- * For LOVD    : 3.0-20
+ * Modified    : 2019-01-22
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -37,7 +37,7 @@ $aSourceSQL =
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("genecards",    "http://www.genecards.org/cgi-bin/carddisp.pl?gene={{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("genetests",    "https://www.ncbi.nlm.nih.gov/gtr/genes/{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("hgmd",         "http://www.hgmd.cf.ac.uk/ac/gene.php?gene={{ ID }}")',
-                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("hgnc",         "http://www.genenames.org/data/hgnc_data.php?hgnc_id={{ ID }}")',
+                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("hgnc",         "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("hpo_disease",  "http://compbio.charite.de/hpoweb/showterm?disease=OMIM:{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("omim",         "http://www.omim.org/entry/{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("pubmed_gene"  ,  "https://www.ncbi.nlm.nih.gov/pubmed?LinkName=gene_pubmed&from_uid={{ ID }}")',


### PR DESCRIPTION
HGNC has updated its website, links are broken.

- Fixed URL to gene pages on HGNC website.
  - Bumped version to 3.0-21b.
- Tested `lovd_getGeneInfoFromHgnc()`, no changes needed.
  - Just applied some coding standards.
- Updated `lovd_getGeneInfoFromHgncOld()` to be compatible with the new HGNC site.
- Fixed bug in PDO installation error reporting.
  - The parsing of INI files was changed recently. Due to this change, the `$aConfigValues` variable was no longer available in `inc-init.php`, so the error message about the selected database not being supported by PDO was not mentioning the selected database type.