### PR TITLE
Several fixes in the security of ViewLists.

### DIFF
--- a/src/ajax/viewlist.php
+++ b/src/ajax/viewlist.php
@@ -141,7 +141,18 @@ $aColsToSkip = (!empty($_REQUEST['skip'])? $_REQUEST['skip'] : array());
 //  about users than the info the access sharing page gives them.
 if ($sObject == 'User' && $_AUTH['level'] < LEVEL_MANAGER) {
     // Force removal of certain columns, regardless of this has been requested or not.
-    $aColsToSkip = array_unique(array_merge($aColsToSkip, array('username', 'status_', 'last_login_', 'created_date_', 'curates', 'level_')));
+    // We cannot trust this was set in $_SESSION already since the VL can be loaded independently.
+    $aColsToSkip = array_unique(
+        array_merge(
+            $aColsToSkip,
+            array(
+                'username',
+                'status_',
+                'last_login_',
+                'created_date_',
+                'curates',
+                'level_'
+            )));
 }
 
 // Managers, and sometimes curators, are allowed to download lists...
@@ -221,7 +232,12 @@ if (POST && ACTION == 'applyFR') {
 // Parameters are assumed to be in $_SESSION, only cols_to_skip can be overridden. This is for the external viewer.
 $aOptions = array();
 if ($aColsToSkip) {
-    $aOptions['cols_to_skip'] = $aColsToSkip;
+    // Don't let the requested list of columns overwrite the original one. Only additional columns may be hidden.
+    $aOptions['cols_to_skip'] = array_unique(array_merge(
+        (!isset($_SESSION['viewlists'][$_GET['viewlistid']]['options']['cols_to_skip'])? array()
+            : $_SESSION['viewlists'][$_GET['viewlistid']]['options']['cols_to_skip']),
+        $aColsToSkip
+    ));
 }
 $_DATA->viewList($_GET['viewlistid'], $aOptions);
 ?>

--- a/src/ajax/viewlist.php
+++ b/src/ajax/viewlist.php
@@ -105,11 +105,15 @@ if ($_AUTH['level'] < LEVEL_MANAGER && (!empty($_AUTH['curates']) || !empty($_AU
         $_GET['search_geneid'] = $_REQUEST['search_geneid'];
     } elseif ($sObject == 'Shared_Column' && isset($_REQUEST['object_id'])) {
         lovd_isAuthorized('gene', $sObjectID); // Authorize for the gene currently loaded.
+    } elseif ($sObject == 'Screening' && $sViewListID == 'Screenings_for_I_VE' && isset($_REQUEST['search_individualid']) && ctype_digit($_REQUEST['search_individualid'])) {
+        // Screenings_for_I_VE has no ID but authorizes on search_individualid.
+        lovd_isAuthorized('individual', $_REQUEST['search_individualid']); // Authorize for the Screening(s) currently searched (it restricts the view).
+        // Since we're authorizing on $_REQUEST which also contains $_POST data, make sure the $_GET (what we actually filter on) matches what we authorize on!!!
+        $_GET['search_individualid'] = $_REQUEST['search_individualid'];
     } elseif ($sObject == 'Custom_ViewList') {
         // 2013-06-28; 3.0-06; We can't just authorize users based on the given ID without actually checking the shown objects and checking if the search results are actually limited or not.
         // CustomVL_IN_GENE has no ID and does not require authorization (only public VOGs loaded).
 
-var_dump($_REQUEST['id']);
         if (!empty($_REQUEST['id'])) {
             // CustomVL_VOT_VOG_<<GENE>> is restricted per gene in the object argument, and search_transcriptid should contain a transcript ID that matches.
             // CustomVL_VIEW_<<GENE>> is restricted per gene in the object argument, and search_transcriptid should contain a transcript ID that matches.

--- a/src/ajax/viewlist.php
+++ b/src/ajax/viewlist.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-02-18
- * Modified    : 2018-08-09
+ * Modified    : 2018-08-22
  * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -97,8 +97,12 @@ if ($_AUTH['level'] < LEVEL_MANAGER && (!empty($_AUTH['curates']) || !empty($_AU
         lovd_isAuthorized('gene', $_AUTH['curates']); // Any gene will do.
     } elseif ($sObject == 'Individual' && isset($_REQUEST['search_genes_searched']) && preg_match('/^="([^"]+)"$/', $_REQUEST['search_genes_searched'], $aRegs)) {
         lovd_isAuthorized('gene', $aRegs[1]); // Authorize for the gene currently searched (it currently restricts the view).
+        // Since we're authorizing on $_REQUEST which also contains $_POST data, make sure the $_GET (what we actually filter on) matches what we authorize on!!!
+        $_GET['search_genes_searched'] = $_REQUEST['search_genes_searched'];
     } elseif ($sObject == 'Transcript' && isset($_REQUEST['search_geneid']) && preg_match('/^="([^"]+)"$/', $_REQUEST['search_geneid'], $aRegs)) {
         lovd_isAuthorized('gene', $aRegs[1]); // Authorize for the gene currently searched (it currently restricts the view).
+        // Since we're authorizing on $_REQUEST which also contains $_POST data, make sure the $_GET (what we actually filter on) matches what we authorize on!!!
+        $_GET['search_geneid'] = $_REQUEST['search_geneid'];
     } elseif ($sObject == 'Shared_Column' && isset($_REQUEST['object_id'])) {
         lovd_isAuthorized('gene', $sObjectID); // Authorize for the gene currently loaded.
     } elseif ($sObject == 'Custom_ViewList' && isset($_REQUEST['id'])) {
@@ -109,7 +113,13 @@ if ($_AUTH['level'] < LEVEL_MANAGER && (!empty($_AUTH['curates']) || !empty($_AU
 
         // CustomVL_VOT_VOG_<<GENE>> is restricted per gene in the object argument, and search_transcriptid should contain a transcript ID that matches.
         // CustomVL_VIEW_<<GENE>> is restricted per gene in the object argument, and search_transcriptid should contain a transcript ID that matches.
-        if (in_array($sObjectID, array('VariantOnTranscript,VariantOnGenome', 'VariantOnTranscriptUnique,VariantOnGenome', 'VariantOnTranscript,VariantOnGenome,Screening,Individual')) && (!isset($_REQUEST['search_transcriptid']) || !$_DB->query('SELECT COUNT(*) FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ? AND geneid = ?', array($_REQUEST['search_transcriptid'], $_REQUEST['id']))->fetchColumn())) {
+        if (in_array($sObjectID,
+            array(
+                'VariantOnTranscript,VariantOnGenome',
+                'VariantOnTranscriptUnique,VariantOnGenome',
+                'VariantOnTranscript,VariantOnGenome,Screening,Individual'
+            )) && (!isset($_REQUEST['search_transcriptid'])
+                || !$_DB->query('SELECT COUNT(*) FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ? AND geneid = ?', array($_REQUEST['search_transcriptid'], $_REQUEST['id']))->fetchColumn())) {
             die(AJAX_NO_AUTH);
         }
         lovd_isAuthorized('gene', $nID); // Authorize for the gene currently loaded.

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2018-04-13
- * For LOVD    : 3.0-21
+ * Modified    : 2019-08-22
+ * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -62,8 +62,8 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
         }
     }
 
-    // Managers are allowed to download this list...
-    if ($_AUTH['level'] >= LEVEL_MANAGER) {
+    // Managers and authorized curators are allowed to download this list...
+    if ($_AUTH['level'] >= LEVEL_CURATOR) {
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
@@ -81,7 +81,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
     $_DATA = new LOVD_Individual();
     $aVLOptions = array(
         'cols_to_skip' => $aColsToHide,
-        'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+        'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
         'find_and_replace' => true,
     );
     $_DATA->viewList('Individuals', $aVLOptions);
@@ -168,7 +168,9 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
             'cols_to_skip' => array('screeningid', 'individualid', 'created_date', 'edited_date'),
             'track_history' => false,
             'show_navigation' => false,
+            'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
         );
+        // This ViewList ID is checked in ajax/viewlist.php. Don't just change it.
         $_DATA->viewList('Screenings_for_I_VE', $aScreeningVLOptions);
         unset($_GET['search_individualid']);
 
@@ -180,7 +182,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         // VOG needs to be first, so it groups by the VOG ID.
         $_DATA = new LOVD_CustomViewList(array('VariantOnGenome', 'Scr2Var', 'VariantOnTranscript'));
         $aVariantVLOptions = array(
-            'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+            'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
         );
         $_DATA->viewList('CustomVL_VOT_for_I_VE', $aVariantVLOptions);
     }

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2019-08-07
+ * Modified    : 2019-08-22
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -144,7 +144,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         $_DATA = new LOVD_CustomViewList(array('VariantOnGenome', 'Scr2Var', 'VariantOnTranscript'));
         $aVLOptions = array(
             'cols_to_skip' => array('transcriptid'),
-            'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+            'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
         );
         $_DATA->viewList('CustomVL_VOT_for_S_VE', $aVLOptions);
     }


### PR DESCRIPTION
Several fixes in the security of ViewLists.
- Fixed security issue in loading the authorization for ViewLists.
  - During Find & Replace implementation, the code was changed to load the gene-specific authorization using `$_REQUEST` rather than `$_GET`. However, the filtering of the results was still using `$_GET`. Hence, authorizations can be loaded forging a `$_POST` request while not necessarily filtering the results using `$_GET`.
  - This allowed Curators to craft special requests to load VLs with non-public data of other genes.
  - Solved this by enforcing filtering when authorizing Curators.
- Made it a bit harder for ViewLists to get their ColsToSkip overridden.
  - Hiding columns for a VL is stored in session upon defining the VL. However, VLs can be loaded independently of being defined first, for the External Viewer.
  - To allow for the External Viewer to hide columns, VLs could be told to hide additional columns. However, this was overwriting the current list of hidden columns, allowing special requests that would columns previously hidden.
  - For the Users VL, which was opened up to Submitters due to the Colleagues feature, overwriting the ColsToSkip was prevented in the VL code specifically, to hide sensitive data.
  - Added a global solution that makes sure for other VLs the list doesn't get overwritten either, but merged instead. This prevents pre-defined VLs to lose their ColsToSkip using specially crafted requests.
  - However, as the External Viewer just loads undefined VLs, it can be configured to show all columns in these VLs. As such, if the ColsToSkip feature is ever used to hide sensitive data, these columns need to be defined in the VL code itself.
- Fixed bug; Variant ViewLists on Individual and Screening VEs were authorized for Curators, but the Ajax-VL wasn't.
  - This means Curators can't search for non-public variants on the VL on either of these VEs.
  - Now it loads the needed authorization.
- Fixed bug; Screening ViewList on Individual VE was authorized for Curators, but the Ajax-VL wasn't.
  - This means Curators couldn't search for non-public Screenings on the VL on this VE.
  - Now it loads the needed authorization.
- Allow Curators to also download more ViewLists.
  - Allow Curators to download the gene-specific Individuals view.
  - Now that we have code authorizing Curators for VLs on the Individual's VE, let Curators download the Screening and Variant VLs there.
  - Now that we have code authorizing Curators for the Variants VL on the Screenings VE, let Curators download it.