### PR TITLE
Fix username field to also allow for email address.

### DIFF
--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2017-10-26
- * For LOVD    : 3.0-21
+ * Modified    : 2019-02-13
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -240,8 +240,8 @@ class LOVD_User extends LOVD_Object {
 
         if (lovd_getProjectFile() == '/install/index.php' || ACTION == 'create') {
             // Check username format.
-            if ($aData['username'] && !lovd_matchUsername($aData['username'])) {
-                lovd_errorAdd('username', 'Please fill in a correct username; 4 to 20 characters and starting with a letter followed by letters, numbers, dots, underscores and dashes only.');
+            if ($aData['username'] && !lovd_matchUsername($aData['username']) && !lovd_matchEmail($aData['username'])) {
+                lovd_errorAdd('username', 'Please fill in a correct username; 4 to 20 characters and starting with a letter followed by letters, numbers, dots, underscores and dashes only. An email address is also allowed.');
             }
         }
 

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2019-01-22
+ * Modified    : 2019-02-13
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -149,7 +149,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-21b',
+                            'version' => '3.0-21c',
                           ),
                 'user_levels' =>
                      array(

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2019-01-22
+ * Modified    : 2019-02-13
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -631,6 +631,13 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                  ),
                  '3.0-21b' => array(
                      'UPDATE ' . TABLE_SOURCES . ' SET url = "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:{{ ID }}" WHERE id = "hgnc"',
+                 ),
+                 '3.0-21c' => array(
+                     'SET @bExists := (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = "' . TABLE_USERS . '" AND COLUMN_NAME = "username" AND CHARACTER_MAXIMUM_LENGTH < 50)',
+                     'SET @sSQL := IF(@bExists < 1, \'SELECT "INFO: Column not found or already enlarged."\', "
+                            ALTER TABLE ' . TABLE_USERS . ' MODIFY COLUMN username VARCHAR(50) NOT NULL")',
+                     'PREPARE Statement FROM @sSQL',
+                     'EXECUTE Statement',
                  ),
              );
 

--- a/src/install/inc-sql-tables.php
+++ b/src/install/inc-sql-tables.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-22
- * Modified    : 2017-12-01
- * For LOVD    : 3.0-21
+ * Modified    : 2019-02-13
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -75,7 +75,7 @@ $aTableSQL =
     email TEXT NOT NULL,
     email_confirmed BOOLEAN NOT NULL DEFAULT 0,
     reference VARCHAR(50) NOT NULL DEFAULT "",
-    username VARCHAR(20) NOT NULL,
+    username VARCHAR(50) NOT NULL,
     password CHAR(50) NOT NULL,
     password_autogen CHAR(50),
     password_force_change BOOLEAN NOT NULL DEFAULT 0,


### PR DESCRIPTION
Fix username field to also allow for email address.
- Enlarged the username field to 50 characters.
  - When the username field is not smaller than 50 characters, it will not be touched.
- Allow also an email address as a username.
- Version bump to 3.0-21c.