### PR TITLE
Release/3.0-23

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,6 @@ before_script:
   - ./tests/travis/setup/setup_config.sh
   - ./tests/travis/setup/setup_selenium_server.sh
   - phpenv config-rm xdebug.ini
-
-before_script:
   - firefox --version
   - google-chrome --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,10 @@ before_script:
   - ./tests/travis/setup/setup_selenium_server.sh
   - phpenv config-rm xdebug.ini
 
+before_script:
+  - firefox --version
+  - google-chrome --version
+
 script:
   # Use phpunit or vendor/bin/phpunit to start tests.
   # vendor/bin/phpunit is the best option to run the tests. Because this one

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ php:
 
 env:
   # Let Selenium use Firefox driver.
-  - LOVD_SELENIUM_DRIVER=firefox
+  # - LOVD_SELENIUM_DRIVER=firefox # Doesn't currently work anymore.
   # Let Selenium use Chrome driver.
   - LOVD_SELENIUM_DRIVER=chrome
 

--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -1724,16 +1724,11 @@ The header and footer will also be shown on the variant listings.
 
 
 
-\pagebreak[4] % Break the page here (up to 4; 4 is very persistent)
 \subsection{Security settings}
 Using the following settings you can control some security settings of LOVD.
 \begin{description}
   \item[Allow public to download variant entries] \hfill \\
   This controls whether or not the public can also make downloads of your gene's variants.
-  \item[Allow my public variant and individual data to be indexed by WikiProfessional] \hfill \\
-  \emph{Note: Not yet implemented!}
-  \\
-  If you'll allow the \href{http://www.wikiprofessional.org/}{WikiProfessional} concept web to index your variant and individual data, enable this checkbox.
 \end{description}
 
 

--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -5,7 +5,7 @@
 % To convert the manual to an html file use: pdf2htmlEX --zoom 1.3 --embed-css 2 manual.pdf
 
 %%%%% SETTINGS FOR THE TITLE PAGE %%%%%
-\setLOVDversion{3.0-22}
+\setLOVDversion{3.0-23}
 \title{LOVD 3.0 user manual \\\vskip 0.2cm Build \LOVDversion}
 \author{Ivo F.A.C. Fokkema \\ Daan Asscheman}
 \setpointercolor{red}

--- a/src/2Do.txt
+++ b/src/2Do.txt
@@ -2,7 +2,7 @@ Release LOVD?
 =============
 Changed something? Change the manual, too! Don't forget setting the LOVD version and last updated time in the manual, too!!!
 Check changelog and release date in it (and don't use "mutation") && inc-upgrade.php, edit inc-init.php, update manual PDF size in docs/index.php.
-git pull, git commit, git log, git tag -a -m 'Tag 3.0-15' '3.0-15', git push, git push --tags
+git pull, git commit, git tag -a -m 'Tag 3.0-15' '3.0-15', git push, git push --tags
 ER MOGEN GEEN ONGECOMMITTE CHANGES IN STAAN IN DEZE STAP (INCL. NIEUWE FILES!!!), TENZIJ GEMARKEERD ALS DMD_SPECIFIC, ANDERS WORDEN DEZE GEPACKAGED!!!
 Run package script, follow instructions.
 Update download.php, news.php (mark closed bugs), package_update.php, sync docs dirs. Update GitHub. Update Facebook & Twitter.
@@ -11,7 +11,7 @@ Update LOVD installations:
 (De LOVD3 databases zouden misschien een eigen /www/LOVD_upgrade.php versie moeten krijgen?)
 /DNA_profiles/ heeft aangepaste index.php.
 /my_genome/ heeft veel aangepaste files (ajax/map_variants.php, ajax/viewlist.php, class/object_custom_viewlist.php, class/object_genes.php, class/object_individuals.php, individuals.php, screenings.php, variants.php), NOOIT ZOMAAR OVERSCHRIJVEN!!! Also this install no longer has a key on id_ncbi, because duplicate values already existed (????????) and altering the table in any way (to increase the transcriptid length) was rejected because of this.
-/shared/ heeft een aangepaste class/template.php, download.php, import.php en individuals.php en een paar eigen files die niet overschreven mag worden (zoals export.php).
+/shared/ heeft een aangepaste class/api.submissions.php, class/template.php, download.php, import.php en individuals.php en een paar eigen files die niet overschreven mag worden (zoals export.php).
 /whole_genome/ heeft aangepaste files (class/api.php, class/object_custom_viewlists.php, class/object_genes.php, class/object_genome_variants.php, class/template.php, api.php, genes.php, variants.php), NOOIT ZOMAAR OVERSCHRIJVEN!!!
 After updating all installations, send email to team with all improvements summarized.
 

--- a/src/2Do.txt
+++ b/src/2Do.txt
@@ -23,7 +23,6 @@ In form fields (SELECTs?) set style="max-width:400px" or so?
 
 Columns we no longer use that can be removed:
 - TABLE_TRANSCRIPTS/id_mutalyzer
-- TABLE_USERS/reference
 
 - Access sharing: Users zouden moeten worden gesorteerd op naam.
 - Gerard: Als ik bij (bijv.) Age examined (Phenotype) '<00y' invul, dus onderzoek aan een ongeboren kind, komt er '<00y (before )' te staan, zou dit '<00y (before birth)' moeten zijn?

--- a/src/2Do.txt
+++ b/src/2Do.txt
@@ -22,7 +22,6 @@ Prioritize:
 In form fields (SELECTs?) set style="max-width:400px" or so?
 
 Columns we no longer use that can be removed:
-- TABLE_GENES/allow_index_wiki
 - TABLE_TRANSCRIPTS/id_mutalyzer
 - TABLE_USERS/reference
 

--- a/src/ajax/map_variants.php
+++ b/src/ajax/map_variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-15
- * Modified    : 2019-07-25
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-06
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
  *               Ivar Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -604,7 +604,6 @@ if (!empty($aVariants)) {
                                          'url_homepage' => '',
                                          'url_external' => '',
                                          'allow_download' => 0,
-                                         'allow_index_wiki' => 0,
                                          'id_hgnc' => $sHgncID,
                                          'id_entrez' => $sEntrez,
                                          'id_omim' => $sOmim,

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -5,6 +5,28 @@
  *************/
 
 /***************************
+ * 3.0 Build 23 (tag:3.0-23)
+ * 2020-02-19
+ *********/
+ * Removed the reference field from the user data entry form.
+ * Fixed potential XSS risk in combination with the gene switcher.
+ * Fixed potential XSS risk in combination with the updater.
+ * Links to variant pages from the Individuals or Screenings detailed views,
+   were malformed and didn't fully work.
+ * Updated copyright notice in the page footer to 2020.
+ * Added some LOVD2 columns to the LOVD2 to LOVD3 converter script.
+ * Added timezone indicators to all printed timestamps in LOVD (currently: the
+   system's time zone).
+ * Opened up the variant Options menu for the public, to have links to the
+   genome browsers.
+ * Removed the WikiProfessional feature.
+ * Data owner information is now not only shown in the data listings, but also
+   on the data detailed views.
+ * Make adding a disease or phenotype to an individual mandatory for the data
+   entry forms as well as the submission API.
+
+
+/***************************
  * 3.0 Build 22 (tag:3.0-22)
  * 2019-10-02
  *********/

--- a/src/check_update.php
+++ b/src/check_update.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-15
- * Modified    : 2019-08-21
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-06
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -142,10 +142,6 @@ if ((time() - strtotime($_STAT['update_checked_date'])) > (60*60*24)) {
         }
         $sData = serialize($aData);
         $sPOSTVars .= '&data=' . rawurlencode($sData);
-
-        // Send setting for wiki indexing.
-        $bAllowIndex = $_DB->query('SELECT MAX(allow_index_wiki) FROM ' . TABLE_GENES)->fetchColumn();
-        $sPOSTVars .= '&allow_index_wiki=' . (int) $bAllowIndex;
     }
 
     // Contact upstream.

--- a/src/class/object_announcements.php
+++ b/src/class/object_announcements.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-08-26
- * Modified    : 2017-10-26
- * For LOVD    : 3.0-21
+ * Modified    : 2020-02-04
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -69,13 +69,13 @@ class LOVD_Announcement extends LOVD_Object
                         'id' => 'Announcement ID',
                         'type' => 'Type',
                         'announcement' => 'Announcement text',
-                        'start_date' => 'Start date',
-                        'end_date' => 'End date',
+                        'start_date_' => 'Start date',
+                        'end_date_' => 'End date',
                         'lovd_read_only_' => 'Make LOVD read-only?',
                         'created_by_' => 'Created by',
-                        'created_date' => 'Date created',
+                        'created_date_' => 'Date created',
                         'edited_by_' => 'Last edited by',
-                        'edited_date' => 'Date last edited',
+                        'edited_date_' => 'Date last edited',
                       );
 
         // List of columns and (default?) order for viewing a list of entries.

--- a/src/class/object_columns.php
+++ b/src/class/object_columns.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-03-04
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-04
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -122,9 +122,9 @@ class LOVD_Column extends LOVD_Object
                         'allow_count_all_' => 'Include in search form',
                         'parent_objects' => 'Column activated for',
                         'created_by_' => 'Created by',
-                        'created_date' => 'Date created',
+                        'created_date_' => 'Date created',
                         'edited_by_' => 'Last edited by',
-                        'edited_date' => 'Date last edited',
+                        'edited_date_' => 'Date last edited',
                       );
 
         // List of columns and (default?) order for viewing a list of entries.
@@ -389,7 +389,7 @@ class LOVD_Column extends LOVD_Object
             // Remove unnecessary columns.
             if ($zData['edited_by'] == NULL) {
                 // Never been edited.
-                unset($this->aColumnsViewEntry['edited_by_'], $this->aColumnsViewEntry['edited_date']);
+                unset($this->aColumnsViewEntry['edited_by_'], $this->aColumnsViewEntry['edited_date_']);
             }
 
             // Remove columns based on form type?

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2019-10-01
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-04
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -616,7 +616,7 @@ class LOVD_Gene extends LOVD_Object
             // 2013-10-11; 3.0-08; This query was first done using GROUP_CONCAT incorporated in the ViewEntry query. However, since the results were sometimes too long for MySQL, resulting in incorrect numbers and notices, this query is better represented as a separate query.
             $zData['count_individuals'] = (int) $_DB->query('SELECT SUM(panel_size) FROM (SELECT DISTINCT i.id, i.panel_size FROM ' . TABLE_INDIVIDUALS . ' AS i INNER JOIN ' . TABLE_SCREENINGS . ' AS s ON (i.id = s.individualid) INNER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (s2v.variantid = vog.id) INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vog.id = vot.id) INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE i.panelid IS NULL AND vog.statusid >= ' . STATUS_MARKED . ' AND t.geneid = ?)i', array($zData['id']))->fetchColumn();
 
-            $zData['created_date_'] = str_replace(' 00:00:00', '', $zData['created_date_']);
+            $zData['created_date_'] = preg_replace('/ 00:00:00.*$/', '', $zData['created_date_']);
             if ($zData['updated_date']) {
                 $zData['version_'] = '<B>' . $zData['id'] . date(':ymd', strtotime($zData['updated_date_'])) . '</B>';
             } else {

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2020-02-04
+ * Modified    : 2020-02-06
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -453,7 +453,6 @@ class LOVD_Gene extends LOVD_Object
                         array('', '', 'note', 'Using the following settings you can control some security settings of LOVD.'),
                         'hr',
                         array('Allow public to download variant entries', '', 'checkbox', 'allow_download'),
-                        array('Allow my public variant and individual data to be indexed by WikiProfessional', '', 'checkbox', 'allow_index_wiki'),
                         'hr',
                         'skip',
                   );
@@ -544,7 +543,6 @@ class LOVD_Gene extends LOVD_Object
             }
 
             $zData['allow_download_']   = '<IMG src="gfx/mark_' . $zData['allow_download'] . '.png" alt="" width="11" height="11">';
-            $zData['allow_index_wiki_'] = '<IMG src="gfx/mark_' . $zData['allow_index_wiki'] . '.png" alt="" width="11" height="11">';
 
             // Human readable RefSeq link.
             if ($zData['refseq_url']) {

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -70,7 +70,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
                                            'a.name AS allele_, ' .
                                            'GROUP_CONCAT(DISTINCT i.id, ";", i.statusid SEPARATOR ";;") AS __individuals, ' .
                                            'GROUP_CONCAT(s2v.screeningid SEPARATOR "|") AS screeningids, ' .
-                                           'uo.name AS owned_by_, ' .
+                                           'uo.name AS owned_by_, CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) AS _owner, ' .
                                            'uc.name AS created_by_, ' .
                                            'ue.name AS edited_by_';
         $this->aSQLViewEntry['FROM']     = TABLE_VARIANTS . ' AS vog ' .

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2019-12-19
+ * Modified    : 2020-02-10
  * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -59,9 +59,8 @@ class LOVD_GenomeVariant extends LOVD_Custom
         global $_AUTH, $_CONF, $_SETT;
 
         // SQL code for loading an entry for an edit form.
-        // FIXME; change owner to owned_by_ in the load entry query below.
         $this->sSQLLoadEntry = 'SELECT vog.*, ' .
-                               'uo.name AS owner ' .
+                               'uo.name AS owned_by_ ' .
                                'FROM ' . TABLE_VARIANTS . ' AS vog ' .
                                'LEFT OUTER JOIN ' . TABLE_USERS . ' AS uo ON (vog.owned_by = uo.id) ' .
                                'WHERE vog.id = ?';

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -76,8 +76,7 @@ class LOVD_Individual extends LOVD_Custom
                                            'GROUP_CONCAT(DISTINCT d.id, ";", IF(CASE d.symbol WHEN "-" THEN "" ELSE d.symbol END = "", d.name, d.symbol), ";", d.name ORDER BY (d.symbol != "" AND d.symbol != "-") DESC, d.symbol, d.name SEPARATOR ";;") AS __diseases, ' .
                                            'GROUP_CONCAT(DISTINCT p.diseaseid SEPARATOR ";") AS _phenotypes, ' .
                                            'GROUP_CONCAT(DISTINCT s.id SEPARATOR ";") AS _screeningids, ' .
-                                           'uo.id AS owner, ' .
-                                           'uo.name AS owned_by_, ' .
+                                           'uo.name AS owned_by_, CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) AS _owner, ' .
                                            'uc.name AS created_by_, ' .
                                            'ue.name AS edited_by_';
         $this->aSQLViewEntry['FROM']     = TABLE_INDIVIDUALS . ' AS i ' .

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2019-12-19
+ * Modified    : 2020-02-10
  * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -61,9 +61,8 @@ class LOVD_Individual extends LOVD_Custom
         $this->sSQLPreLoadEntry = 'SET group_concat_max_len = 200000';
 
         // SQL code for loading an entry for an edit form.
-        // FIXME; change owner to owned_by_ in the load entry query below.
         $this->sSQLLoadEntry = 'SELECT i.*, ' .
-                               'uo.name AS owner, ' .
+                               'uo.name AS owned_by_, ' .
                                'GROUP_CONCAT(DISTINCT i2d.diseaseid ORDER BY i2d.diseaseid SEPARATOR ";") AS active_diseases_ ' .
                                'FROM ' . TABLE_INDIVIDUALS . ' AS i ' .
                                'LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid) ' .

--- a/src/class/object_links.php
+++ b/src/class/object_links.php
@@ -4,12 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-04-19
- * Modified    : 2017-10-26
- * For LOVD    : 3.0-17
+ * Modified    : 2019-02-04
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -79,9 +79,9 @@ class LOVD_Link extends LOVD_Object
                         'active_columns' => '# active columns',
                         'active_columns_' => 'Active columns',
                         'created_by_' => 'Created by',
-                        'created_date' => 'Date created',
+                        'created_date_' => 'Date created',
                         'edited_by_' => 'Last edited by',
-                        'edited_date' => 'Date last edited',
+                        'edited_date_' => 'Date last edited',
                       );
 
         // List of columns and (default?) order for viewing a list of entries.

--- a/src/class/object_phenotypes.php
+++ b/src/class/object_phenotypes.php
@@ -67,7 +67,7 @@ class LOVD_Phenotype extends LOVD_Custom
         $this->aSQLViewEntry['SELECT']   = 'p.*, ' .
                                            'i.statusid AS individual_statusid, ' .
                                            'd.symbol AS disease, ' .
-                                           'uo.name AS owned_by_, ' .
+                                           'uo.name AS owned_by_, CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) AS _owner, ' .
                                            'uc.name AS created_by_, ' .
                                            'ue.name AS edited_by_';
         $this->aSQLViewEntry['FROM']     = TABLE_PHENOTYPES . ' AS p ' .

--- a/src/class/object_phenotypes.php
+++ b/src/class/object_phenotypes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2019-12-19
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-10
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -57,9 +57,8 @@ class LOVD_Phenotype extends LOVD_Custom
         global $_SETT;
 
         // SQL code for loading an entry for an edit form.
-        // FIXME; change owner to owned_by_ in the load entry query below.
         $this->sSQLLoadEntry = 'SELECT p.*, ' .
-                               'uo.name AS owner ' .
+                               'uo.name AS owned_by_ ' .
                                'FROM ' . TABLE_PHENOTYPES . ' AS p ' .
                                'LEFT JOIN ' . TABLE_USERS . ' AS uo ON (p.owned_by = uo.id) ' .
                                'WHERE p.id = ?';

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2020-02-04
+ * Modified    : 2020-02-10
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -57,10 +57,9 @@ class LOVD_Screening extends LOVD_Custom
         global $_AUTH, $_SETT;
 
         // SQL code for loading an entry for an edit form.
-        // FIXME; change owner to owned_by_ in the load entry query below.
         $this->sSQLLoadEntry = 'SELECT s.*, ' .
                                'GROUP_CONCAT(DISTINCT s2g.geneid ORDER BY s2g.geneid SEPARATOR ";") AS _genes, ' .
-                               'uo.name AS owner ' .
+                               'uo.name AS owned_by_ ' .
                                'FROM ' . TABLE_SCREENINGS . ' AS s ' .
                                'LEFT OUTER JOIN ' . TABLE_SCR2GENE . ' AS s2g ON (s.id = s2g.screeningid) ' .
                                'LEFT OUTER JOIN ' . TABLE_USERS . ' AS uo ON (s.owned_by = uo.id) ' .

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2019-12-19
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-04
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -121,7 +121,7 @@ class LOVD_Screening extends LOVD_Custom
                         'variants_found_' => 'Variants found?',
                         'owned_by_' => 'Owner name',
                         'created_by_' => array('Created by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'created_date' => array('Date created', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'created_date_' => array('Date created', $_SETT['user_level_settings']['see_nonpublic_data']),
                         'edited_by_' => array('Last edited by', $_SETT['user_level_settings']['see_nonpublic_data']),
                         'edited_date_' => array('Date last edited', $_SETT['user_level_settings']['see_nonpublic_data']),
                       ));

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -71,7 +71,7 @@ class LOVD_Screening extends LOVD_Custom
                                            'i.statusid AS individual_statusid, ' .
                                            'GROUP_CONCAT(DISTINCT "=\"", s2g.geneid, "\"" SEPARATOR "|") AS search_geneid, ' .
                                            'IF(s.variants_found = 1 AND COUNT(s2v.variantid) = 0, -1, COUNT(DISTINCT ' . ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? 's2v.variantid' : 'vog.id') . ')) AS variants_found_, ' .
-                                           'uo.name AS owned_by_, ' .
+                                           'uo.name AS owned_by_, CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) AS _owner, ' .
                                            'uc.name AS created_by_, ' .
                                            'ue.name AS edited_by_';
 

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -150,9 +150,6 @@ class LOVD_Screening extends LOVD_Custom
                         'owned_by_' => array(
                                     'view' => array('Owner', 160),
                                     'db'   => array('uo.name', 'ASC', true)),
-                        'created_date' => array(
-                                    'view' => array('Date created', 130),
-                                    'db'   => array('s.created_date', 'ASC', true)),
                         'created_by' => array(
                                     'view' => false,
                                     'db'   => array('s.created_by', false, true)),

--- a/src/class/object_shared_columns.php
+++ b/src/class/object_shared_columns.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-05-02
- * Modified    : 2018-01-26
- * For LOVD    : 3.0-21
+ * Modified    : 2020-02-04
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -116,9 +116,9 @@ class LOVD_SharedColumn extends LOVD_Object
                         'public_view_' => 'Show to public',
                         'public_add_' => 'Show on submission form',
                         'created_by_' => 'Created by',
-                        'created_date' => 'Date created',
+                        'created_date_' => 'Date created',
                         'edited_by_' => 'Last edited by',
-                        'edited_date' => 'Date last edited',
+                        'edited_date_' => 'Date last edited',
                       );
 
         // List of columns and (default?) order for viewing a list of entries.
@@ -284,7 +284,7 @@ class LOVD_SharedColumn extends LOVD_Object
             // Remove unnecessary columns.
             if ($zData['edited_by'] == NULL) {
                 // Never been edited.
-                unset($this->aColumnsViewEntry['edited_by_'], $this->aColumnsViewEntry['edited_date']);
+                unset($this->aColumnsViewEntry['edited_by_'], $this->aColumnsViewEntry['edited_date_']);
             }
 
             // Remove columns based on form type?

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2020-02-04
+ * Modified    : 2020-02-10
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -117,7 +117,6 @@ class LOVD_User extends LOVD_Object
                         'city' => 'City',
                         'country_' => 'Country',
                         'email' => array('Email address', LEVEL_CURATOR),
-                        'reference' => 'Reference',
                         'username' => array('Username', LEVEL_MANAGER),
                         'password_force_change_' => array('Force change password', LEVEL_MANAGER),
                         'phpsessid' => array('Session ID', LEVEL_MANAGER),
@@ -375,7 +374,6 @@ class LOVD_User extends LOVD_Object
                         'hr',
                         array('Country', '', 'select', 'countryid', 1, $aCountryList, true, false, false),
                         array('City', 'Please enter your city, even if it\'s included in your postal address, for sorting purposes.', 'text', 'city', 30),
-         'reference' => array('Reference (optional)', 'Your submissions will contain a reference to you in the format "Country:City" by default. You may change this to your preferred reference here.', 'text', 'reference', 30),
                         'hr',
                         'skip',
                         array('', '', 'print', '<B>Security</B>'),
@@ -426,8 +424,6 @@ class LOVD_User extends LOVD_Object
                 unset($this->aFormData['change_self']);
             }
         }
-        // Unused, don't let it confuse users.
-        unset($this->aFormData['reference']);
 
         if (LOVD_plus && isset($this->aFormData['level'])) {
             $this->aFormData['level'][1] = ($_AUTH['level'] != LEVEL_ADMIN? '' : '<B>Managers</B> basically have the same rights as you, but can\'t uninstall LOVD nor can they create or edit other Manager accounts.<BR>') . '<B>Analyzers</B> can analyze individuals that are not analyzed yet by somebody else, but can not send variants for confirmation.<BR><B>Read-only</B> users can only see existing data in LOVD+, but can not start or edit any analyses or data.';

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2019-12-19
+ * Modified    : 2020-02-04
  * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -133,9 +133,9 @@ class LOVD_User extends LOVD_Object
                         'allowed_ip_' => array('Allowed IP address list', LEVEL_MANAGER),
                         'status_' => array('Status', LEVEL_MANAGER),
                         'locked_' => array('Locked', LEVEL_MANAGER),
-                        'last_login' => array('Last login', LEVEL_MANAGER),
+                        'last_login_' => array('Last login', LEVEL_MANAGER),
                         'created_by_' => array('Created by', LEVEL_CURATOR),
-                        'created_date' => array('Date created', LEVEL_CURATOR),
+                        'created_date_' => array('Date created', LEVEL_CURATOR),
                         'edited_by_' => array('Last edited by', LEVEL_MANAGER),
                         'edited_date_' => array('Date last edited', LEVEL_MANAGER),
                       );

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2020-02-04
+ * Modified    : 2020-02-10
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1533,35 +1533,6 @@ class LOVD_Object
                     }
                 }
             }
-            // If we find an owned_by_ field, and an owner array, we set up the popups as well.
-            if (isset($zData['owned_by_']) && !empty($zData['owner'])) {
-                if (!is_array($zData['owner'][0])) {
-                    $zData['owner'] = array($zData['owner']);
-                }
-                // We are going to overwrite the 'owned_by_' field.
-                $zData['owned_by_'] = '';
-                foreach($zData['owner'] as $aLinkData) {
-                    if (count($aLinkData) >= 6) {
-                        list($nID, $sName, $sEmail, $sInstitute, $sDepartment, $sCountryID) = $aLinkData;
-                        if (intval($nID) === 0) {
-                            // Skip special "LOVD" user.
-                            continue;
-                        }
-                        // Call the tooltip function with a request to move the tooltip left, because "Owner" is often the last column in the table, and we don't want it to run off the page. I have found no way of moving the tooltip left whenever it's enlarging the document size.
-                        $zData['owned_by_'] .= (!$zData['owned_by_']? '' : ', ') .
-                            '<SPAN class="custom_link" onmouseover="lovd_showToolTip(\'' .
-                            addslashes('<TABLE border=0 cellpadding=0 cellspacing=0 width=350 class=S11><TR><TH valign=top>User&nbsp;ID</TH><TD>' . ($_AUTH['level'] < LEVEL_MANAGER? $nID : '<A href=users/' . $nID . '>' . $nID . '</A>') . '</TD></TR><TR><TH valign=top>Name</TH><TD>' . $sName . '</TD></TR><TR><TH valign=top>Email&nbsp;address</TH><TD>' . str_replace("\r\n", '<BR>', lovd_hideEmail($sEmail)) . '</TD></TR><TR><TH valign=top>Institute</TH><TD>' . $sInstitute . '</TD></TR><TR><TH valign=top>Department</TH><TD>' . $sDepartment . '</TD></TR><TR><TH valign=top>Country</TH><TD>' . $sCountryID . '</TD></TR></TABLE>') .
-                            '\', this, [-200, 0]);">' . $sName . '</SPAN>';
-                    }
-                }
-            }
-            if (LOVD_plus) {
-                // Analyzer's details like the owner's details.
-                if (isset($zData['analysis_by']) && (int) $zData['analysis_by'] && !empty($zData['analyzer'])) {
-                    list($nID, $sName, $sEmail, $sInstitute, $sDepartment, $sCountryID) = $zData['analyzer'];
-                    $zData['analysis_by_'] = '<SPAN class="custom_link" onmouseover="lovd_showToolTip(\'' . addslashes('<TABLE border=0 cellpadding=0 cellspacing=0 width=350 class=S11><TR><TH valign=top>User&nbsp;ID</TH><TD>' . ($_AUTH['level'] < LEVEL_MANAGER? $nID : '<A href=users/' . $nID . '>' . $nID . '</A>') . '</TD></TR><TR><TH valign=top>Name</TH><TD>' . $sName . '</TD></TR><TR><TH valign=top>Email&nbsp;address</TH><TD>' . str_replace("\r\n", '<BR>', lovd_hideEmail($sEmail)) . '</TD></TR><TR><TH valign=top>Institute</TH><TD>' . $sInstitute . '</TD></TR><TR><TH valign=top>Department</TH><TD>' . $sDepartment . '</TD></TR><TR><TH valign=top>Country</TH><TD>' . $sCountryID . '</TD></TR></TABLE>') . '\', this);">' . $sName . '</SPAN>';
-                }
-            }
             // Determine minimum status for all data in current VL row.
             $nRowStatus = STATUS_OK;
             // Status coloring will only be done, when we have authorization.
@@ -1615,6 +1586,37 @@ class LOVD_Object
                     // Restructure the JSON.
                     $zData[$sKey] = $this->formatArrayToTable(json_decode(htmlspecialchars_decode($Value), true));
                 }
+            }
+        }
+
+        // If we find an owned_by_ field, and an owner array, we set up the popups as well.
+        if (isset($zData['owned_by_']) && !empty($zData['owner'])) {
+            if (!is_array($zData['owner'][0])) {
+                $zData['owner'] = array($zData['owner']);
+            }
+            // We are going to overwrite the 'owned_by_' field.
+            $zData['owned_by_'] = '';
+            foreach($zData['owner'] as $aLinkData) {
+                if (count($aLinkData) >= 6) {
+                    list($nID, $sName, $sEmail, $sInstitute, $sDepartment, $sCountryID) = $aLinkData;
+                    if (intval($nID) === 0) {
+                        // Skip special "LOVD" user.
+                        continue;
+                    }
+                    // For VLs, call the tooltip function with a request to move the tooltip left, because "Owner" is often the last column in the table,
+                    //  and we don't want it to run off the page. I have found no way of moving the tooltip left whenever it's enlarging the document size.
+                    $zData['owned_by_'] .= (!$zData['owned_by_']? '' : ', ') .
+                        '<SPAN class="custom_link" onmouseover="lovd_showToolTip(\'' .
+                        addslashes('<TABLE border=0 cellpadding=0 cellspacing=0 width=350 class=S11><TR><TH valign=top>User&nbsp;ID</TH><TD>' . ($_AUTH['level'] < LEVEL_MANAGER? $nID : '<A href=users/' . $nID . '>' . $nID . '</A>') . '</TD></TR><TR><TH valign=top>Name</TH><TD>' . $sName . '</TD></TR><TR><TH valign=top>Email&nbsp;address</TH><TD>' . str_replace("\r\n", '<BR>', lovd_hideEmail($sEmail)) . '</TD></TR><TR><TH valign=top>Institute</TH><TD>' . $sInstitute . '</TD></TR><TR><TH valign=top>Department</TH><TD>' . $sDepartment . '</TD></TR><TR><TH valign=top>Country</TH><TD>' . $sCountryID . '</TD></TR></TABLE>') .
+                        '\', this, [' . ($sView == 'list'? '-200' : '0') . ', 0]);">' . $sName . '</SPAN>';
+                }
+            }
+        }
+        if (LOVD_plus) {
+            // Analyzer's details like the owner's details.
+            if (isset($zData['analysis_by']) && (int) $zData['analysis_by'] && !empty($zData['analyzer'])) {
+                list($nID, $sName, $sEmail, $sInstitute, $sDepartment, $sCountryID) = $zData['analyzer'];
+                $zData['analysis_by_'] = '<SPAN class="custom_link" onmouseover="lovd_showToolTip(\'' . addslashes('<TABLE border=0 cellpadding=0 cellspacing=0 width=350 class=S11><TR><TH valign=top>User&nbsp;ID</TH><TD>' . ($_AUTH['level'] < LEVEL_MANAGER? $nID : '<A href=users/' . $nID . '>' . $nID . '</A>') . '</TD></TR><TR><TH valign=top>Name</TH><TD>' . $sName . '</TD></TR><TR><TH valign=top>Email&nbsp;address</TH><TD>' . str_replace("\r\n", '<BR>', lovd_hideEmail($sEmail)) . '</TD></TR><TR><TH valign=top>Institute</TH><TD>' . $sInstitute . '</TD></TR><TR><TH valign=top>Department</TH><TD>' . $sDepartment . '</TD></TR><TR><TH valign=top>Country</TH><TD>' . $sCountryID . '</TD></TR></TABLE>') . '\', this);">' . $sName . '</SPAN>';
             }
         }
 

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -2803,7 +2803,7 @@ FROptions
             if (ACTION == 'downloadSelected') {
                 print('## Filter: selected = ' . implode(',', $aSessionViewList['checked']) . "\r\n");
             }
-            print('# charset=UTF-8' . "\r\n");
+            print('# charset = UTF-8' . "\r\n");
             $i = 0;
             foreach ($this->aColumnsViewList as $sField => $aCol) {
                 if (in_array($sField, $aOptions['cols_to_skip'])) {

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2019-10-01
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-04
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -1511,9 +1511,14 @@ class LOVD_Object
         // Quote special characters, disallowing HTML and other tricks.
         $zData = lovd_php_htmlspecialchars($zData);
 
-        $aDateColumns = array('created_date', 'edited_date', 'updated_date', 'valid_from', 'valid_to');
+        $aDateColumns = array('created_date', 'edited_date', 'updated_date', 'last_login', 'start_date', 'end_date', 'valid_from', 'valid_to');
         foreach($aDateColumns as $sDateColumn) {
+            // Replace empty date values with "N/A".
             $zData[$sDateColumn . ($sView == 'list'? '' : '_')] = (!empty($zData[$sDateColumn])? $zData[$sDateColumn] : 'N/A');
+            if (preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/', $zData[$sDateColumn . ($sView == 'list'? '' : '_')])) {
+                // Add timezone to full datetime values. VLs usually have removed the times.
+                $zData[$sDateColumn . ($sView == 'list'? '' : '_')] .= ' ' . date('P (T)', strtotime($zData[$sDateColumn]));
+            }
         }
 
         if ($sView == 'list') {

--- a/src/docs/index.php
+++ b/src/docs/index.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-11-27
- * Modified    : 2019-10-02
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-17
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -51,7 +51,7 @@ if (PATH_COUNT == 1 && !ACTION) {
     } else {
         print('      The LOVD 3.0 documentation is continuously being updated.<BR>Currently available is the LOVD 3.0 user manual, in PDF and HTML formats.<BR>' .
               '      <UL>' . "\n" .
-              '        <LI>LOVD manual 3.0-22 (<A href="docs/LOVD_manual_3.0.pdf" target="_blank"><B>PDF</B>, 87 pages, 1.5Mb</A>) (<A href="docs/manual.html" target="_blank"><B>HTML</B>, single file, 5.0Mb</A>) - last updated October 2nd 2019</LI></UL>' . "\n\n");
+              '        <LI>LOVD manual 3.0-23 (<A href="docs/LOVD_manual_3.0.pdf" target="_blank"><B>PDF</B>, 88 pages, 1.5Mb</A>) (<A href="docs/manual.html" target="_blank"><B>HTML</B>, single file, 5.0Mb</A>) - last updated February 17th 2020</LI></UL>' . "\n\n");
     }
 
     $_T->printFooter();

--- a/src/download.php
+++ b/src/download.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2019-07-25
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-06
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -305,7 +305,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
             $aObjects['Genes']['hide_columns'] =
                 array(
                     'imprinting', 'refseq_genomic', 'refseq_UD', 'reference', 'url_homepage', 'url_external',
-                    'allow_download', 'allow_index_wiki', 'show_hgmd', 'show_genecards', 'show_genetests',
+                    'allow_download', 'show_hgmd', 'show_genecards', 'show_genetests',
                     'note_index', 'note_listing', 'refseq', 'refseq_url', 'disclaimer', 'disclaimer_text',
                     'header', 'header_align', 'footer', 'footer_align', 'created_by', 'created_date',
                     'edited_by', 'edited_date', 'updated_by', 'updated_date',

--- a/src/genes.php
+++ b/src/genes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2019-10-01
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-06
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -475,7 +475,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                 // Fields to be used.
                 $aFields = array(
                                 'id', 'name', 'chromosome', 'chrom_band', 'imprinting', 'refseq_genomic', 'refseq_UD', 'reference', 'url_homepage',
-                                'url_external', 'allow_download', 'allow_index_wiki', 'id_hgnc', 'id_entrez', 'id_omim', 'show_hgmd',
+                                'url_external', 'allow_download', 'id_hgnc', 'id_entrez', 'id_omim', 'show_hgmd',
                                 'show_genecards', 'show_genetests', 'note_index', 'note_listing', 'refseq', 'refseq_url', 'disclaimer',
                                 'disclaimer_text', 'header', 'header_align', 'footer', 'footer_align', 'created_by', 'created_date',
                                 );
@@ -718,7 +718,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
             // Fields to be used.
             $aFields = array(
                             'name', 'chrom_band', 'imprinting', 'refseq_genomic', 'reference', 'url_homepage', 'url_external', 'allow_download',
-                            'allow_index_wiki', 'show_hgmd', 'show_genecards', 'show_genetests', 'note_index', 'note_listing', 'refseq',
+                            'show_hgmd', 'show_genecards', 'show_genetests', 'note_index', 'note_listing', 'refseq',
                             'refseq_url', 'disclaimer', 'disclaimer_text', 'header', 'header_align', 'footer', 'footer_align', 'created_date',
                             'edited_by', 'edited_date',
                             );

--- a/src/import.php
+++ b/src/import.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2020-02-04
+ * Modified    : 2020-02-06
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -971,7 +971,7 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
                                 );
                             break;
                         case 'Genes':
-                            // The following columns are allowed for update: chrom_band, imprinting, reference, url_homepage, url_external, allow_download, allow_index_wiki, show_hgmd, show_genecards,
+                            // The following columns are allowed for update: chrom_band, imprinting, reference, url_homepage, url_external, allow_download, show_hgmd, show_genecards,
                             // show_genetests, note_index, note_listing, refseq, refseq_url, disclaimer, disclaimer_text, header, header_align,
                             // footer, footer_align.
                             if ($sMode == 'update') {

--- a/src/import.php
+++ b/src/import.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-04
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -304,7 +304,7 @@ if (ACTION == 'schedule' && PATH_COUNT == 1) {
         $bConverted = ($i != -1);
 
         print('            <TD>
-              <TABLE border="0" cellpadding="10" cellspacing="1" width="' . (!$bConverted || $bProcessed? '350' : '450') . '" class="data" style="font-size : 13px;">
+              <TABLE border="0" cellpadding="10" cellspacing="1" width="' . (!$bConverted || $bProcessed? '400' : '450') . '" class="data" style="font-size : 13px;">
                 <TR>
                   <TH' . (!$bConverted || $bProcessed? '' : '></TH><TH') . ' class="S16">' .
             ($bProcessed == 1? 'Files already processed' : ($bConverted? 'Files to be processed' : 'Files to be converted')) . '</TH></TR>');
@@ -380,12 +380,12 @@ if (ACTION == 'schedule' && PATH_COUNT == 1) {
             $sDownloadHTML = ($aFile['file_lost']? '' : '
                     <A href="' . CURRENT_PATH . '?download_scheduled_file&amp;file=' . $sFile . '" target="_blank" onclick="event.stopPropagation(); if (!window.confirm(\'' . $sDownloadWarningMessage . '\')) { return false; }"><IMG src="gfx/menu_save.png" alt="Download" width="16" height="16" title="Download file" style="float : right;"></A>');
             $sInformationHTML = (!$aFile['scheduled'] || !$bConverted? '' : '
-                    <IMG src="gfx/lovd_form_information.png" alt="Information" width="16" height="16" title="' . ($sFile == $sFileDisplayName? '' : $sFile . ' - ') . 'Scheduled ' . $zScheduledFiles[$sFile]['scheduled_date'] . ' by ' . $zScheduledFiles[$sFile]['scheduled_by_name'] . '" style="float : right;">');
+                    <IMG src="gfx/lovd_form_information.png" alt="Information" width="16" height="16" title="' . ($sFile == $sFileDisplayName? '' : $sFile . ' - ') . 'Scheduled ' . date('Y-m-d H:i:s P (T)', strtotime($zScheduledFiles[$sFile]['scheduled_date'])) . ' by ' . $zScheduledFiles[$sFile]['scheduled_by_name'] . '" style="float : right;">');
             $sPriorityHTML = (!$aFile['priority']? '' : '
                     <IMG src="gfx/lovd_form_warning.png" alt="Priority" width="16" height="16" title="Priority import: ' . $_SETT['import_priorities'][$aFile['priority']] . '" style="float : right;">');
             $sProcessingHTML = (!$bProcessing? '' : '
                     <IMG src="gfx/menu_clock.png" alt="Processing ..." width="16" height="16" title="' .
-                ($bConverted? 'Processing' : 'Conversion') . ' started ' . $aFile['processed_date'] . '" style="float : right;">');
+                ($bConverted? 'Processing' : 'Conversion') . ' started ' . date('Y-m-d H:i:s P (T)', strtotime($aFile['processed_date'])) . '" style="float : right;">');
             $sErrorsHTML = (!$bError? '' : '
                     <IMG src="gfx/cross.png" alt="Errors while processing" width="16" height="16" title="Errors while processing:' . "\n" .
                 ($bProcessed? htmlspecialchars($zScheduledFiles[$sFile]['process_errors']) :
@@ -393,7 +393,7 @@ if (ACTION == 'schedule' && PATH_COUNT == 1) {
             print('
                   <TD>' . $sDownloadHTML . $sInformationHTML . $sPriorityHTML . $sProcessingHTML . $sErrorsHTML . '
                     <B>' . $sFileDisplayName . '</B><BR>
-                    <SPAN class="S11">' . ($aFile['file_lost']? 'File not found' : $aFile['file_date'] . ' - ' . ($bAPI? 'Submitted' : (LOVD_plus && $bConverted? 'Converted' : 'Created')) . ' ' . $sAge . ' ago') . '</SPAN>
+                    <SPAN class="S11">' . ($aFile['file_lost']? 'File not found' : date('Y-m-d H:i:s P (T)', strtotime($aFile['file_date'])) . ' - ' . ($bAPI? 'Submitted' : (LOVD_plus && $bConverted? 'Converted' : 'Created')) . ' ' . $sAge . ' ago') . '</SPAN>
                   </TD></TR>');
         }
         print('</TABLE><BR>' .

--- a/src/import.php
+++ b/src/import.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2020-02-06
+ * Modified    : 2020-02-10
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2413,7 +2413,6 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
                     'country_' => 'Country',
                     'email' => 'Email address',
                     'telephone' => 'Telephone',
-                    'reference' => 'Reference',
                 );
             $zUser['country_'] = $_DB->query('SELECT name FROM ' . TABLE_COUNTRIES . ' WHERE id = ?', array($zUser['countryid']))->fetchColumn();
 

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-02-13
+ * Modified    : 2020-02-18
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -149,7 +149,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-22',
+                            'version' => '3.0-23',
                           ),
                 'user_levels' =>
                      array(
@@ -374,7 +374,7 @@ $_SETT = array(
                                                             '22' => 'NC_000022.10',
                                                             'X'  => 'NC_000023.10',
                                                             'Y'  => 'NC_000024.9',
-                                                            'M'  => 'NC_012920.1',
+                                                            'M'  => 'NC_012920.1', // Note that hg19 uses NC_012920!
                                                           ),
                                           ),
                             // http://www.ncbi.nlm.nih.gov/projects/genome/assembly/grc/human/data/

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-01-16
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-06
+ * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -269,7 +269,6 @@ $_SETT = array(
                 'upstream_URL' => 'http://www.LOVD.nl/',
                 'upstream_BTS_URL' => 'https://github.com/LOVDnl/LOVD3/issues/',
                 'upstream_BTS_URL_new_ticket' => 'https://github.com/LOVDnl/LOVD3/issues/new',
-                'wikiprofessional_iprange' => '131.174.88.0-255',
                 'list_sizes' =>
                      array(
                             10,
@@ -760,10 +759,7 @@ if (get_magic_quotes_gpc()) {
 }
 
 // Use of SSL required?
-// FIXME:
-//// (SSL not required when exporting data to WikiProfessional because their scripts do not support it)
-//// (The UCSC also has issues with retrieving the BED files through SSL...)
-//if (!empty($_CONF['use_ssl']) && !SSL && !(lovd_getProjectFile() == '/export_data.php' && !empty($_GET['format']) && $_GET['format'] == 'wiki') && !(substr(lovd_getProjectFile(), 0, 9) == '/api/rest' && !empty($_GET['format']) && $_GET['format'] == 'text/bed')) {
+// (The UCSC has issues with retrieving the BED files through SSL...)
 if (!empty($_CONF['use_ssl']) && !SSL && !(lovd_getProjectFile() == '/api.php' && !empty($_GET['format']) && $_GET['format'] == 'text/bed')) {
     // We were enabled, when SSL was available. So I guess SSL is still available. If not, this line here would be a problem.
     // No, not sending any $_POST values either. Let's just assume no-one is working with LOVD when the ssl setting is activated.

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-02-06
+ * Modified    : 2020-02-13
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -659,7 +659,7 @@ if ($_INI['database']['driver'] == 'mysql') {
 
 
 
-ini_set('default_charset','UTF-8');
+@ini_set('default_charset','UTF-8');
 if (function_exists('mb_internal_encoding')) {
     mb_internal_encoding('UTF-8');
 }
@@ -728,8 +728,9 @@ if (defined('MISSING_CONF') || defined('MISSING_STAT') || !preg_match('/^([1-9]\
         define('NOT_INSTALLED', true);
     }
 
+    // phpunit check is necessary because our Travis tests load inc-init.php when we're not installed yet to get LOVD globals.
     // inc-js-submit-settings.php check is necessary because it gets included in the install directory.
-    if (dirname(lovd_getProjectFile()) != '/install' && lovd_getProjectFile() != '/inc-js-submit-settings.php') {
+    if (dirname(lovd_getProjectFile()) != '/install' && !in_array(lovd_getProjectFile(), array('phpunit', '/inc-js-submit-settings.php'))) {
         // We're not installing, so throwing an error.
 
         if (defined('NOT_INSTALLED')) {
@@ -769,11 +770,11 @@ if (!empty($_CONF['use_ssl']) && !SSL && !(lovd_getProjectFile() == '/api.php' &
 }
 
 // Session settings - use cookies.
-ini_set('session.use_cookies', 1);
-ini_set('session.use_only_cookies', 1);
+@ini_set('session.use_cookies', 1);
+@ini_set('session.use_only_cookies', 1);
 if (ini_get('session.cookie_path') == '/') {
     // Don't share cookies with other systems - set the cookie path!
-    ini_set('session.cookie_path', lovd_getInstallURL(false));
+    @ini_set('session.cookie_path', lovd_getInstallURL(false));
 }
 if (!empty($_STAT['signature'])) {
     // Set the session name to something unique, to prevent mixing cookies with other LOVDs on the same server.
@@ -781,7 +782,7 @@ if (!empty($_STAT['signature'])) {
 } else {
     $_SETT['cookie_id'] = md5($_INI['database']['database'] . $_INI['database']['table_prefix']);
 }
-session_name('PHPSESSID_' . $_SETT['cookie_id']);
+@session_name('PHPSESSID_' . $_SETT['cookie_id']);
 
 // Start sessions - use cookies.
 @session_start(); // On some Ubuntu distributions this can cause a distribution-specific error message when session cleanup is triggered.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-10
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -1124,6 +1124,35 @@ function lovd_getTableInfoByCategory ($sCategory)
         return false;
     }
     return $aTables[$sCategory];
+}
+
+
+
+
+
+function lovd_hideEmail ($s)
+{
+    // Function kindly provided by Ileos.nl in the interest of Open Source.
+    // Obscure email addresses from spambots.
+
+    $a_replace = array(45 => '-', '.',
+        48 => '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+        64 => '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+        95 => '_',
+        97 => 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    );
+
+    $s_return = '';
+    for ($i = 0; $i < strlen($s); $i ++) {
+        $s_sub = substr($s, $i, 1);
+        if ($key = array_search($s_sub, $a_replace)) {
+            $s_return .= '&#' . str_pad($key, 3, '0', STR_PAD_LEFT) . ';';
+        } else {
+            $s_return .= $s_sub;
+        }
+    }
+
+    return $s_return;
 }
 
 

--- a/src/inc-lib-viewlist.php
+++ b/src/inc-lib-viewlist.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-22
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-10
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -112,35 +112,6 @@ function lovd_formatSearchExpression ($sExpression, $sColumnType)
     }
 
     return preg_replace('/{{SPACE}}/', ' ', $sFormattedExpressions);
-}
-
-
-
-
-
-function lovd_hideEmail ($s)
-{
-    // Function kindly provided by Ileos.nl in the interest of Open Source.
-    // Obscure email addresses from spambots.
-
-    $a_replace = array(45 => '-', '.',
-        48 => '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-        64 => '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-        95 => '_',
-        97 => 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-    );
-
-    $s_return = '';
-    for ($i = 0; $i < strlen($s); $i ++) {
-        $s_sub = substr($s, $i, 1);
-        if ($key = array_search($s_sub, $a_replace)) {
-            $s_return .= '&#' . str_pad($key, 3, '0', STR_PAD_LEFT) . ';';
-        } else {
-            $s_return .= $s_sub;
-        }
-    }
-
-    return $s_return;
 }
 
 

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2020-01-22
+ * Modified    : 2020-02-06
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -684,6 +684,9 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                      'UPDATE ' . TABLE_COLS . ' SET select_options = "intergenic\r\nnear-gene-5\r\nutr-5\r\nstart-lost\r\ncoding\r\nnon-coding-exon\r\ncoding-near-splice\r\nnon-coding-exon-near-splice\r\ncoding-synonymous\r\ncoding-synonymous-near-splice\r\ncodingComplex\r\ncodingComplex-near-splice\r\nframeshift\r\nframeshift-near-splice\r\nmissense\r\nmissense-near-splice\r\nsplice-5\r\nsplice\r\nnon-coding-intron-near-splice\r\nintron\r\nsplice-3\r\nstop-gained\r\nstop-gained-near-splice\r\nstop-lost\r\nstop-lost-near-splice\r\nutr-3\r\nnear-gene-3" WHERE select_options = "intergenic\r\nnear-gene-5\r\nutr-5\r\ncoding\r\ncoding-near-splice\r\ncoding-synonymous\r\ncoding-synonymous-near-splice\r\ncodingComplex\r\ncodingComplex-near-splice\r\nframeshift\r\nframeshift-near-splice\r\nmissense\r\nmissense-near-splice\r\nsplice-5\r\nintron\r\nsplice-3\r\nstop-gained\r\nstop-gained-near-splice\r\nstop-lost\r\nstop-lost-near-splice\r\nutr-3\r\nnear-gene-3" AND id = "VariantOnTranscript/GVS/Function"',
                      'UPDATE ' . TABLE_SHARED_COLS . ' SET select_options = "intergenic\r\nnear-gene-5\r\nutr-5\r\nstart-lost\r\ncoding\r\nnon-coding-exon\r\ncoding-near-splice\r\nnon-coding-exon-near-splice\r\ncoding-synonymous\r\ncoding-synonymous-near-splice\r\ncodingComplex\r\ncodingComplex-near-splice\r\nframeshift\r\nframeshift-near-splice\r\nmissense\r\nmissense-near-splice\r\nsplice-5\r\nsplice\r\nnon-coding-intron-near-splice\r\nintron\r\nsplice-3\r\nstop-gained\r\nstop-gained-near-splice\r\nstop-lost\r\nstop-lost-near-splice\r\nutr-3\r\nnear-gene-3" WHERE select_options = "intergenic\r\nnear-gene-5\r\nutr-5\r\ncoding\r\ncoding-near-splice\r\ncoding-synonymous\r\ncoding-synonymous-near-splice\r\ncodingComplex\r\ncodingComplex-near-splice\r\nframeshift\r\nframeshift-near-splice\r\nmissense\r\nmissense-near-splice\r\nsplice-5\r\nintron\r\nsplice-3\r\nstop-gained\r\nstop-gained-near-splice\r\nstop-lost\r\nstop-lost-near-splice\r\nutr-3\r\nnear-gene-3" AND colid = "VariantOnTranscript/GVS/Function"',
                  ),
+                 '3.0-23' => array(
+                     'ALTER TABLE ' . TABLE_GENES . ' DROP COLUMN allow_index_wiki',
+                 )
              );
 
     if ($sCalcVersionDB < lovd_calculateVersion('3.0-alpha-01')) {

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2020-02-06
+ * Modified    : 2020-02-10
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -686,6 +686,7 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                  ),
                  '3.0-23' => array(
                      'ALTER TABLE ' . TABLE_GENES . ' DROP COLUMN allow_index_wiki',
+                     'ALTER TABLE ' . TABLE_USERS . ' DROP COLUMN references',
                  )
              );
 

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2020-02-10
+ * Modified    : 2020-02-18
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -686,7 +686,7 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                  ),
                  '3.0-23' => array(
                      'ALTER TABLE ' . TABLE_GENES . ' DROP COLUMN allow_index_wiki',
-                     'ALTER TABLE ' . TABLE_USERS . ' DROP COLUMN references',
+                     'ALTER TABLE ' . TABLE_USERS . ' DROP COLUMN reference',
                  )
              );
 

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2019-10-01
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-10
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -371,8 +371,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
 
             if (!$bSubmit && !(GET && ACTION == 'publish')) {
                 // Put $zData with the old values in $_SESSION for mailing.
-                // FIXME; change owner to owned_by_ in the load entry query of object_individuals.php.
-                $zData['owned_by_'] = $zData['owner'];
                 $_SESSION['work']['edits']['individual'][$nID] = $zData;
             }
 
@@ -543,6 +541,8 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
         }
 
         if (!lovd_error()) {
+            // FIXME: All of this doesn't look right. We should first check which genes are linked to the *public variants*, if we're deleting them OR if this Ind is public.
+            //  Only then can you delete the variants when requested. Now it's the other way around, and the selection isn't done right.
             // Query text.
             // This also deletes the entries in TABLE_PHENOTYPES && TABLE_SCREENINGS && TABLE_SCR2VAR && TABLE_SCR2GENES.
             $_DB->beginTransaction();
@@ -573,7 +573,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
             $_DB->commit();
 
             // Write to log...
-            lovd_writeLog('Event', LOG_EVENT, 'Deleted individual information entry ' . $nID . ' (Owner: ' . $zData['owner'] . ')');
+            lovd_writeLog('Event', LOG_EVENT, 'Deleted individual information entry ' . $nID . ' (Owner: ' . $zData['owned_by_'] . ')');
 
             // Thank the user...
             header('Refresh: 3; url=' . lovd_getInstallURL() . $_PE[0]);
@@ -608,7 +608,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
     $aForm = array_merge(
                  array(
                         array('POST', '', '', '', '45%', '14', '55%'),
-                        array('Deleting individual information entry', '', 'print', '<B>' . $nID . ' (Owner: ' . $zData['owner'] . ')</B>'),
+                        array('Deleting individual information entry', '', 'print', '<B>' . $nID . ' (Owner: ' . $zData['owned_by_'] . ')</B>'),
                         'skip',
                         array('', '', 'print', 'This individual entry has ' . ($nVariants? $nVariants : 0) . ' variant' . ($nVariants == 1? '' : 's') . ' attached.'),
           'variants' => array('What should LOVD do with the attached variants?', '', 'select', 'remove_variants', 1, $aOptions, false, false, false),

--- a/src/install/inc-sql-tables.php
+++ b/src/install/inc-sql-tables.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-22
- * Modified    : 2019-08-27
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-06
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -136,7 +136,6 @@ $aTableSQL =
     url_homepage VARCHAR(255) NOT NULL DEFAULT "",
     url_external TEXT,
     allow_download BOOLEAN NOT NULL DEFAULT 0,
-    allow_index_wiki BOOLEAN NOT NULL DEFAULT 0,
     id_hgnc INT(10) UNSIGNED' . (LOVD_plus? '' : ' NOT NULL') . ',
     id_entrez INT(10) UNSIGNED,
     id_omim INT(10) UNSIGNED,

--- a/src/install/inc-sql-tables.php
+++ b/src/install/inc-sql-tables.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-22
- * Modified    : 2020-02-06
+ * Modified    : 2020-02-10
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -74,7 +74,6 @@ $aTableSQL =
     countryid CHAR(2),
     email TEXT NOT NULL,
     email_confirmed BOOLEAN NOT NULL DEFAULT 0,
-    reference VARCHAR(50) NOT NULL DEFAULT "",
     username VARCHAR(50) NOT NULL,
     password CHAR(50) NOT NULL,
     password_autogen CHAR(50),

--- a/src/install/index.php
+++ b/src/install/index.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-10
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -442,11 +442,11 @@ if ($_GET['step'] == 2 && defined('NOT_INSTALLED')) {
     // (3) Creating LOVD user & administrator.
     $aInstallSQL['Creating LOVD account &amp; LOVD database administrator account...'] =
              array(
-                    'INSERT INTO ' . TABLE_USERS . ' (name, institute, department, telephone, address, city, email, reference, username, password, password_force_change, level, allowed_ip, login_attempts, created_date) VALUES ("LOVD' . (LOVD_plus? '+' : '') . '", "", "", "", "", "", "", "", "", "", 0, 0, "", 9, NOW())',
+                    'INSERT INTO ' . TABLE_USERS . ' (name, institute, department, telephone, address, city, email, username, password, password_force_change, level, allowed_ip, login_attempts, created_date) VALUES ("LOVD' . (LOVD_plus? '+' : '') . '", "", "", "", "", "", "", "", "", 0, 0, "", 9, NOW())',
                     'UPDATE ' . TABLE_USERS . ' SET id = 0, created_by = 0',
-                    'INSERT INTO ' . TABLE_USERS . ' (id, name, institute, department, telephone, address, city, countryid, email, reference, username, password, password_autogen, password_force_change, phpsessid, saved_work, level, allowed_ip, login_attempts, last_login, created_by, created_date) VALUES
+                    'INSERT INTO ' . TABLE_USERS . ' (id, name, institute, department, telephone, address, city, countryid, email, username, password, password_autogen, password_force_change, phpsessid, saved_work, level, allowed_ip, login_attempts, last_login, created_by, created_date) VALUES
                      ("00001", ' . $_DB->quote($_POST['name']) . ', ' . $_DB->quote($_POST['institute']) . ', ' . $_DB->quote($_POST['department']) . ', ' . $_DB->quote($_POST['telephone']) . ', ' . $_DB->quote($_POST['address']) . ', ' .
-                        $_DB->quote($_POST['city']) . ', ' . $_DB->quote($_POST['countryid']) . ', ' . $_DB->quote($_POST['email']) . ', ' . $_DB->quote($_POST['reference']) . ', ' . $_DB->quote($_POST['username']) . ', ' . $_DB->quote($_POST['password']) . ', "", 0, "' . session_id() . '", "", ' . LEVEL_ADMIN . ', ' . $_DB->quote($_POST['allowed_ip']) . ', 0, NOW(), 1, NOW())',
+                        $_DB->quote($_POST['city']) . ', ' . $_DB->quote($_POST['countryid']) . ', ' . $_DB->quote($_POST['email']) . ', ' . $_DB->quote($_POST['username']) . ', ' . $_DB->quote($_POST['password']) . ', "", 0, "' . session_id() . '", "", ' . LEVEL_ADMIN . ', ' . $_DB->quote($_POST['allowed_ip']) . ', 0, NOW(), 1, NOW())',
                   );
     $nInstallSQL ++;
 

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -116,6 +116,9 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     // Load appropriate user level for this phenotype entry.
     lovd_isAuthorized('phenotype', $nID);
 
+    // Tooltip JS code for the owner field. Other VEs don't have to load this, because they have VLs.
+    lovd_includeJS('inc-js-tooltip.php');
+
     require ROOT_PATH . 'class/object_phenotypes.php';
     $_DATA = new LOVD_Phenotype('', $nID);
     $zData = $_DATA->viewEntry($nID);

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-23
- * Modified    : 2017-11-20
- * For LOVD    : 3.0-21
+ * Modified    : 2020-02-10
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -405,8 +405,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
 
             if (!$bSubmit && !(GET && ACTION == 'publish')) {
                 // Put $zData with the old values in $_SESSION for mailing.
-                // FIXME; change owner to owned_by_ in the load entry query of object_phenotypes.php.
-                $zData['owned_by_'] = $zData['owner'];
                 $zData['diseaseid_'] = $_DB->query('SELECT name FROM ' . TABLE_DISEASES . ' WHERE id = ?', array($zData['diseaseid']))->fetchColumn();
                 $_SESSION['work']['edits']['phenotype'][$nID] = $zData;
             }
@@ -553,7 +551,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
             }
 
             // Write to log...
-            lovd_writeLog('Event', LOG_EVENT, 'Deleted phenotype information entry ' . $nID . ' (Owner: ' . $zData['owner'] . ')');
+            lovd_writeLog('Event', LOG_EVENT, 'Deleted phenotype information entry ' . $nID . ' (Owner: ' . $zData['owned_by_'] . ')');
 
             // Thank the user...
             header('Refresh: 3; url=' . lovd_getInstallURL() . 'individuals/' . $zData['individualid']);
@@ -585,7 +583,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
     $aForm = array_merge(
                  array(
                         array('POST', '', '', '', '40%', '14', '60%'),
-                        array('Deleting phenotype information entry', '', 'print', $nID . ' (Owner: ' . $zData['owner'] . ')'),
+                        array('Deleting phenotype information entry', '', 'print', $nID . ' (Owner: ' . $zData['owned_by_'] . ')'),
                         'skip',
                         array('Enter your password for authorization', '', 'password', 'password', 20),
                         array('', '', 'submit', 'Delete phenotype information entry'),

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2019-08-22
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-10
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -356,8 +356,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
 
             if (!$bSubmit) {
                 // Put $zData with the old values in $_SESSION for mailing.
-                // FIXME; change owner to owned_by_ in the load entry query of object_screenings.php.
-                $zData['owned_by_'] = $zData['owner'];
                 if ($zData['variants_found']) {
                     $zData['variants_found_'] = $_DB->query('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn();
                     if (!$zData['variants_found_']) {
@@ -930,7 +928,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
     $aForm = array_merge(
                  array(
                         array('POST', '', '', '', '40%', '14', '60%'),
-                        array('Deleting screening information entry', '', 'print', '<B>' . $nID . ' (Owner: ' . $zData['owner'] . ')</B>'),
+                        array('Deleting screening information entry', '', 'print', '<B>' . $nID . ' (Owner: ' . $zData['owned_by_'] . ')</B>'),
                         'skip',
                         array('', '', 'print', 'This screening entry has ' . ($nVariants? $nVariants : 0) . ' variant' . ($nVariants == 1? '' : 's') . ' attached.'),
 'variants_removable' => array('', '', 'print', (!$nVariantsRemovable? 'No variants will be removed.' : '<B>' . $nVariantsRemovable . ' variant' . ($nVariantsRemovable == 1? '' : 's') . ' will be removed, because ' . ($nVariantsRemovable == 1? 'it is' : 'these are'). ' not attached to other screenings!!!</B>')),

--- a/src/scripts/convert_lovd2.php
+++ b/src/scripts/convert_lovd2.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-10-04
- * Modified    : 2019-08-08
- * For LOVD    : 3.0-22
+ * Modified    : 2020-01-30
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2014-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2014-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
@@ -71,6 +71,7 @@ $aFieldLinks = array(
     'Patient/Occurrence' =>             array('phenotype',  'Phenotype/Inheritance',        'lovd_convertInheritance'),
     'Patient/Phenotype/Inheritance' =>  array('phenotype',  'Phenotype/Inheritance',        'lovd_convertInheritance'),
     'Patient/Mutation/Origin' =>        array('vog',        'VariantOnGenome/Genetic_origin',   'lovd_convertOrigin'),
+    'Patient/Variant_Origin' =>         array('vog',        'VariantOnGenome/Genetic_origin',   'lovd_convertOrigin'),
     'Patient/Origin/Ethnic' =>          array('individual', 'Individual/Origin/Population'),
     'Patient/Age' =>                    array('phenotype',  'Phenotype/Age'),
     'Patient/Phenotype/Age_exam' =>     array('phenotype',  'Phenotype/Age'),
@@ -102,6 +103,7 @@ $aFieldLinks = array(
 // will be preferred, so be careful to place more generic prefixes at the
 // bottom.
 $aCustomColLinks = array(
+    'Patient/Detection' =>  array('screening', 'Screening'),
     'Variant/Detection' =>  array('screening', 'Screening'),
     'Variant' =>            array('vot', 'VariantOnTranscript'),
     'Patient/Phenotype' =>  array('phenotype', 'Phenotype'),

--- a/src/submit.php
+++ b/src/submit.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-21
- * Modified    : 2019-08-07
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-10
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -646,7 +646,6 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
             'country_' => 'Country',
             'email' => 'Email address',
             'telephone' => 'Telephone',
-            'reference' => 'Reference',
         );
     $aIndividualFields =
         array(

--- a/src/users.php
+++ b/src/users.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2018-03-09
- * For LOVD    : 3.0-21
+ * Modified    : 2020-02-10
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -458,7 +458,7 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
 
         if (!lovd_error()) {
             // Fields to be used.
-            $aFields = array('name', 'institute', 'department', 'telephone', 'address', 'city', 'countryid', 'email', 'reference', 'username', 'password', 'password_force_change', 'level', 'allowed_ip', 'login_attempts', 'created_date');
+            $aFields = array('name', 'institute', 'department', 'telephone', 'address', 'city', 'countryid', 'email', 'username', 'password', 'password_force_change', 'level', 'allowed_ip', 'login_attempts', 'created_date');
 
             // Prepare values.
             if ($_POST['orcid_id'] != 'none') {
@@ -549,7 +549,6 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
                         'country_' => 'Country',
                         'email' => 'Email address',
                         'telephone' => 'Telephone',
-                        'reference' => 'Reference',
                         'username' => 'Username',
                         'password_1' => 'Password',
                         'allowed_ip' => 'Allowed IPs',
@@ -700,7 +699,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
 
         if (!lovd_error()) {
             // Fields to be used.
-            $aFields = array('name', 'institute', 'department', 'telephone', 'address', 'city', 'countryid', 'email', 'reference', 'password_force_change', 'level', 'allowed_ip', 'login_attempts', 'edited_by', 'edited_date');
+            $aFields = array('name', 'institute', 'department', 'telephone', 'address', 'city', 'countryid', 'email', 'password_force_change', 'level', 'allowed_ip', 'login_attempts', 'edited_by', 'edited_date');
 
             // Prepare values.
             // In case the password is getting changed...

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2020-01-16
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-04
+ * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -437,28 +437,18 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         if ($_AUTH['level'] >= $_SETT['user_level_settings']['delete_variant']) {
             $aNavigation[CURRENT_PATH . '?delete'] = array('cross.png', 'Delete variant entry', 1);
         }
-        if (!empty($zData['position_g_start']) && $_CONF['refseq_build'] != '----') {
-            $lVariant = abs($zData['position_g_end'] - $zData['position_g_start']);
-            $lMargin = ($lVariant > 20? 5 : round((30 - $lVariant)/2));
+    }
+    if (!empty($zData['position_g_start']) && $_CONF['refseq_build'] != '----') {
+        if ($bAuthorized) {
             $aNavigation['javascript:lovd_openWindow(\'' . lovd_getInstallURL() . CURRENT_PATH . '?search_global\', \'global_search\', 900, 450);'] = array('menu_magnifying_glass.png', 'Search public LOVDs', 1);
-            // FIXME; Once this navigation menu supports multi-level menu's, add this in a sub level.
-            $aNavigation['javascript:lovd_openWindow(\'http://genome.ucsc.edu/cgi-bin/hgTracks?clade=mammal&amp;org=Human&amp;db=' . $_CONF['refseq_build'] . '&amp;position=chr' . $zData['chromosome'] . ':' . ($zData['position_g_start'] - $lMargin) . '-' . ($zData['position_g_end'] + $lMargin) . '&amp;width=800&amp;ruler=full&amp;ccdsGene=full\', \'variant_UCSC\', 1000, 500);'] = array('menu_magnifying_glass.png', 'Visualize in UCSC genome browser', 1);
-            $sURLEnsembl = 'http://' . ($_CONF['refseq_build'] == 'hg18'? 'may2009.archive' : ($_CONF['refseq_build'] == 'hg19'? 'grch37' : 'www')) . '.ensembl.org/Homo_sapiens/Location/View?r=' . $zData['chromosome'] . ':' . ($zData['position_g_start'] - $lMargin) . '-' . ($zData['position_g_end'] + $lMargin);
-            $aNavigation['javascript:lovd_openWindow(\'' . $sURLEnsembl . '\', \'variant_Ensembl\', 1000, 500);'] = array('menu_magnifying_glass.png', 'Visualize in Ensembl genome browser', 1);
-            // FIXME; For loading the BED file, we'll need a gene symbol!
-//            $sURLBedFile = rawurlencode(str_replace('https://', 'http://', ($_CONF['location_url']? $_CONF['location_url'] : lovd_getInstallURL())) . 'api/rest/variants/' . $zData['id'] . '?format=text/bed');
-//            $sURLUCSC = 'http://genome.ucsc.edu/cgi-bin/hgTracks?clade=mammal&amp;org=Human&amp;db=' . $_CONF['refseq_build'] . '&amp;position=chr' . $zData['chromosome'] . ':' . ($zData['position_g_mrna_start'] - 50) . '-' . ($zData['position_g_mrna_end'] + 50) . ($zData['sense']? '' : '&amp;complement_hg19=1') . '&amp;hgt.customText=' . $sURLBedFile;
-//            $zData['ucsc'] = 'Show variants in the UCSC Genome Browser (<A href="' . $sURLUCSC . '" target="_blank">full view</A>, <A href="' . $sURLUCSC . rawurlencode('&visibility=4') . '" target="_blank">compact view</A>)';
-//            // The weird addition in the end is to fake a proper name in Ensembl.
-//            if ($_CONF['refseq_build'] == 'hg18') {
-//                $sURLEnsembl = 'http://may2009.archive.ensembl.org/Homo_sapiens/Location/View?r=' . $zData['chromosome'] . ':' . ($zData['position_g_mrna_start'] - 50) . '-' . ($zData['position_g_mrna_end'] + 50) . ';data_URL=' . $sURLBedFile . rawurlencode('&name=/' . $zData['id'] . ' variants');
-//                //} elseif ($_CONF['refseq_build'] == 'hg19') {
-//            } else {
-//                $sURLEnsembl = 'http://www.ensembl.org/Homo_sapiens/Location/View?r=' . $zData['chromosome'] . ':' . ($zData['position_g_mrna_start'] - 50) . '-' . ($zData['position_g_mrna_end'] + 50) . ';contigviewbottom=url:' . $sURLBedFile . rawurlencode('&name=/' . $zData['id'] . ' variants');
-//            }
-//            $zData['ensembl'] = 'Show variants in the Ensembl Genome Browser (<A href="' . $sURLEnsembl . '=labels" target="_blank">full view</A>, <A href="' . $sURLEnsembl . '=normal" target="_blank">compact view</A>)';
-//            $zData['ncbi'] = 'Show distribution histogram of variants in the <A href="http://www.ncbi.nlm.nih.gov/projects/sviewer/?id=' . $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$zData['chromosome']] . '&amp;v=' . ($zData['position_g_mrna_start'] - 100) . ':' . ($zData['position_g_mrna_end'] + 100) . '&amp;content=7&amp;url=' . $sURLBedFile . '" target="_blank">NCBI Sequence Viewer</A>';
         }
+        $lVariant = abs($zData['position_g_end'] - $zData['position_g_start']);
+        $lMargin = ($lVariant > 20? 5 : round((30 - $lVariant)/2));
+        // FIXME; Once this navigation menu supports multi-level menu's, add this in a sub level.
+        // FIXME: Add the BED file here?
+        $aNavigation['javascript:lovd_openWindow(\'http://genome.ucsc.edu/cgi-bin/hgTracks?clade=mammal&amp;org=Human&amp;db=' . $_CONF['refseq_build'] . '&amp;position=chr' . $zData['chromosome'] . ':' . ($zData['position_g_start'] - $lMargin) . '-' . ($zData['position_g_end'] + $lMargin) . '&amp;width=800&amp;ruler=full&amp;ccdsGene=full\', \'variant_UCSC\', 1000, 500);'] = array('menu_magnifying_glass.png', 'View location in UCSC genome browser', 1);
+        $sURLEnsembl = 'http://' . ($_CONF['refseq_build'] == 'hg18'? 'may2009.archive' : ($_CONF['refseq_build'] == 'hg19'? 'grch37' : 'www')) . '.ensembl.org/Homo_sapiens/Location/View?r=' . $zData['chromosome'] . ':' . ($zData['position_g_start'] - $lMargin) . '-' . ($zData['position_g_end'] + $lMargin);
+        $aNavigation['javascript:lovd_openWindow(\'' . $sURLEnsembl . '\', \'variant_Ensembl\', 1000, 500);'] = array('menu_magnifying_glass.png', 'View location in Ensembl genome browser', 1);
     }
     lovd_showJGNavigation($aNavigation, 'Variants');
 

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2020-02-04
+ * Modified    : 2020-02-06
  * For LOVD    : 3.0-23
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1833,7 +1833,6 @@ if (PATH_COUNT == 2 && $_PE[1] == 'upload' && ACTION == 'create') {
                                         'url_homepage' => '',
                                         'url_external' => '',
                                         'allow_download' => 0,
-                                        'allow_index_wiki' => 0,
                                         'id_hgnc' => $sHgncID,
                                         'id_entrez' => $sEntrez,
                                         'id_omim' => $sOmim,

--- a/tests/selenium_tests/access_sharing_tests/access_sharing_submitter.php
+++ b/tests/selenium_tests/access_sharing_tests/access_sharing_submitter.php
@@ -4,11 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-04-21
- * Modified    : 2016-08-11
- * For LOVD    : 3.0-17
+ * Modified    : 2020-02-18
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2016-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -58,6 +59,8 @@ class AccessSharingSubmitterTest extends LOVDSeleniumWebdriverBaseTestCase
         // Create individual as first submitter.
         $this->driver->get(ROOT_URL . "/src/individuals?create");
         $this->enterValue(WebDriverBy::name("Individual/Lab_ID"), "dummy");
+        $option = $this->driver->findElement(WebDriverBy::xpath('//select[@name="active_diseases[]"]/option[text()="Healthy/Control (Healthy individual / control)"]'));
+        $option->click();
         $createButton = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Create individual information entry']"));
         $createButton->click();
 

--- a/tests/selenium_tests/admin_tests/add_summary_variant_only_described_on_genomic_level.php
+++ b/tests/selenium_tests/admin_tests/add_summary_variant_only_described_on_genomic_level.php
@@ -8,7 +8,7 @@ class AddSummaryVariantOnlyDescribedOnGenomicLevelTest extends LOVDSeleniumWebdr
 {
     public function testAddSummaryVariantOnlyDescribedOnGenomicLevel()
     {
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000168$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000168($|#)/', $this->driver->getCurrentURL()));
 
         // Mouse hover over Submit tab, to make 'submit new data' link visible.
         $tabElement = $this->driver->findElement(WebDriverBy::xpath("//img[@id='tab_submit']"));

--- a/tests/selenium_tests/admin_tests/post_finish_add_variant_only_described_on_genomic_level_to_IVA_individual.php
+++ b/tests/selenium_tests/admin_tests/post_finish_add_variant_only_described_on_genomic_level_to_IVA_individual.php
@@ -49,6 +49,6 @@ class PostFinishAddVariantOnlyDescribedOnGenomicLevelToIVAIndividualTest extends
         // wait for page redirect
         $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000333$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000333($|#)/', $this->driver->getCurrentURL()));
     }
 }

--- a/tests/selenium_tests/collaborator_tests/curate_submitted_data.php
+++ b/tests/selenium_tests/collaborator_tests/curate_submitted_data.php
@@ -18,7 +18,7 @@ class CurateSubmittedDataTest extends LOVDSeleniumWebdriverBaseTestCase
         $element = $this->driver->findElement(WebDriverBy::linkText("0000000001"));
         $element->click();
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000001$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000001($|#)/', $this->driver->getCurrentURL()));
         $this->assertEquals("Pending", $this->driver->findElement(WebDriverBy::xpath("//tr[12]/td/span"))->getText());
         $element = $this->driver->findElement(WebDriverBy::id("viewentryOptionsButton_Variants"));
         $element->click();
@@ -48,7 +48,7 @@ class CurateSubmittedDataTest extends LOVDSeleniumWebdriverBaseTestCase
         $element = $this->driver->findElement(WebDriverBy::linkText("0000000002"));
         $element->click();
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000002$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000002($|#)/', $this->driver->getCurrentURL()));
         $this->assertEquals("Pending", $this->driver->findElement(WebDriverBy::xpath("//tr[12]/td/span"))->getText());
         $element = $this->driver->findElement(WebDriverBy::id("viewentryOptionsButton_Variants"));
         $element->click();

--- a/tests/selenium_tests/collaborator_tests/post_finish_add_screening_to_CMT_individual.php
+++ b/tests/selenium_tests/collaborator_tests/post_finish_add_screening_to_CMT_individual.php
@@ -10,24 +10,24 @@ class PostFinishAddScreeningToCMTIndividualTest extends LOVDSeleniumWebdriverBas
     {
         $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000004$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000004($|#)/', $this->driver->getCurrentURL()));
 
         // Move mouse to Screenings tab and click 'view all screenings' option.
         $tabElement = $this->driver->findElement(WebDriverBy::id("tab_individuals"));
         $this->driver->getMouse()->mouseMove($tabElement->getCoordinates());
         $allIndividualsLink = $this->driver->findElement(WebDriverBy::partialLinkText('View all individuals'));
         $allIndividualsLink->click();
-        
+
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/individuals$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::cssSelector("td.ordered"));
         $element->click();
-        
+
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/individuals\/00000001$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::id("viewentryOptionsButton_Individuals"));
         $element->click();
         $element = $this->driver->findElement(WebDriverBy::linkText("Add screening to individual"));
         $element->click();
-        
+
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/screenings[\s\S]create&target=00000001$/', $this->driver->getCurrentURL()));
         $option = $this->driver->findElement(WebDriverBy::xpath('//select[@name="Screening/Template[]"]/option[text()="RNA (cDNA)"]'));
         $option->click();
@@ -46,8 +46,8 @@ class PostFinishAddScreeningToCMTIndividualTest extends LOVDSeleniumWebdriverBas
         $this->check(WebDriverBy::name("variants_found"));
         $element = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Create screening information entry']"));
         $element->click();
-        
+
         $this->assertEquals("Successfully created the screening entry!", $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
-        
+
     }
 }

--- a/tests/selenium_tests/collaborator_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
+++ b/tests/selenium_tests/collaborator_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
@@ -11,7 +11,7 @@ class PostFinishAddVariantLocatedWithinGeneToCMTTest extends LOVDSeleniumWebdriv
         // Wait for redirect
         $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000003$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000003($|#)/', $this->driver->getCurrentURL()));
 
         // Move mouse to Screenings tab and click 'view all screenings' option.
         $tabElement = $this->driver->findElement(WebDriverBy::id("tab_screenings"));

--- a/tests/selenium_tests/curator_tests/add_summary_variant_only_described_on_genomic_level.php
+++ b/tests/selenium_tests/curator_tests/add_summary_variant_only_described_on_genomic_level.php
@@ -11,7 +11,7 @@ class AddSummaryVariantOnlyDescribedOnGenomicLevelTest extends LOVDSeleniumWebdr
         // Wait for redirect
         $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000003$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000003($|#)/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::id("tab_submit"));
         $element->click();
 

--- a/tests/selenium_tests/curator_tests/post_finish_add_screening_to_CMT_individual.php
+++ b/tests/selenium_tests/curator_tests/post_finish_add_screening_to_CMT_individual.php
@@ -11,7 +11,7 @@ class PostFinishAddScreeningToCMTIndividualTest extends LOVDSeleniumWebdriverBas
         // Wait for redirect
         $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000006$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000006($|#)/', $this->driver->getCurrentURL()));
 
         // Move mouse to Screenings tab and click 'view all screenings' option.
         $tabElement = $this->driver->findElement(WebDriverBy::id("tab_individuals"));
@@ -23,13 +23,13 @@ class PostFinishAddScreeningToCMTIndividualTest extends LOVDSeleniumWebdriverBas
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/individuals$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::cssSelector("td.ordered"));
         $element->click();
-        
+
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/individuals\/00000001$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::id("viewentryOptionsButton_Individuals"));
         $element->click();
         $element = $this->driver->findElement(WebDriverBy::linkText("Add screening to individual"));
         $element->click();
-        
+
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/screenings[\s\S]create&target=00000001$/', $this->driver->getCurrentURL()));
         $option = $this->driver->findElement(WebDriverBy::xpath('//select[@name="Screening/Template[]"]/option[text()="RNA (cDNA)"]'));
         $option->click();
@@ -49,8 +49,8 @@ class PostFinishAddScreeningToCMTIndividualTest extends LOVDSeleniumWebdriverBas
         $option->click();
         $element = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Create screening information entry']"));
         $element->click();
-        
+
         $this->assertEquals("Successfully created the screening entry!", $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
-        
+
     }
 }

--- a/tests/selenium_tests/curator_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
+++ b/tests/selenium_tests/curator_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
@@ -11,7 +11,7 @@ class PostFinishAddVariantLocatedWithinGeneToCMTIndividualTest extends LOVDSelen
         // Wait for redirect
         $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000005$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000005($|#)/', $this->driver->getCurrentURL()));
 
         // Move mouse to Screenings tab and click 'view all screenings' option.
         $tabElement = $this->driver->findElement(WebDriverBy::id("tab_screenings"));

--- a/tests/selenium_tests/inc-lib-test.php
+++ b/tests/selenium_tests/inc-lib-test.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-07-13
- * Modified    : 2017-12-07
- * For LOVD    : 3.0-18
+ * Modified    : 2020-02-13
+ * For LOVD    : 3.0-23
  *
- * Copyright   : 2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2016-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
@@ -129,6 +129,12 @@ function setMutalyzerServiceURL ($sURL)
     //  the Mutalyzer team. This way, one test run of LOVD also tests their
     //  update.
     list($db,) = getLOVDGlobals();
+
+    if (defined('NOT_INSTALLED')) {
+        // Just return true here. Don't fail on not being able to set this URL.
+        return true;
+    }
+
     $result = $db->query('UPDATE ' . TABLE_CONFIG . ' SET mutalyzer_soap_url=?', array($sURL));
 
     // Return true if query was executed successfully

--- a/tests/selenium_tests/submitter_tests/curate_submitted_data.php
+++ b/tests/selenium_tests/submitter_tests/curate_submitted_data.php
@@ -22,7 +22,7 @@ class CurateSubmittedDataTest extends LOVDSeleniumWebdriverBaseTestCase
         $element = $this->driver->findElement(WebDriverBy::linkText("0000000001"));
         $element->click();
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000001$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000001($|#)/', $this->driver->getCurrentURL()));
         $this->assertEquals("Pending", $this->driver->findElement(WebDriverBy::xpath("//tr[12]/td/span"))->getText());
         $element = $this->driver->findElement(WebDriverBy::id("viewentryOptionsButton_Variants"));
         $element->click();
@@ -52,7 +52,7 @@ class CurateSubmittedDataTest extends LOVDSeleniumWebdriverBaseTestCase
         $element = $this->driver->findElement(WebDriverBy::linkText("0000000002"));
         $element->click();
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000002$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000002($|#)/', $this->driver->getCurrentURL()));
         $this->assertEquals("Pending", $this->driver->findElement(WebDriverBy::xpath("//tr[12]/td/span"))->getText());
         $element = $this->driver->findElement(WebDriverBy::id("viewentryOptionsButton_Variants"));
         $element->click();

--- a/tests/selenium_tests/submitter_tests/post_finish_add_screening_to_CMT_individual.php
+++ b/tests/selenium_tests/submitter_tests/post_finish_add_screening_to_CMT_individual.php
@@ -11,24 +11,24 @@ class PostFinishAddScreeningToCMTIndividualTest extends LOVDSeleniumWebdriverBas
         // Wait for redirect
         $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000004$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000004($|#)/', $this->driver->getCurrentURL()));
 
         // Move mouse to Individuals tab and click 'view all individuals' option.
         $tabElement = $this->driver->findElement(WebDriverBy::id("tab_individuals"));
         $this->driver->getMouse()->mouseMove($tabElement->getCoordinates());
         $allIndividualsLink = $this->driver->findElement(WebDriverBy::partialLinkText('View all individuals'));
         $allIndividualsLink->click();
-        
+
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/individuals$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::cssSelector("td.ordered"));
         $element->click();
-        
+
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/individuals\/00000001$/', $this->driver->getCurrentURL()));
         $element = $this->driver->findElement(WebDriverBy::id("viewentryOptionsButton_Individuals"));
         $element->click();
         $element = $this->driver->findElement(WebDriverBy::linkText("Add screening to individual"));
         $element->click();
-        
+
         $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/screenings[\s\S]create&target=00000001$/', $this->driver->getCurrentURL()));
         $option = $this->driver->findElement(WebDriverBy::xpath('//select[@name="Screening/Template[]"]/option[text()="RNA (cDNA)"]'));
         $option->click();
@@ -46,8 +46,8 @@ class PostFinishAddScreeningToCMTIndividualTest extends LOVDSeleniumWebdriverBas
         $this->check(WebDriverBy::name("variants_found"));
         $element = $this->driver->findElement(WebDriverBy::xpath("//input[@value='Create screening information entry']"));
         $element->click();
-        
+
         $this->assertEquals("Successfully created the screening entry!", $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
-        
+
     }
 }

--- a/tests/selenium_tests/submitter_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
+++ b/tests/selenium_tests/submitter_tests/post_finish_add_variant_located_within_gene_to_CMT_individual.php
@@ -11,7 +11,7 @@ class PostFinishAddVariantLocatedWithinGeneToCMTIndividualTest extends LOVDSelen
         // Wait for redirect
         $this->waitUntil(WebDriverExpectedCondition::titleContains("Genomic variant"));
 
-        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000003$/', $this->driver->getCurrentURL()));
+        $this->assertTrue((bool)preg_match('/^[\s\S]*\/src\/variants\/0000000003($|#)/', $this->driver->getCurrentURL()));
 
         // Move mouse to Screenings tab and click 'view all screenings' option.
         $tabElement = $this->driver->findElement(WebDriverBy::id("tab_screenings"));

--- a/tests/test_data_files/FalseInsertImport.txt
+++ b/tests/test_data_files/FalseInsertImport.txt
@@ -10,9 +10,9 @@
 
 ## Genes ## Do not remove or alter this header ##
 ## Count = 1
-"{{id}}"	"{{name}}"	"{{chromosome}}"	"{{chrom_band}}"	"{{imprinting}}"	"{{refseq_genomic}}"	"{{refseq_UD}}"	"{{reference}}"	"{{url_homepage}}"	"{{url_external}}"	"{{allow_download}}"	"{{allow_index_wiki}}"	"{{id_hgnc}}"	"{{id_entrez}}"	"{{id_omim}}"	"{{show_hgmd}}"	"{{show_genecards}}"	"{{show_genetests}}"	"{{note_index}}"	"{{note_listing}}"	"{{refseq}}"	"{{refseq_url}}"	"{{disclaimer}}"	"{{disclaimer_text}}"	"{{header}}"	"{{header_align}}"	"{{footer}}"	"{{footer_align}}"	"{{created_by}}"	"{{created_date}}"	"{{edited_by}}"	"{{edited_date}}"	"{{updated_by}}"	"{{updated_date}}"
-"IVD"	"isovaleryl-CoA dehydrogenase"	"15"	"q14-q15"	"unknown"	"NG_011986.1"	"UD_142663684045"	""	""	""	"0"	"0"	"6186"	"3712"	"607036"	"1"	"1"	"1"	""	""	""	""	"1"	""	""	"-1"	""	"-1"	"00001"	"2015-06-02 15:42:21"	""	""	"00001"	"2015-06-02 15:42:48"
-"ARSE"	"arylsulfatase E (chondrodysplasia punctata 1)"	"X"	"p22.33"	"unknown"	"NG_007091.1"	"UD_139310223054"	""	""	""	"0"	"0"	"719"	"415"	"300180"	"0"	"0"	"0"	""	""	""	""	"1"	""	""	"-1"	""	"-1"	"00001"	"2015-06-04 08:45:53"	""	""	""	""
+"{{id}}"	"{{name}}"	"{{chromosome}}"	"{{chrom_band}}"	"{{imprinting}}"	"{{refseq_genomic}}"	"{{refseq_UD}}"	"{{reference}}"	"{{url_homepage}}"	"{{url_external}}"	"{{allow_download}}"	"{{id_hgnc}}"	"{{id_entrez}}"	"{{id_omim}}"	"{{show_hgmd}}"	"{{show_genecards}}"	"{{show_genetests}}"	"{{note_index}}"	"{{note_listing}}"	"{{refseq}}"	"{{refseq_url}}"	"{{disclaimer}}"	"{{disclaimer_text}}"	"{{header}}"	"{{header_align}}"	"{{footer}}"	"{{footer_align}}"	"{{created_by}}"	"{{created_date}}"	"{{edited_by}}"	"{{edited_date}}"	"{{updated_by}}"	"{{updated_date}}"
+"IVD"	"isovaleryl-CoA dehydrogenase"	"15"	"q14-q15"	"unknown"	"NG_011986.1"	"UD_142663684045"	""	""	""	"0"	"6186"	"3712"	"607036"	"1"	"1"	"1"	""	""	""	""	"1"	""	""	"-1"	""	"-1"	"00001"	"2015-06-02 15:42:21"	""	""	"00001"	"2015-06-02 15:42:48"
+"ARSE"	"arylsulfatase E (chondrodysplasia punctata 1)"	"X"	"p22.33"	"unknown"	"NG_007091.1"	"UD_139310223054"	""	""	""	"0"	"719"	"415"	"300180"	"0"	"0"	"0"	""	""	""	""	"1"	""	""	"-1"	""	"-1"	"00001"	"2015-06-04 08:45:53"	""	""	""	""
 
 ## Transcripts ## Do not remove or alter this header ##
 ## Count = 1

--- a/tests/test_data_files/FalseUpdateImport.txt
+++ b/tests/test_data_files/FalseUpdateImport.txt
@@ -10,9 +10,9 @@
 
 ## Genes ## Do not remove or alter this header ##
 ## Count = 2
-"{{id}}"	"{{name}}"	"{{chromosome}}"	"{{chrom_band}}"	"{{imprinting}}"	"{{refseq_genomic}}"	"{{refseq_UD}}"	"{{reference}}"	"{{url_homepage}}"	"{{url_external}}"	"{{allow_download}}"	"{{allow_index_wiki}}"	"{{id_hgnc}}"	"{{id_entrez}}"	"{{id_omim}}"	"{{show_hgmd}}"	"{{show_genecards}}"	"{{show_genetests}}"	"{{note_index}}"	"{{note_listing}}"	"{{refseq}}"	"{{refseq_url}}"	"{{disclaimer}}"	"{{disclaimer_text}}"	"{{header}}"	"{{header_align}}"	"{{footer}}"	"{{footer_align}}"	"{{created_by}}"	"{{created_date}}"	"{{edited_by}}"	"{{edited_date}}"	"{{updated_by}}"	"{{updated_date}}"
-"IVD"	"isovaleryl-CoA dehydrogenase1"	"151"	"q14-q15"	"unknown"	"NG_011986.1"	"UD_142663684045"	""	""	""	"0"	"0"	"6186"	"3712"	"607036"	"1"	"1"	"1"	""	""	""	""	"1"	""	""	"-1"	""	"-1"	"00001"	"2015-06-02 15:42:21"	"00001"	""	"00001"	"2015-06-02 15:42:48"
-"ARSE"	"arylsulfatase E (chondrodysplasia punctata 1)"	"X"	"p22.33"	"unknown"	"NG_007091.1"	"UD_139310223054"	""	""	""	"0"	"0"	"719"	"415"	"300180"	"0"	"0"	"0"	""	""	""	""	"1"	""	""	"-1"	""	"-1"	"00001"	"2015-06-04 08:45:53"	""	""	""	""
+"{{id}}"	"{{name}}"	"{{chromosome}}"	"{{chrom_band}}"	"{{imprinting}}"	"{{refseq_genomic}}"	"{{refseq_UD}}"	"{{reference}}"	"{{url_homepage}}"	"{{url_external}}"	"{{allow_download}}"	"{{id_hgnc}}"	"{{id_entrez}}"	"{{id_omim}}"	"{{show_hgmd}}"	"{{show_genecards}}"	"{{show_genetests}}"	"{{note_index}}"	"{{note_listing}}"	"{{refseq}}"	"{{refseq_url}}"	"{{disclaimer}}"	"{{disclaimer_text}}"	"{{header}}"	"{{header_align}}"	"{{footer}}"	"{{footer_align}}"	"{{created_by}}"	"{{created_date}}"	"{{edited_by}}"	"{{edited_date}}"	"{{updated_by}}"	"{{updated_date}}"
+"IVD"	"isovaleryl-CoA dehydrogenase1"	"151"	"q14-q15"	"unknown"	"NG_011986.1"	"UD_142663684045"	""	""	""	"0"	"6186"	"3712"	"607036"	"1"	"1"	"1"	""	""	""	""	"1"	""	""	"-1"	""	"-1"	"00001"	"2015-06-02 15:42:21"	"00001"	""	"00001"	"2015-06-02 15:42:48"
+"ARSE"	"arylsulfatase E (chondrodysplasia punctata 1)"	"X"	"p22.33"	"unknown"	"NG_007091.1"	"UD_139310223054"	""	""	""	"0"	"719"	"415"	"300180"	"0"	"0"	"0"	""	""	""	""	"1"	""	""	"-1"	""	"-1"	"00001"	"2015-06-04 08:45:53"	""	""	""	""
 
 ## Transcripts ## Do not remove or alter this header ##
 ## Count = 2

--- a/tests/test_data_files/InsertImport.txt
+++ b/tests/test_data_files/InsertImport.txt
@@ -8,8 +8,8 @@
 
 ## Genes ## Do not remove or alter this header ##
 ## Count = 1
-"{{id}}"	"{{name}}"	"{{chromosome}}"	"{{chrom_band}}"	"{{imprinting}}"	"{{refseq_genomic}}"	"{{refseq_UD}}"	"{{reference}}"	"{{url_homepage}}"	"{{url_external}}"	"{{allow_download}}"	"{{allow_index_wiki}}"	"{{id_hgnc}}"	"{{id_entrez}}"	"{{id_omim}}"	"{{show_hgmd}}"	"{{show_genecards}}"	"{{show_genetests}}"	"{{note_index}}"	"{{note_listing}}"	"{{refseq}}"	"{{refseq_url}}"	"{{disclaimer}}"	"{{disclaimer_text}}"	"{{header}}"	"{{header_align}}"	"{{footer}}"	"{{footer_align}}"	"{{created_by}}"	"{{created_date}}"	"{{edited_by}}"	"{{edited_date}}"	"{{updated_by}}"	"{{updated_date}}"
-"IVD"	"isovaleryl-CoA dehydrogenase"	"15"	"q14-q15"	"unknown"	"NG_011986.1"	"UD_142663684045"	""	""	""	"0"	"0"	"6186"	"3712"	"607036"	"1"	"1"	"1"	""	""	""	""	"1"	""	""	"-1"	""	"-1"	"00001"	"2015-06-03 11:30:15"	""	""	"00001"	"2015-06-03 11:31:16"
+"{{id}}"	"{{name}}"	"{{chromosome}}"	"{{chrom_band}}"	"{{imprinting}}"	"{{refseq_genomic}}"	"{{refseq_UD}}"	"{{reference}}"	"{{url_homepage}}"	"{{url_external}}"	"{{allow_download}}"	"{{id_hgnc}}"	"{{id_entrez}}"	"{{id_omim}}"	"{{show_hgmd}}"	"{{show_genecards}}"	"{{show_genetests}}"	"{{note_index}}"	"{{note_listing}}"	"{{refseq}}"	"{{refseq_url}}"	"{{disclaimer}}"	"{{disclaimer_text}}"	"{{header}}"	"{{header_align}}"	"{{footer}}"	"{{footer_align}}"	"{{created_by}}"	"{{created_date}}"	"{{edited_by}}"	"{{edited_date}}"	"{{updated_by}}"	"{{updated_date}}"
+"IVD"	"isovaleryl-CoA dehydrogenase"	"15"	"q14-q15"	"unknown"	"NG_011986.1"	"UD_142663684045"	""	""	""	"0"	"6186"	"3712"	"607036"	"1"	"1"	"1"	""	""	""	""	"1"	""	""	"-1"	""	"-1"	"00001"	"2015-06-03 11:30:15"	""	""	"00001"	"2015-06-03 11:31:16"
 
 
 ## Transcripts ## Do not remove or alter this header ##

--- a/tests/test_data_files/SecondInsertImport.txt
+++ b/tests/test_data_files/SecondInsertImport.txt
@@ -9,7 +9,7 @@
 
 ## Genes ## Do not remove or alter this header ##
 ## Count = 1
-"{{id}}"	"{{name}}"	"{{chromosome}}"	"{{chrom_band}}"	"{{imprinting}}"	"{{refseq_genomic}}"	"{{refseq_UD}}"	"{{reference}}"	"{{url_homepage}}"	"{{url_external}}"	"{{allow_download}}"	"{{allow_index_wiki}}"	"{{id_hgnc}}"	"{{id_entrez}}"	"{{id_omim}}"	"{{show_hgmd}}"	"{{show_genecards}}"	"{{show_genetests}}"	"{{note_index}}"	"{{note_listing}}"	"{{refseq}}"	"{{refseq_url}}"	"{{disclaimer}}"	"{{disclaimer_text}}"	"{{header}}"	"{{header_align}}"	"{{footer}}"	"{{footer_align}}"	"{{created_by}}"	"{{created_date}}"	"{{edited_by}}"	"{{edited_date}}"	"{{updated_by}}"	"{{updated_date}}"
+"{{id}}"	"{{name}}"	"{{chromosome}}"	"{{chrom_band}}"	"{{imprinting}}"	"{{refseq_genomic}}"	"{{refseq_UD}}"	"{{reference}}"	"{{url_homepage}}"	"{{url_external}}"	"{{allow_download}}"	"{{id_hgnc}}"	"{{id_entrez}}"	"{{id_omim}}"	"{{show_hgmd}}"	"{{show_genecards}}"	"{{show_genetests}}"	"{{note_index}}"	"{{note_listing}}"	"{{refseq}}"	"{{refseq_url}}"	"{{disclaimer}}"	"{{disclaimer_text}}"	"{{header}}"	"{{header_align}}"	"{{footer}}"	"{{footer_align}}"	"{{created_by}}"	"{{created_date}}"	"{{edited_by}}"	"{{edited_date}}"	"{{updated_by}}"	"{{updated_date}}"
 
 
 ## Transcripts ## Do not remove or alter this header ##

--- a/tests/travis/setup/setup_chrome.sh
+++ b/tests/travis/setup/setup_chrome.sh
@@ -6,8 +6,8 @@ export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
 
 # Fixme: uncomment lines below to use latest stable Chrome browser for testing
-#export CHROME_BIN=/usr/bin/google-chrome
-#sudo apt-get update
-#sudo apt-get install -y libappindicator1 fonts-liberation
-#wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-#sudo dpkg -i google-chrome*.deb
+export CHROME_BIN=/usr/bin/google-chrome
+sudo apt-get update
+sudo apt-get install -y libappindicator1 fonts-liberation
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+sudo dpkg -i google-chrome*.deb

--- a/tests/travis/setup/setup_chrome.sh
+++ b/tests/travis/setup/setup_chrome.sh
@@ -8,6 +8,5 @@ sh -e /etc/init.d/xvfb start
 # Fixme: uncomment lines below to use latest stable Chrome browser for testing
 export CHROME_BIN=/usr/bin/google-chrome
 sudo apt-get update
-sudo apt-get install -y libappindicator1 fonts-liberation
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 sudo dpkg -i google-chrome*.deb

--- a/tests/travis/setup/setup_selenium_server.sh
+++ b/tests/travis/setup/setup_selenium_server.sh
@@ -10,7 +10,7 @@ serverFile=selenium-server-standalone-2.53.1.jar
 # Download chromedriver.
 # Fixme: uncomment following line and remove "=2.24" line to use latest release.
 #chromeDriverVersion=`curl http://chromedriver.storage.googleapis.com/LATEST_RELEASE`
-chromeDriverVersion=2.24
+chromeDriverVersion=2.39
 chromeDriverSrc=http://chromedriver.storage.googleapis.com/${chromeDriverVersion}/chromedriver_linux64.zip
 
 phpVersion=`php -v`

--- a/tests/travis/setup/setup_selenium_server.sh
+++ b/tests/travis/setup/setup_selenium_server.sh
@@ -2,7 +2,7 @@
 
 ## This file is used in Travis CI.
 ## In this file composer is used to install the dependencies defined in composer.json
-## Then the selenium server is downloaded and started. 
+## Then the selenium server is downloaded and started.
 ## When the selenium server is not started this script exits 1. And in Travis the tests will fail.
 serverUrl='http://127.0.0.1:4444'
 serverFile=selenium-server-standalone-2.53.1.jar
@@ -49,7 +49,7 @@ export DISPLAY=:99.0
 
 #sh -e /etc/init.d/xvfb start
 #sleep 3
-sudo java -jar $serverFile -port 4444 -Djava.net.preferIPv4Stack=true -Dwebdriver.chrome.driver=chromedriver > /tmp/selenium.log 2> /tmp/selenium_error.log &
+java -jar $serverFile -port 4444 -Djava.net.preferIPv4Stack=true -Dwebdriver.chrome.driver=chromedriver > /tmp/selenium.log 2> /tmp/selenium_error.log &
 
 sleep 3
 


### PR DESCRIPTION
Release 3.0-23.
- Added some LOVD2 columns to the conversion script to be recognized.
- Minor update to the old 2Do file, standardized "charset" label formatting in download files.
- Added timezone indicators to all printed timestamps in LOVD.
  - Currently, this is set to the server's timezone.
  - This explains when timestamps for just created entries are in the past or future.
  - In the future, the timestamps will be shown based on the user's timezone.
- Removed the `created_date` timestamp from the Screenings VL.
  - It was the only VL showing this information, and it just got longer because of the addition of the timezone.
- Open up the variant VE Options menu for the public, and add links to genome browsers.
  - Renamed the link to indicate you're just viewing the location, not the variant (we need to load the BED file for this).
  - Removed some old code that loads the BED file but needs to be reviewed.
- Removing the WikiProfessional feature.
  - Their service has been down for a long time and has anyway never worked for LOVD3.
- Adding hg38 positions to the REST API in case an hg19 LOVD stores it.
  - This is intended for the GV shared, but future LOVDs will use this as well.
  - The varcache database can then switch to JSON and pick this up.
- Removed the Reference column in the Users table.
  - It was unused since LOVD2.
- Standardized the "owner" LoadEntry variable into `owned_by_`.
  - This lets us use the "owner" variable for something else.
- All VEs now also show the owner with a tooltip table, just like in the VLs.
  - This allows the public to contact the data owner more easily.
  - `lovd_hideEmail()` had to be moved from `inc-lib-viewlist.php` to `inc-lib-init.php` for this.
  - `phenotypes.php` had to load `inc-js-tooltip.php` for this.
- Applying some fixes from the `travis_upgrade` branch in hopes Travis will work again.
  - Suppressing LOVD error messages during tests.
  - `getLOVDGlobals()` was triggering an `exit()` from `inc-init.php` when called when not installed yet.
  - Let `setMutalyzerServiceURL()` not die when we're not installed.
  - `ini_set()` calls from `inc-init.php` were triggering warnings during CLI calls because output was already created.
  - Also, Selenium shouldn't be started as root - newer Firefoxes don't like it.
- Slightly increase the version of Chrome driver, and disable FF testing for now.
- Try the latest stable Chrome, then, and display Chrome and FF versions before running tests.
- Fixed tests that broke after automatic VOT loading.
  - The URL checks on `/variants/ID` now had to allow for `/variants/ID#VOTID` matches.
- Version bump on manual, updated docs stats.
- Fixed tests after recent changes from master.
  - Selecting a disease is now mandatory when creating an individual.