### PR TITLE
Some fixes to the objects.

### DIFF
--- a/src/class/PDO.php
+++ b/src/class/PDO.php
@@ -38,7 +38,8 @@ if (!defined('ROOT_PATH')) {
 
 
 
-class LOVD_PDO extends PDO {
+class LOVD_PDO extends PDO
+{
     // This class provides a wrapper around PDO such that database errors are handled automatically by LOVD.
     // FIXME; lovd_queryDB() provided a $bDebug argument. How to implement that now?
     private $aLastError = array();

--- a/src/class/api.php
+++ b/src/class/api.php
@@ -7,7 +7,7 @@
  * Modified    : 2016-12-09
  * For LOVD    : 3.0-18
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -35,7 +35,8 @@ if (!defined('ROOT_PATH')) {
 
 
 
-class LOVD_API {
+class LOVD_API
+{
     // This class defines the LOVD API object, handling URL parsing and general
     //  handling of headers.
 

--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -35,7 +35,8 @@ if (!defined('ROOT_PATH')) {
 
 
 
-class LOVD_API_Submissions {
+class LOVD_API_Submissions
+{
     // This class defines the LOVD API object handling submissions.
 
     private $API;                     // The API object.

--- a/src/class/feeds.php
+++ b/src/class/feeds.php
@@ -7,7 +7,7 @@
  * Modified    : 2018-04-18
  * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -35,7 +35,8 @@ if (!defined('ROOT_PATH')) {
 
 
 
-class Feed {
+class Feed
+{
     // Some member variables.
     private $sAtomFeed = '<?xml version="1.0" encoding="UTF-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">

--- a/src/class/graphs.php
+++ b/src/class/graphs.php
@@ -39,7 +39,8 @@ if (!defined('ROOT_PATH')) {
 
 
 
-class LOVD_Graphs {
+class LOVD_Graphs
+{
     // This class provides different methods for graphs implemented using Flot, a JS graph library with jQuery handlers.
 
 

--- a/src/class/object_announcements.php
+++ b/src/class/object_announcements.php
@@ -7,7 +7,7 @@
  * Modified    : 2017-10-26
  * For LOVD    : 3.0-21
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -40,9 +40,10 @@ require_once ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_Announcement extends LOVD_Object {
-// This class extends the basic Object class and it handles the Announcement object.
-var $sObject = 'Announcement';
+class LOVD_Announcement extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the Announcements.
+    var $sObject = 'Announcement';
 
 
 

--- a/src/class/object_basic.php
+++ b/src/class/object_basic.php
@@ -7,7 +7,7 @@
  * Modified    : 2016-04-29
  * For LOVD    : 3.0-15
  *
- * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2016-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -35,9 +35,13 @@ require_once ROOT_PATH . 'class/objects.php';
 
 class LOVD_Basic extends LOVD_Object
 {
-    // "Basic" LOVD object to be used for entities within the LOVD system that
-    // do not have user interface related metadata, but which provides access
-    // to useful methods such as checkFields().
+    // This class extends the basic Object class and it gives quick access to the Object class' methods,
+    // such as insertEntry(). In practice, this method is only used in import.php for the linking objects
+    // (Genes_To_Diseases, Individuals_To_Diseases, Screenings_To_Genes, Screenings_To_Variants)
+    // to get them inserted into the database.
+
+
+
 
 
     function __construct($sTable)

--- a/src/class/object_columns.php
+++ b/src/class/object_columns.php
@@ -42,8 +42,9 @@ require_once ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_Column extends LOVD_Object {
-    // This class extends the basic Object class and it handles the Column object.
+class LOVD_Column extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the Custom Columns.
     var $sObject = 'Column';
     var $sTable  = 'TABLE_COLS';
 

--- a/src/class/object_custom.php
+++ b/src/class/object_custom.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-17
- * Modified    : 2019-10-01
- * For LOVD    : 3.0-22
+ * Modified    : 2019-12-19
+ * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -41,15 +41,16 @@ require_once ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_Custom extends LOVD_Object {
-    // This class extends the basic Object class and it handles the Link object.
+class LOVD_Custom extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles all Custom objects, serving as a parent class.
     var $sObject = 'Custom';
     var $sCategory = '';
-    var $bShared = false;
     var $aColumns = array();
     var $aCustomLinks = array();
     var $sObjectID = '';
     var $nID = '';
+
 
 
 
@@ -62,8 +63,9 @@ class LOVD_Custom extends LOVD_Object {
         $aArgs = array();
 
         $this->sCategory = (empty($this->sCategory)? $this->sObject : $this->sCategory);
+        $aTableInfo = lovd_getTableInfoByCategory($this->sCategory);
 
-        if (!$this->bShared) {
+        if (empty($aTableInfo['shared'])) {
             // "Simple", non-shared, data types (individuals, genomic variants, screenings).
             $sSQL = 'SELECT c.*, ac.* ' .
                     'FROM ' . TABLE_ACTIVE_COLS . ' AS ac ' .

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -42,8 +42,9 @@ require_once ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_CustomViewList extends LOVD_Object {
-    // This class extends the basic Object class and it handles pre-configured custom viewLists.
+class LOVD_CustomViewList extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the pre-configured Custom ViewLists.
     var $sObject = 'Custom_ViewList';
     var $nOtherID = 0; // Some objects (like DistanceToVar) need an additional ID.
     var $aColumns = array();

--- a/src/class/object_diseases.php
+++ b/src/class/object_diseases.php
@@ -127,8 +127,9 @@ $_SETT['disease_tissues'] = array(
 
 
 
-class LOVD_Disease extends LOVD_Object {
-    // This class extends the basic Object class and it handles the Link object.
+class LOVD_Disease extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the Diseases.
     var $sObject = 'Disease';
 
 

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -42,8 +42,9 @@ require_once ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_Gene extends LOVD_Object {
-    // This class extends the basic Object class and it handles the Link object.
+class LOVD_Gene extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the Genes.
     var $sObject = 'Gene';
 
 

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2019-10-01
- * For LOVD    : 3.0-22
+ * Modified    : 2019-12-19
+ * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -42,12 +42,12 @@ require_once ROOT_PATH . 'class/object_custom.php';
 
 
 
-class LOVD_GenomeVariant extends LOVD_Custom {
-    // This class extends the basic Object class and it handles the GenomeVariant object.
+class LOVD_GenomeVariant extends LOVD_Custom
+{
+    // This class extends the Custom class and it handles the Variants On Genome.
     var $sObject = 'Genome_Variant';
     var $sCategory = 'VariantOnGenome';
     var $sTable = 'TABLE_VARIANTS';
-    var $bShared = false;
 
 
 

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2019-10-01
- * For LOVD    : 3.0-22
+ * Modified    : 2019-12-19
+ * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -42,10 +42,10 @@ require_once ROOT_PATH . 'class/object_custom.php';
 
 
 
-class LOVD_Individual extends LOVD_Custom {
-    // This class extends the basic Object class and it handles the Link object.
+class LOVD_Individual extends LOVD_Custom
+{
+    // This class extends the Custom class and it handles the Individuals.
     var $sObject = 'Individual';
-    var $bShared = false;
 
 
 

--- a/src/class/object_links.php
+++ b/src/class/object_links.php
@@ -7,7 +7,7 @@
  * Modified    : 2017-10-26
  * For LOVD    : 3.0-17
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -41,8 +41,9 @@ require_once ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_Link extends LOVD_Object {
-    // This class extends the basic Object class and it handles the Link object.
+class LOVD_Link extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the Links.
     var $sObject = 'Link';
 
 

--- a/src/class/object_logs.php
+++ b/src/class/object_logs.php
@@ -41,8 +41,9 @@ require_once ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_Log extends LOVD_Object {
-    // This class extends the basic Object class and it handles the Log object.
+class LOVD_Log extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the Logs.
     var $sObject = 'Log';
 
 

--- a/src/class/object_phenotypes.php
+++ b/src/class/object_phenotypes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2019-10-01
+ * Modified    : 2019-12-19
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -42,10 +42,10 @@ require_once ROOT_PATH . 'class/object_custom.php';
 
 
 
-class LOVD_Phenotype extends LOVD_Custom {
-    // This class extends the basic Object class and it handles the Link object.
+class LOVD_Phenotype extends LOVD_Custom
+{
+    // This class extends the Custom class and it handles the Phenotypes.
     var $sObject = 'Phenotype';
-    var $bShared = true;
 
 
 
@@ -55,11 +55,6 @@ class LOVD_Phenotype extends LOVD_Custom {
     {
         // Default constructor.
         global $_SETT;
-
-        if (LOVD_plus) {
-            // We don't have shared custom columns in LOVD+.
-            $this->bShared = false;
-        }
 
         // SQL code for loading an entry for an edit form.
         // FIXME; change owner to owned_by_ in the load entry query below.

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2019-10-01
+ * Modified    : 2019-12-19
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -42,10 +42,10 @@ require_once ROOT_PATH . 'class/object_custom.php';
 
 
 
-class LOVD_Screening extends LOVD_Custom {
-    // This class extends the basic Object class and it handles the Link object.
+class LOVD_Screening extends LOVD_Custom
+{
+    // This class extends the Custom class and it handles the Screenings.
     var $sObject = 'Screening';
-    var $bShared = false;
 
 
 

--- a/src/class/object_shared_columns.php
+++ b/src/class/object_shared_columns.php
@@ -7,7 +7,7 @@
  * Modified    : 2018-01-26
  * For LOVD    : 3.0-21
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -40,8 +40,9 @@ require_once ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_SharedColumn extends LOVD_Object {
-    // This class extends the basic Object class and it handles the Column object.
+class LOVD_SharedColumn extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the Shared Columns.
     var $sObject = 'Shared_Column';
     var $sTable  = 'TABLE_SHARED_COLS';
     var $aTableInfo = array(); // Info about the type of custom column (VOT or Phenotype).

--- a/src/class/object_system_settings.php
+++ b/src/class/object_system_settings.php
@@ -41,8 +41,9 @@ require ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_SystemSetting extends LOVD_Object {
-    // This class, handling the System Settings, extends the basic Object class.
+class LOVD_SystemSetting extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the System Settings.
     var $sObject = 'Settings';
     var $sTable  = 'TABLE_CONFIG';
 

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-12
- * Modified    : 2019-10-01
+ * Modified    : 2019-12-19
  * For LOVD    : 3.0-22
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
@@ -42,12 +42,12 @@ require_once ROOT_PATH . 'class/object_custom.php';
 
 
 
-class LOVD_TranscriptVariant extends LOVD_Custom {
-    // This class extends the basic Object class and it handles the Link object.
+class LOVD_TranscriptVariant extends LOVD_Custom
+{
+    // This class extends the Custom class and it handles the Variants On Transcripts.
     var $sObject = 'Transcript_Variant';
     var $sCategory = 'VariantOnTranscript';
     var $sTable = 'TABLE_VARIANTS_ON_TRANSCRIPTS';
-    var $bShared = true;
     var $aTranscripts = array();
     // Flag to give transcript-specific fields used in getForm() and checkFields() a prefix to separate them.
     var $bPrefixTranscriptFields = true;
@@ -60,11 +60,6 @@ class LOVD_TranscriptVariant extends LOVD_Custom {
     {
         // Default constructor.
         global $_DB, $_SETT;
-
-        if (LOVD_plus) {
-            // We don't have shared custom columns in LOVD+.
-            $this->bShared = false;
-        }
 
         // SQL code for loading an entry for an edit form.
         $this->sSQLLoadEntry = 'SELECT vot.* ' .

--- a/src/class/object_transcripts.php
+++ b/src/class/object_transcripts.php
@@ -42,8 +42,9 @@ require_once ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_Transcript extends LOVD_Object {
-    // This class extends the basic Object class and it handles the Link object.
+class LOVD_Transcript extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the Transcripts.
     var $sObject = 'Transcript';
 
 

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2019-02-13
- * For LOVD    : 3.0-22
+ * Modified    : 2019-12-19
+ * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -374,7 +374,7 @@ class LOVD_User extends LOVD_Object {
                         'hr',
                         array('Country', '', 'select', 'countryid', 1, $aCountryList, true, false, false),
                         array('City', 'Please enter your city, even if it\'s included in your postal address, for sorting purposes.', 'text', 'city', 30),
-                        array('Reference (optional)', 'Your submissions will contain a reference to you in the format "Country:City" by default. You may change this to your preferred reference here.', 'text', 'reference', 30),
+         'reference' => array('Reference (optional)', 'Your submissions will contain a reference to you in the format "Country:City" by default. You may change this to your preferred reference here.', 'text', 'reference', 30),
                         'hr',
                         'skip',
                         array('', '', 'print', '<B>Security</B>'),
@@ -425,6 +425,9 @@ class LOVD_User extends LOVD_Object {
                 unset($this->aFormData['change_self']);
             }
         }
+        // Unused, don't let it confuse users.
+        unset($this->aFormData['reference']);
+
         if (LOVD_plus && isset($this->aFormData['level'])) {
             $this->aFormData['level'][1] = ($_AUTH['level'] != LEVEL_ADMIN? '' : '<B>Managers</B> basically have the same rights as you, but can\'t uninstall LOVD nor can they create or edit other Manager accounts.<BR>') . '<B>Analyzers</B> can analyze individuals that are not analyzed yet by somebody else, but can not send variants for confirmation.<BR><B>Read-only</B> users can only see existing data in LOVD+, but can not start or edit any analyses or data.';
         }

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -41,8 +41,9 @@ require_once ROOT_PATH . 'class/objects.php';
 
 
 
-class LOVD_User extends LOVD_Object {
-    // This class extends the basic Object class and it handles the User object.
+class LOVD_User extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the Users.
     var $sObject = 'User';
 
 

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -38,9 +38,10 @@ if (!defined('ROOT_PATH')) {
 }
 
 
-class LOVD_Object {
-    // This class is the base class which is inherited by other object classes.
-    // It provides basic functionality for setting up forms and showing data.
+class LOVD_Object
+{
+    // This class is the base class which is inherited by all other object classes.
+    // It provides functionality for setting up forms and for showing, checking, inserting, updating and deleting data.
     var $sObject = '';
     var $sTable = '';
     var $aFormData = array();

--- a/src/class/pedigree.php
+++ b/src/class/pedigree.php
@@ -7,7 +7,7 @@
  * Modified    : 2013-03-29
  * For LOVD    : 3.0-04
  *
- * Copyright   : 2004-2013 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -37,7 +37,8 @@ if (!defined('ROOT_PATH')) {
 
 
 
-class Pedigree {
+class Pedigree
+{
     // Creates a pedigree tree around the given individual, calculates withs, and prints it on the screen.
     private $individuals = array();
     private $tree = array();
@@ -131,7 +132,7 @@ class Pedigree {
             }
             $aIDs = array_merge($aIDs, $aSpouseIDs); // Should of course only be one spouse.
         }
-        
+
         // Get information about the individual(s) itself.
         $q = $_DB->query('SELECT i.id, i.`Individual/Name` AS name, i.`Individual/Gender` AS gender, i.`fatherid` AS father, i.`motherid` AS mother, GROUP_CONCAT(i2d.diseaseid SEPARATOR ";") AS _diseases FROM ' . TABLE_INDIVIDUALS . ' AS i LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid) WHERE i.id IN (?' . str_repeat(', ?', count($aIDs)-1) . ') GROUP BY i.id', $aIDs);
         while ($z = $q->fetchAssoc()) {
@@ -260,7 +261,7 @@ class Pedigree {
 
                     // Print individual itself.
                     foreach ($aIndividual['ids'] as $nKey => $nID) {
-                        $aI = $this->individuals[$nID]; 
+                        $aI = $this->individuals[$nID];
                         if ($nKey) {
                             // Not the first.
                             print('    <TD><IMG src="gfx/pedigree/' . ($this->sMode == 'pedigree'? '' : '100x100/') . 'l14.png"></TD>' . "\n");
@@ -300,7 +301,7 @@ class Pedigree {
                             } else {
                                 $nHeight = 100;
                             }
-                            
+
                             // FIXME: Display the name nicely (shorten in intelligent way).
                             $sName = $aI['name'];
                             print('    <TD align="center" style="position : relative;"><A href="#"' . "\n" . // Relative position is needed to have the DIV stick to the TD.

--- a/src/class/progress_bar.php
+++ b/src/class/progress_bar.php
@@ -7,7 +7,7 @@
  * Modified    : 2017-11-10
  * For LOVD    : 3.0-21
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -38,7 +38,8 @@ if (!defined('ROOT_PATH')) {
 
 
 
-class ProgressBar {
+class ProgressBar
+{
     // This class creates a progress bar that can be controlled in various ways.
     var $sID = '';
     var $nCurrentPercentage = 0;

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -40,7 +40,8 @@ if (!defined('ROOT_PATH')) {
 
 
 
-class LOVD_Template {
+class LOVD_Template
+{
     // This class provides the code necessary to view the headers and footers.
     // It's replacing inc-top.php, inc-top-clean.php, inc-bot.php, inc-bot-clean.php,
     //   and the lovd_printHeader() function from inc-lib-init.php.


### PR DESCRIPTION
Some fixes to the objects.
- Hide the reference field from the user data entry form.
- Don't hard-code what are shared objects in the object definitions themselves, keep it in one place.
- Fix class definitions to match the coding standards.