### PR TITLE
Multiple bug fixes.

### DIFF
--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2019-07-24
+ * Modified    : 2019-07-25
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2592,7 +2592,7 @@ class LOVD_Object {
         // FIXME; this is a temporary hack just to get the genes?authorize working when all users have been selected.
         //   There is no longer a viewList when all users have been selected, but we need one for the JS execution.
         //   Possibly, this code can be standardized a bit and, if necessary for other viewLists as well, can be kept here.
-        if (!$nTotal && !$bSearched && (($this->sObject == 'User' && !empty($_GET['search_id'])))) {
+        if (!$nTotal && !$bSearched && (($this->sObject == 'User' && !empty($_GET['search_userid'])))) {
             // FIXME; Maybe check for JS contents of the rowlink?
             // There has been searched, but apparently the ID column is forced hidden. This must be the authorize page.
             $bSearched = true; // This will trigger the creation of the viewList table.

--- a/src/download.php
+++ b/src/download.php
@@ -392,6 +392,16 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
                         'edited_date',
                     )
                 );
+                $aObjects['Phenotypes']['hide_columns'] = array_merge(
+                    $aObjects['Phenotypes']['hide_columns'],
+                    array(
+                        'statusid',
+                        'created_by',
+                        'created_date',
+                        'edited_by',
+                        'edited_date',
+                    )
+                );
                 $aObjects['Variants']['hide_columns'] = array_merge(
                     $aObjects['Variants']['hide_columns'],
                     array(

--- a/src/download.php
+++ b/src/download.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2017-06-15
- * For LOVD    : 3.0-19
+ * Modified    : 2019-07-25
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -382,6 +382,27 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
                 $aObjects['Phenotypes']['filters']['statusid'] = array(STATUS_MARKED, STATUS_OK);
 
                 // Hide non-public columns.
+                $aObjects['Individuals']['hide_columns'] = array_merge(
+                    $aObjects['Individuals']['hide_columns'],
+                    array(
+                        'statusid',
+                        'created_by',
+                        'created_date',
+                        'edited_by',
+                        'edited_date',
+                    )
+                );
+                $aObjects['Variants']['hide_columns'] = array_merge(
+                    $aObjects['Variants']['hide_columns'],
+                    array(
+                        'mapping_flags',
+                        'statusid',
+                        'created_by',
+                        'created_date',
+                        'edited_by',
+                        'edited_date',
+                    )
+                );
                 $aObjectTranslations = array(
                     'VariantOnTranscript' => 'Variants_On_Transcripts',
                     'VariantOnGenome' => 'Variants',
@@ -601,9 +622,12 @@ foreach ($aObjects as $sObject => $aSettings) {
         $aColumns = array_keys($aSettings['data'][0]);
     }
 
+    // in_array() is really quite slow, especially with large arrays. Flipping the array will speed things up.
+    $aSettings['hide_columns'] = array_flip($aSettings['hide_columns']);
+
     // Print headers.
     foreach ($aColumns as $key => $sCol) {
-        if (!in_array($sCol, $aSettings['hide_columns'])) {
+        if (!isset($aSettings['hide_columns'][$sCol])) {
             print((!$key? '' : "\t") . '"{{' . $sCol . '}}"');
         }
     }
@@ -615,7 +639,7 @@ foreach ($aObjects as $sObject => $aSettings) {
         $z = array_map('addslashes', $z);
 
         foreach ($aColumns as $key => $sCol) {
-            if (!in_array($sCol, $aSettings['hide_columns'])) {
+            if (!isset($aSettings['hide_columns'][$sCol])) {
                 // Replace line endings and tabs (they should not be there but oh well), so they don't cause problems with importing.
                 print(($key? "\t" : '') . '"' . str_replace(array("\r\n", "\r", "\n", "\t"), array('\r\n', '\r', '\n', '\t'), $z[$sCol]) . '"');
             }

--- a/src/genes.php
+++ b/src/genes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2018-01-19
- * For LOVD    : 3.0-21
+ * Modified    : 2019-07-25
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -1695,15 +1695,15 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
         lovd_showInfoTable('The following users are currently not a curator for this gene. Click on a user to select him/her as Curator or Collaborator.', 'information');
         if ($aCurators) {
             // Create search string that hides the users currently selected to be curator or collaborator.
-            $_GET['search_id'] = '!' . implode(' !', array_keys($aCurators));
+            $_GET['search_userid'] = '!' . implode(' !', array_keys($aCurators));
         } else {
             // We must have something non-empty here, otherwise the JS fails when selecting users.
-            $_GET['search_id'] = '!0';
+            $_GET['search_userid'] = '!0';
         }
         $_GET['page_size'] = 10;
         $_DATA->setRowLink('Genes_AuthorizeUser', 'javascript:lovd_passAndRemoveViewListRow("{{ViewListID}}", "{{ID}}", {id: "{{ID}}", name: "{{zData_name}}", level: "{{zData_level}}"}, lovd_authorizeUser); return false;');
         $aVLOptions = array(
-            'cols_to_skip' => array('id', 'status_', 'last_login_', 'created_date_'),
+            'cols_to_skip' => array('orcid_id_', 'status_', 'last_login_', 'created_date_'),
             'track_history' => false,
         );
         $_DATA->viewList('Genes_AuthorizeUser', $aVLOptions); // Create known viewListID for lovd_unauthorizeUser().
@@ -1778,7 +1778,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
             objUsers = document.getElementById('curator_list');
             oLI = document.createElement('LI');
             oLI.id = 'li_' + aData.id;
-            oLI.innerHTML = '<INPUT type="hidden" name="curators[]" value="' + aData.id + '"><TABLE width="100%"><TR><TD class="handle" width="13" align="center"><IMG src="gfx/drag_vertical.png" alt="" title="Click and drag to sort" width="5" height="13"></TD><TD>' + aData.name + '</TD><TD width="100" align="right"><INPUT type="checkbox" name="allow_edit[]" value="' + aData.id + '" onchange="if (this.checked == true) { this.parentNode.nextSibling.children[0].disabled = false; } else if (' + aData.level + ' >= <?php echo LEVEL_MANAGER; ?>) { this.checked = true; } else { this.parentNode.nextSibling.children[0].checked = false; this.parentNode.nextSibling.children[0].disabled = true; }" checked></TD><TD width="75" align="right"><INPUT type="checkbox" name="shown[]" value="' + aData.id + '" checked></TD><TD width="30" align="right"><A href="#" onclick="lovd_unauthorizeUser(\'Genes_AuthorizeUser\', \'' + aData.id + '\'); return false;"><IMG src="gfx/mark_0.png" alt="Remove" width="11" height="11" border="0"></A></TD></TR></TABLE>';
+            oLI.innerHTML = '<INPUT type="hidden" name="curators[]" value="' + aData.id + '"><TABLE width="100%"><TR><TD class="handle" width="13" align="center"><IMG src="gfx/drag_vertical.png" alt="" title="Click and drag to sort" width="5" height="13"></TD><TD>' + aData.name + ' (#' + aData.id + ')</TD><TD width="100" align="right"><INPUT type="checkbox" name="allow_edit[]" value="' + aData.id + '" onchange="if (this.checked == true) { this.parentNode.nextSibling.children[0].disabled = false; } else if (' + aData.level + ' >= <?php echo LEVEL_MANAGER; ?>) { this.checked = true; } else { this.parentNode.nextSibling.children[0].checked = false; this.parentNode.nextSibling.children[0].disabled = true; }" checked></TD><TD width="75" align="right"><INPUT type="checkbox" name="shown[]" value="' + aData.id + '" checked></TD><TD width="30" align="right"><A href="#" onclick="lovd_unauthorizeUser(\'Genes_AuthorizeUser\', \'' + aData.id + '\'); return false;"><IMG src="gfx/mark_0.png" alt="Remove" width="11" height="11" border="0"></A></TD></TR></TABLE>';
             objUsers.appendChild(oLI);
 
             return true;
@@ -1796,7 +1796,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
 
             // Reset the viewList.
             // Does an ltrim, too. But trim() doesn't work in IE < 9.
-            objViewListF.search_id.value = objViewListF.search_id.value.replace('!' + nID, '').replace('  ', ' ').replace(/^\s*/, '');
+            objViewListF.search_userid.value = objViewListF.search_userid.value.replace('!' + nID, '').replace('  ', ' ').replace(/^\s*/, '');
             lovd_AJAX_viewListSubmit(sViewListID);
 
             return true;

--- a/src/inc-js-viewlist.php
+++ b/src/inc-js-viewlist.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-29
- * Modified    : 2017-11-15
- * For LOVD    : 3.0-21
+ * Modified    : 2019-07-25
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -941,13 +941,15 @@ function lovd_passAndRemoveViewListRow (sViewListID, sRowID, aRowData, callback)
     // removed from the ViewList and the ViewList will be updated (extending the
     // view to the original number of rows and making sure the deleted item will
     // not re-occur).
+    // FIXME: This function is using search_id which is usually shown, so that's a pretty bad idea. It should have been
+    //  made configurable. Will not fix this now, will just override it to search_userid, as it's only used for users.
 
     var oViewListForm = $('#viewlistForm_' + sViewListID).get(0);
 
     // Change the search terms in the ViewList such that submitting it will not reshow this item.
-    oViewListForm.search_id.value += ' !' + sRowID;
+    oViewListForm.search_userid.value += ' !' + sRowID;
     // Does an ltrim, too. But trim() doesn't work in IE < 9.
-    oViewListForm.search_id.value = oViewListForm.search_id.value.replace(/^\s*/, '');
+    oViewListForm.search_userid.value = oViewListForm.search_userid.value.replace(/^\s*/, '');
 
     lovd_AJAX_viewListHideRow(sViewListID, sRowID);
     oViewListForm.total.value --;

--- a/src/inc-lib-users.php
+++ b/src/inc-lib-users.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-04-21
- * Modified    : 2017-09-08
- * For LOVD    : 3.0-20
+ * Modified    : 2019-07-25
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2014-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2014-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
@@ -259,7 +259,7 @@ function lovd_removeUserShareAccess (sViewListID, nID)
 
     // Reset the viewList.
     // Does an ltrim, too. But trim() doesn't work in IE < 9.
-    objViewListF.search_id.value = objViewListF.search_id.value.replace('!' + nID, '').replace('  ', ' ').replace(/^\s*/, '');
+    objViewListF.search_userid.value = objViewListF.search_userid.value.replace('!' + nID, '').replace('  ', ' ').replace(/^\s*/, '');
     lovd_AJAX_viewListSubmit(sViewListID);
 
     return true;

--- a/src/transcripts.php
+++ b/src/transcripts.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2017-11-20
- * For LOVD    : 3.0-21
+ * Modified    : 2019-07-25
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -167,34 +167,28 @@ if (ACTION == 'create') {
 
         $_T->printHeader();
         $_T->printTitle();
-        require ROOT_PATH . 'inc-lib-form.php';
 
-        print('      Please select the gene on which you wish to add a transcript.<BR>' . "\n" .
-              '      <BR>' . "\n\n" .
-              '      <FORM name="transcriptsCreate" method="post" onsubmit="window.location = \'' . $_PE[0] . '/\' + this.geneSymbol.options[this.geneSymbol.selectedIndex].value + \'?' . ACTION . '\'; return false;">' . "\n" .
-              '        <TABLE border="0" cellpadding="0" cellspacing="1" width="760">');
-
-        if ($_AUTH['level'] >= LEVEL_MANAGER) {
-            $sSQL = 'SELECT id, CONCAT(id, " (", name, ")") AS name FROM ' . TABLE_GENES . ' ORDER BY id';
-            $aSQL = array();
-        } else {
-            $sSQL = 'SELECT g.id, CONCAT(g.id, " (", g.name, ")") AS name FROM ' . TABLE_GENES . ' AS g LEFT JOIN ' . TABLE_CURATES . ' AS cu ON (cu.geneid = g.id) WHERE cu.userid = ? AND allow_edit = 1 ORDER BY g.id';
-            $aSQL = array($_AUTH['id']);
+        // Show a VL of genes instead of a dropdown.
+        $sViewListID = 'Genes_for_createTranscript';
+        require ROOT_PATH . 'class/object_genes.php';
+        $_GET['page_size'] = 25;
+        // For curators, select only the genes they are curator for. That is, if the list is not too big.
+        if ($_AUTH['level'] == LEVEL_CURATOR && count($_AUTH['curates']) <= 25) {
+            $_GET['search_geneid'] = '="' . implode('"|="', $_AUTH['curates']) . '"';
         }
-
-        $aSelectGene = $_DB->query($sSQL, $aSQL)->fetchAllCombine();
-
         // Select currently selected gene, if any.
-        $_POST['geneSymbol'] = $_SESSION['currdb'];
-
-        // Array which will make up the form table.
-        $aFormData = array(
-                            array('POST', '', '', '', '20%', '14', '80%'),
-                            array('Gene', '', 'select', 'geneSymbol', 1, $aSelectGene, false, false, false),
-                            array('', '', 'submit', 'Continue &raquo;'),
-                          );
-        lovd_viewForm($aFormData);
-        print('</TABLE></FORM>' . "\n\n");
+        // But only if we're managers or if this is a curator that is curator of the currently selected gene.
+        if ($_SESSION['currdb'] && ($_AUTH['level'] >= LEVEL_MANAGER
+                || (isset($_AUTH['curates']) && in_array($_SESSION['currdb'], $_AUTH['curates'])))) {
+            $_GET['search_id_'] = '="' . $_SESSION['currdb'] . '"';
+        }
+        $_DATA = new LOVD_Gene();
+        $_DATA->setRowLink($sViewListID, $_PE[0] . '/' . $_DATA->sRowID . '?create');
+        lovd_showInfoTable('Please select the gene to which you wish to add a new transcript. <B>Click on the gene to proceed.</B>', 'information', 600);
+        $aVLOptions = array(
+            'cols_to_skip' => array('variants', 'uniq_variants', 'updated_date_', 'diseases_'),
+        );
+        $_DATA->viewList($sViewListID, $aVLOptions);
 
         $_T->printFooter();
         exit;


### PR DESCRIPTION
Multiple bug fixes.
- Fixed bug; The mapper didn't fill in the VOT's effectid, but left it at its default.
  - Now, it'll take the VOG's effectid and it'll copy it.
- The public gene-specific downloads had some non-public columns included, like status, created_by, created_date, etc.
  - These are now removed. They're not damaging to be shared, but they're not shown on VLs or VEs, so they should remain hidden in the download as well.
- A download will now no longer show inactive Phenotype and VOT columns, if filters are active for Diseases or Genes, respectively.
  - This cleans up the file a lot for single-gene downloads.
  - It reports a warning for Phenotype data, since it's possible that data is selected unrelated to the selected Disease(s).
- When creating a transcript without selecting a gene first, LOVD no longer uses a dropdown but a VL.
  - The dropdown became too large on large databases.
  - The VL is much better equipped to handle large datasets.
  - The output is restricted for curators in case they curate 25 genes or less.
  - The currently selected gene is highlighted.
- Cleaned up the genes?authorize and the users?share_access.
  - Selected user's IDs where stored in both userid and id. Since the latter is visible, part of this selection could be influenced. Now only userid is used, making the filtering of the VL complete invisible to the user.
  - Also, when selecting users as curators/collaborators, their ID wasn't added to their name, like with previously selected users.