### PR TITLE
Make adding a disease or phenotype mandatory.

### DIFF
--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2019-08-08
- * For LOVD    : 3.0-22
+ * Modified    : 2019-10-23
+ * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1075,7 +1075,7 @@ class LOVD_API_Submissions {
                     }
                 }
             } else {
-                $aInput['lsdb']['individual'][$iIndividual]['phenotype'] = array();
+                $this->API->aResponse['errors'][] = 'VarioML error: Individual #' . $nIndividual . ': Missing required phenotype element.';
             }
 
 

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -263,6 +263,11 @@ class LOVD_Individual extends LOVD_Custom {
                         'statusid',
                       );
 
+        // Check the 'active_diseases' field only when not importing.
+        if (!$bImport) {
+            $this->aCheckMandatory[] = 'active_diseases';
+        }
+
         // Checks fields before submission of data.
         parent::checkFields($aData, $zData, $aOptions);
 


### PR DESCRIPTION
Make adding a disease or phenotype mandatory.
- Make entering a Disease mandatory from the data entry forms.
- Make submitting phenotype data mandatory when using the submission API.
  - The submitters that I know from the GV shared that are using this API, all submit phenotype data already.