### PR TITLE
Fix VOG row link.

### DIFF
--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-15
- * Modified    : 2019-10-01
+ * Modified    : 2020-01-28
  * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -596,7 +596,14 @@ class LOVD_CustomViewList extends LOVD_Object
                         // First data table in view.
                         $this->sSortDefault = 'VariantOnGenome/DNA';
                     }
-                    $this->sRowLink = 'variants/{{zData_vogid}}#{{zData_transcriptid}}';
+
+                    // Set RowLink. It depends on whether we have VOT=>VOG or VOG=>grouped VOT.
+                    if (array_search('VariantOnGenome', $aObjects) < array_search('VariantOnTranscript', $aObjects)) {
+                        // Object VOG is before object VOT; we don't have a transcript ID.
+                        $this->sRowLink = 'variants/{{zData_vogid}}';
+                    } else {
+                        $this->sRowLink = 'variants/{{zData_vogid}}#{{zData_transcriptid}}';
+                    }
                     break;
 
                 case 'VariantOnTranscript':

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -7,7 +7,7 @@
  * Modified    : 2019-10-01
  * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -354,7 +354,7 @@ class LOVD_Template
 
         }
         print('  Powered by <A href="' . $_SETT['upstream_URL'] . $_STAT['tree'] . '/" target="_blank">LOVD v.' . $_STAT['tree'] . '</A> Build ' . $_STAT['build'] . '<BR>' . "\n" .
-              '  LOVD' . (LOVD_plus? '+' : '') . ' software &copy;2004-2019 <A href="http://www.lumc.nl/" target="_blank">Leiden University Medical Center</A>' . "\n");
+              '  LOVD' . (LOVD_plus? '+' : '') . ' software &copy;2004-2020 <A href="http://www.lumc.nl/" target="_blank">Leiden University Medical Center</A>' . "\n");
 ?>
     </TD>
     <TD width="42" align="right">


### PR DESCRIPTION
Fixed row links from Individuals and Screenings VEs to VOG VE.
- The transcript ID is not available for the VOG VLs, so this sent a zData string into the URL. Then the VOG VE didn't open any VOTs, even when present.
- Rowlink for VOG/VOT VLs now depends on the order in which the objects are loaded.

Also:
- Updated copyright notice to 2020.