### PR TITLE
Fixed some speed issues.

### DIFF
--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2018-04-13
+ * Modified    : 2019-02-08
  * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -258,7 +258,11 @@ class LOVD_GenomeVariant extends LOVD_Custom {
         }
 
         // Do this before running checkFields so that we have time to predict the DBID and fill it in.
-        if (!empty($aData['VariantOnGenome/DNA']) && isset($this->aColumns['VariantOnGenome/DBID']) && ($this->aColumns['VariantOnGenome/DBID']['public_add'] || $_AUTH['level'] >= LEVEL_CURATOR)) {
+        if (!empty($aData['VariantOnGenome/DNA']) // DNA filled in.
+            && isset($this->aColumns['VariantOnGenome/DBID']) // DBID column active.
+            && ($this->aColumns['VariantOnGenome/DBID']['public_add'] || $_AUTH['level'] >= LEVEL_CURATOR) // Submitters are allowed to fill it in, or you're curator or up.
+            && !(lovd_getProjectFile() == '/import.php' && isset($zData['VariantOnGenome/DBID']) && $aData['VariantOnGenome/DBID'] == $zData['VariantOnGenome/DBID']) // And we're not updating without touching the DBID.
+            ) {
             // VOGs with at least one VOT, which still have a chr* DBID, will get an error. So we'll empty the DBID field, allowing the new VOT value to be autofilled in.
             if (!empty($aData['aTranscripts']) && !empty($aData['VariantOnGenome/DBID']) && strpos($aData['VariantOnGenome/DBID'], 'chr' . $aData['chromosome'] . '_') !== false) {
                 $aData['VariantOnGenome/DBID'] = '';

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -4,13 +4,13 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-27
- * Modified    : 2018-01-17
- * For LOVD    : 3.0-21
+ * Modified    : 2019-02-07
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
- *               Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -348,7 +348,7 @@ class LOVD_Template {
 
         }
         print('  Powered by <A href="' . $_SETT['upstream_URL'] . $_STAT['tree'] . '/" target="_blank">LOVD v.' . $_STAT['tree'] . '</A> Build ' . $_STAT['build'] . '<BR>' . "\n" .
-              '  LOVD software &copy;2004-2018 <A href="http://www.lumc.nl/" target="_blank">Leiden University Medical Center</A>' . "\n");
+              '  LOVD software &copy;2004-2019 <A href="http://www.lumc.nl/" target="_blank">Leiden University Medical Center</A>' . "\n");
 ?>
     </TD>
     <TD width="42" align="right">

--- a/src/diseases.php
+++ b/src/diseases.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-07-27
- * Modified    : 2017-11-20
- * For LOVD    : 3.0-21
+ * Modified    : 2019-02-08
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -126,7 +126,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     lovd_showJGNavigation($aNavigation, 'Diseases');
 
     if ($zData['individuals']) {
-        $_GET['search_diseaseids'] = $nID;
+        $_GET['search_diseaseids_searched'] = $nID;
         print('<BR><BR>' . "\n\n");
         $_T->printTitle('Individuals', 'H4');
         require ROOT_PATH . 'class/object_individuals.php';

--- a/src/docs/index.php
+++ b/src/docs/index.php
@@ -46,7 +46,7 @@ if (PATH_COUNT == 1 && !ACTION) {
 
     print('      The LOVD 3.0 documentation is continuously being updated.<BR>Currently available is the LOVD 3.0 user manual, in PDF and HTML formats.<BR>' .
           '      <UL>' . "\n" .
-          '        <LI>LOVD manual 3.0-17 (<A href="docs/LOVD_manual_3.0.pdf" target="_blank"><B>PDF</B>, 82 pages, 1.4Mb</A>) (<A href="docs/manual.html" target="_blank"><B>HTML</B>, single file, 4.5Mb</A>) - last updated August 31st 2016</LI></UL>' . "\n\n");
+          '        <LI>LOVD manual 3.0-21 (<A href="docs/LOVD_manual_3.0.pdf" target="_blank"><B>PDF</B>, 85 pages, 1.5Mb</A>) (<A href="docs/manual.html" target="_blank"><B>HTML</B>, single file, 4.5Mb</A>) - last updated February 27th 2018</LI></UL>' . "\n\n");
 
     $_T->printFooter();
     exit;


### PR DESCRIPTION
Fixed some speed issues.
- Don't run the DBID checks like `lovd_checkDBID()` anymore, when running an update import that doesn't even touch the DBID.
  - Even just updating variant effects in a big file took forever.
- Speed up the Individuals VL on the Diseases VE.
  - It was doing a `HAVING` on the concatted Disease IDs. This is slow in large JOINs.
  - Created an optional, additional JOIN that is only used for searching on the Disease ID without limiting the list of Diseases shown.
  - On the shared, this decreases the query time from 6 seconds to 0 seconds.
- Copyright date bump to 2019.
- Updated docs stats.