### PR TITLE
Sync LOVD+ features.

### DIFF
--- a/src/ajax/import_scheduler.php
+++ b/src/ajax/import_scheduler.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-11-16
- * Modified    : 2017-12-04
- * For LOVD    : 3.0-21
+ * Modified    : 2020-02-24
+ * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -33,7 +33,7 @@ require ROOT_PATH . 'inc-init.php';
 header('Content-type: text/javascript; charset=UTF-8');
 
 // Check for basic format.
-if (PATH_COUNT != 3 || !in_array(ACTION, array('reschedule', 'set_priority', 'unschedule', 'view'))) {
+if (PATH_COUNT != 3 || !in_array(ACTION, array('new_screening', 'reschedule', 'set_priority', 'unschedule', 'view'))) {
     die('alert("Error while sending data.");');
 }
 
@@ -68,6 +68,7 @@ $bFileLost  = !file_exists($_INI['paths']['data_files'] . '/' . $sFile);
 $nPriority  = $zFile['priority'];
 $bProcessed = (int) $zFile['in_progress'];
 $bError     = !empty($zFile['process_errors']);
+$bErrorLabID = ($bError && strpos($zFile['process_errors'], 'Another individual with this Lab ID already exists in the database') !== false);
 
 $sFormUnschedule     = '<FORM id=\'import_scheduler_unschedule_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>Are you sure you want to unschedule this file?</FORM>';
 $sFormSetPriority    = '<FORM id=\'import_scheduler_set_priority_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>Please select the priority with which the file will be processed.<BR><SELECT name=\'priority\'>' .
@@ -79,25 +80,30 @@ $sFormSetPriority    = '<FORM id=\'import_scheduler_set_priority_form\'><INPUT t
             array_keys($_SETT['import_priorities']), $_SETT['import_priorities'])
     ) . '</SELECT></FORM>';
 $sFormReschedule     = '<FORM id=\'import_scheduler_reschedule_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>Are you sure you want to clear all errors and reschedule this file?</FORM>';
+$sFormNewScreening   = '<FORM id=\'import_scheduler_new_screening_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>This will remove the Individual entry from the import file, and configure the file to be imported as a new Screening of this Individual.<BR><BR>This action can not be undone.<BR><BR>Are you sure you want to edit this file?</FORM>';
 $sMessageIntro       = 'Please choose from the actions below.<BR>';
 $sMessageUnschedule  = 'You can unschedule this file, which will remove it from the list of files to import. You can do this by clicking &quot;Unschedule file&quot; below.<BR>';
 $sMessageSetPriority = 'You can set the priority with which this file will be imported by clicking &quot;Set priority&quot; below.<BR>';
 $sMessageReschedule  = 'You can also reschedule this file, resetting it and putting it back at the end of the queue, so LOVD will try to import it again. You can do this by clicking &quot;Reschedule file&quot; below.<BR>';
+$sMessageNewScreening = 'However, since this file failed to import due to its Lab ID already existing in the database, you can also have the file edited so the data will be appended to the existing Individual as a new Screening. You can do this by clicking &quot;Import as new Screening&quot; below.<BR>';
 
 // Set JS variables and objects.
 print('
 var bFileLost              = ' . (int) $bFileLost . ';
 var bProcessed             = ' . (int) $bProcessed . ';
 var bError                 = ' . (int) $bError . ';
+var bErrorLabID            = ' . (int) $bErrorLabID . ';
 var oButtonUnschedule      = {"Unschedule file":function () { $.get("' . CURRENT_PATH . '?unschedule"); }};
 var oButtonSetPriority     = {"Set priority":function () { $.get("' . CURRENT_PATH . '?set_priority"); }};
 var oButtonReschedule      = {"Reschedule file":function () { $.get("' . CURRENT_PATH . '?reschedule"); }};
+var oButtonNewScreening    = {"Import as new Screening":function () { $.get("' . CURRENT_PATH . '?new_screening"); }};
 var oButtonBack            = {"Back":function () { $.get("' . CURRENT_PATH . '?view"); }};
 var oButtonCancel          = {"Cancel":function () { $.get("' . CURRENT_PATH . '?view"); }};
 var oButtonClose           = {"Close":function () { $(this).dialog("close"); }};
 var oButtonFormUnschedule  = {"Yes, unschedule":function () { $.post("' . CURRENT_PATH . '?unschedule", $("#import_scheduler_unschedule_form").serialize()); }};
 var oButtonFormSetPriority = {"Set priority":function () { $.post("' . CURRENT_PATH . '?set_priority", $("#import_scheduler_set_priority_form").serialize()); }};
 var oButtonFormReschedule  = {"Yes, reschedule file":function () { $.post("' . CURRENT_PATH . '?reschedule", $("#import_scheduler_reschedule_form").serialize()); }};
+var oButtonFormNewScreening = {"Yes, edit this file":function () { $.post("' . CURRENT_PATH . '?new_screening", $("#import_scheduler_new_screening_form").serialize()); }};
 
 
 ');
@@ -254,7 +260,180 @@ if (ACTION == 'reschedule' && POST) {
     setTimeout(\'window.location.href = window.location.href;\', 1000);
     
     // Select the right buttons.
-    $("#import_scheduler_dialog").dialog({buttons: oButtonBack}); 
+    $("#import_scheduler_dialog").dialog({buttons: oButtonClose}); 
+    ');
+    exit;
+}
+
+
+
+
+
+if (ACTION == 'new_screening') {
+    // Common code for GET and POST.
+
+    if ($bFileLost) {
+        die('alert("Error: File not found.\n");');
+    }
+
+    if (!$bErrorLabID) {
+        die('alert("Error: File did not fail to import, so why would I edit it?\n");');
+    }
+
+    // Check if the file is edited already.
+    // Read the first 5K of the Total file, which should contain the meta data.
+    // file() can't restrict the reading to a certain limit, so we need a step in between.
+    $sMetaData = file_get_contents($_INI['paths']['data_files'] . '/' . $sFile, false, null, 0, 5000);
+    if (!$sMetaData) {
+        die('alert("Error: Could not read file.\n");');
+    }
+    $aMetaData = preg_split('/\r?\n/', $sMetaData);
+    $aParsed = $_ADAPTER->readMetadata($aMetaData);
+    if (empty($aParsed['Individuals']) || empty($aParsed['Screenings'])) {
+        // Not all data was found. Already edited?
+        if (!empty($aParsed['Screenings']) && !empty($aParsed['Genes']) && !empty($aParsed['Transcripts'])) {
+            // Very basic check, but at least it's a better error message.
+            die('alert("Error: It seems that the file has already been edited to be imported as a new Screening.\n");');
+        } else {
+            die('alert("Error: Could not parse the given file. I will not try and edit it.\n");');
+        }
+    }
+}
+
+
+
+
+
+if (ACTION == 'new_screening' && GET) {
+    // Show form for setting the priority.
+    // We do this in two steps, to prevent CSRF.
+
+    $_SESSION['csrf_tokens']['import_scheduler_new_screening'] = md5(uniqid());
+    $sFormNewScreening = str_replace('{{CSRF_TOKEN}}', $_SESSION['csrf_tokens']['import_scheduler_new_screening'], $sFormNewScreening);
+
+    // Display the form, and put the right buttons in place.
+    print('
+    $("#import_scheduler_dialog").html("' . $sFormNewScreening . '<BR>");
+
+    // Select the right buttons.
+    $("#import_scheduler_dialog").dialog({buttons: $.extend({}, oButtonFormNewScreening, oButtonCancel)});
+    ');
+    exit;
+}
+
+
+
+
+
+if (ACTION == 'new_screening' && POST) {
+    // Process form to reschedule a file.
+    // We do this in two steps, to prevent CSRF.
+
+    if (empty($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf_tokens']['import_scheduler_new_screening']) {
+        die('alert("Error while sending data, possible security risk. Try reloading the page, and loading the form again.");');
+    }
+
+    // Find original Individual.
+    $zIndividual = $_DB->query('
+        SELECT i.*, GROUP_CONCAT(i2d.diseaseid SEPARATOR ";") AS _diseases
+        FROM ' . TABLE_INDIVIDUALS . ' AS i LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid)
+        WHERE `Individual/Lab_ID` = ?
+        GROUP BY i.id',
+        array($aParsed['Individuals']['Individual/Lab_ID']))->fetchAssoc();
+    if (!$zIndividual) {
+        die('alert("Error: Could not find original Individual entry in the database. I will not try and edit this file.\n");');
+    }
+    $zIndividual['diseases'] = (!$zIndividual['_diseases']? array() : explode(';', $zIndividual['_diseases']));
+
+    // Compare data from meta data file with database, to check for data mismatches.
+    foreach ($aParsed['Individuals'] as $sKey => $sVal) {
+        if ($sKey != 'id' && $sVal != $zIndividual[$sKey]) {
+            die('alert("Error: Data mismatch between meta data file and database contents at Individual field ' .
+                $sKey . ' (' . $zIndividual[$sKey] . ' => ' . $sVal . '). I will not try and edit this file.\n");');
+        }
+    }
+    if ($aParsed['Individuals_To_Diseases']['diseaseid']
+        && !in_array($aParsed['Individuals_To_Diseases']['diseaseid'], $zIndividual['diseases'])) {
+        die('alert("Error: Data mismatch between meta data file and database contents at Individuals_To_Diseases.' .
+            ' I will not try and edit this file.\n");');
+    }
+
+    // Unfortunately, we cannot easily just remove or edit a line.
+    // We have to loop through the contents, edit in memory, and overwrite the entire file.
+    // This will take a lot of memory, but oh well.
+    $aMetaData = file($_INI['paths']['data_files'] . '/' . $sFile); // Leaving line endings on purpose.
+    $sSection = '';
+    $bHeaderPrevRow = false;
+    $bSuccess = false;
+    foreach ($aMetaData as $i => $sLine) {
+        if (!trim($sLine)) {
+            continue;
+        } elseif (preg_match('/^##\s*([A-Za-z_]+)\s*##\s*Do not remove/', ltrim($sLine, '"'), $aRegs)) {
+            // New section. Get rid of the Individuals data, and edit the Screenings data.
+            $sSection = $aRegs[1];
+            $bHeaderPrevRow = false;
+        } elseif (substr($sLine, 0) == '#') {
+            continue;
+        } elseif (substr($sLine, 0, 3) == '"{{') {
+            // Header.
+            $bHeaderPrevRow = true;
+        } elseif ($bHeaderPrevRow) {
+            if (in_array($sSection, array('Individuals', 'Individuals_To_Diseases'))) {
+                // Kill the Individual-related data.
+                unset($aMetaData[$i-1]);
+                unset($aMetaData[$i]);
+                continue;
+            } elseif ($sSection == 'Screenings') {
+                // Edit the screenings info.
+                $aLine = array_map(function($sData) {
+                    return trim($sData, '"');
+                }, explode("\t", rtrim($sLine)));
+
+                if (array_values($aParsed['Screenings']) == $aLine) {
+                    // Full match; this is the Screenings line.
+                    // Replace individual ID, and replace line.
+                    $aParsed['Screenings']['individualid'] = $zIndividual['id'];
+                    $aMetaData[$i] = '"' . implode("\"\t\"", $aParsed['Screenings']) . "\"\r\n";
+                    $bSuccess = true;
+                    // No else needed here; we'll just complain later if we weren't successful.
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!$bSuccess) {
+        die('alert("Error: Could not find the information to be replaced.\n");');
+    }
+
+    // Done! Move the original file, and write to new file. This prevents disastrous data corruption.
+    if (!rename($_INI['paths']['data_files'] . '/' . $sFile, $_INI['paths']['data_files'] . '/' . $sFile . '.ori')) {
+        die('alert("Error: Could not rename the original file, and I won\'t try to overwrite it.\n");');
+    }
+
+    if (!file_put_contents($_INI['paths']['data_files'] . '/' . $sFile, implode('', $aMetaData))) {
+        // Hmm.... better try and restore previous situation.
+        @unlink($_INI['paths']['data_files'] . '/' . $sFile);
+        @rename($_INI['paths']['data_files'] . '/' . $sFile . '.ori', $_INI['paths']['data_files'] . '/' . $sFile);
+        die('alert("Error: Could not write data to new file.\n");');
+    }
+
+    lovd_writeLog('Event', 'ImportReschedule', 'Successfully edited ' . $sFile . ' to be imported as a new Screening');
+
+    // Also, reschedule the file.
+    if (!$_DB->query('UPDATE ' . TABLE_SCHEDULED_IMPORTS . ' SET in_progress = 0, scheduled_by = ?, scheduled_date = NOW(), process_errors = NULL, processed_by = NULL, processed_date = NULL WHERE filename = ?', array($_AUTH['id'], $sFile), false)) {
+        die('alert("Successfully edited the file to be imported as a new Screening, but failed to reschedule.\n' . htmlspecialchars($_DB->formatError()) . '");');
+    }
+    // If we get here, the file has been successfully rescheduled!
+    lovd_writeLog('Event', 'ImportReschedule', 'Successfully rescheduled ' . $sFile);
+
+    // Display the form, and put the right buttons in place.
+    print('
+    $("#import_scheduler_dialog").html("File successfully edited to be imported as a new Screening, and rescheduled for import!");
+    setTimeout(\'window.location.href = window.location.href;\', 2000);
+    
+    // Select the right buttons.
+    $("#import_scheduler_dialog").dialog({buttons: oButtonClose}); 
     ');
     exit;
 }
@@ -273,6 +452,9 @@ if (ACTION == 'view') {
     }
     if (bError && !bFileLost) {
         $("#import_scheduler_dialog").append("' . $sMessageReschedule . '<BR>");
+        if (bErrorLabID && !bFileLost) {
+            $("#import_scheduler_dialog").append("' . $sMessageNewScreening . '<BR>");
+        }
     }
     $("#import_scheduler_dialog").append("<BR>");
     
@@ -283,6 +465,9 @@ if (ACTION == 'view') {
     }
     if (bError && !bFileLost) {
         $.extend(oButtons, oButtonReschedule);
+        if (bErrorLabID && !bFileLost) {
+            $.extend(oButtons, oButtonNewScreening);
+        }
     }
     $.extend(oButtons, oButtonClose);
     $("#import_scheduler_dialog").dialog({buttons: oButtons}); 

--- a/src/ajax/viewentry.php
+++ b/src/ajax/viewentry.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-11-09
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-24
+ * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -46,7 +46,7 @@ if (empty($nID) || empty($sObject) || !preg_match('/^[A-Z_]+$/i', $sObject)) {
 // To prevent security problems if we forget to set a requirement here, we default to LEVEL_ADMIN.
 $aNeededLevel =
          array(
-                'ScreeningMOD' => 0, // LOVD+
+                'ScreeningPLUS' => 0, // LOVD+
                 'Transcript_Variant' => 0,
                 'User' => LEVEL_OWNER,
               );
@@ -83,8 +83,8 @@ if (FORMAT == 'text/plain' && !defined('FORMAT_ALLOW_TEXTPLAIN')) {
 
 $sFile = ROOT_PATH . 'class/object_' . strtolower($sObject) . 's.php';
 // Exception for LOVD+.
-if (LOVD_plus && substr($sObject, -3) == 'MOD') {
-    $sFile = str_replace('mods.', 's.mod.', $sFile);
+if (LOVD_plus && substr($sObject, -4) == 'PLUS') {
+    $sFile = str_replace('pluss.', 's.plus.', $sFile);
 }
 
 if (!file_exists($sFile)) {
@@ -94,7 +94,7 @@ if (!file_exists($sFile)) {
 
 
 
-if (in_array($sObject, array('Phenotype', 'Transcript_Variant', 'Custom_ViewList', 'ScreeningMOD'))) {
+if (in_array($sObject, array('Phenotype', 'Transcript_Variant', 'Custom_ViewList', 'ScreeningPLUS'))) {
     // Exception for VOT viewEntry, we need to isolate the gene from the ID to correctly pass this to the data object.
     if ($sObject == 'Transcript_Variant') {
         // This line below is redundant as long as it's also called at the lovd_isAuthorized() call. Remove it here maybe...?

--- a/src/ajax/viewlist.php
+++ b/src/ajax/viewlist.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-02-18
- * Modified    : 2019-10-01
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-24
+ * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -51,7 +51,7 @@ $aNeededLevel =
          array(
                 'Column' => LEVEL_CURATOR,
                 'Custom_ViewList' => 0,
-                'Custom_ViewListMOD' => 0, // LOVD+
+                'Custom_ViewListPLUS' => 0, // LOVD+
                 'Disease' => 0,
                 'Gene' => 0,
                 'Gene_Panel' => LEVEL_SUBMITTER, // LOVD+
@@ -60,12 +60,12 @@ $aNeededLevel =
                 'Gene_Statistic' => LEVEL_SUBMITTER, // LOVD+
                 'Genome_Variant' => 0,
                 'Individual' => 0,
-                'IndividualMOD' => 0, // LOVD+
+                'IndividualPLUS' => 0, // LOVD+
                 'Link' => LEVEL_MANAGER,
                 'Log' => (LOVD_plus? LEVEL_SUBMITTER : LEVEL_MANAGER),
                 'Phenotype' => 0,
                 'Screening' => 0,
-                'ScreeningMOD' => 0, // LOVD+
+                'ScreeningPLUS' => 0, // LOVD+
                 'Shared_Column' => LEVEL_CURATOR,
                 'Transcript' => 0,
                 'Transcript_Variant' => 0,
@@ -197,8 +197,8 @@ $sFile = ROOT_PATH . 'class/object_' . strtolower($sObject) . 's.php';
 // For revision tables.
 $sFile = str_replace('_revs.php', 's.rev.php', $sFile);
 // Exception for LOVD+.
-if (LOVD_plus && substr($_GET['object'], -3) == 'MOD') {
-    $sFile = str_replace('mods.', 's.mod.', $sFile);
+if (LOVD_plus && substr($_GET['object'], -4) == 'PLUS') {
+    $sFile = str_replace('pluss.', 's.plus.', $sFile);
 }
 
 if (!file_exists($sFile)) {

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2020-02-10
- * For LOVD    : 3.0-23
+ * Modified    : 2020-02-24
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -315,15 +315,25 @@ class LOVD_Individual extends LOVD_Custom
             }
         }
 
-        // Diagnostics: Don't allow individuals with an identical Lab-ID.
-        // Can't enforce this in the table, because it's a custom column that's not active during installation, so I'll just do it like this.
+        // LOVD+: Don't allow individuals with an identical Lab-ID.
+        // Can't enforce this in the table, because it's a custom column, so I'll just do it like this.
         if (LOVD_plus && !empty($aData['Individual/Lab_ID'])) {
-            if ($zData && isset($zData['id']) && isset($zData['Individual/Lab_ID'])) {
-                if ($_DB->query('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE `Individual/Lab_ID` = ? AND id != ?', array($aData['Individual/Lab_ID'], $zData['id']))->fetchColumn()) {
-                    lovd_errorAdd('Individual/Lab_ID', 'Another individual with this Lab ID already exists in the database.');
-                }
-            } elseif ($_DB->query('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE `Individual/Lab_ID` = ?', array($aData['Individual/Lab_ID']))->fetchColumn()) {
-                lovd_errorAdd('Individual/Lab_ID', 'Another individual with this Lab ID already exists in the database.');
+            if ($zData && isset($zData['id'])) {
+                $r = $_DB->query('SELECT id, created_date
+                                  FROM ' . TABLE_INDIVIDUALS . '
+                                  WHERE `Individual/Lab_ID` = ? AND id != ?',
+                        array($aData['Individual/Lab_ID'], $zData['id']))->fetchRow();
+            } else {
+                $r = $_DB->query('SELECT id, created_date
+                                  FROM ' . TABLE_INDIVIDUALS . '
+                                  WHERE `Individual/Lab_ID` = ?',
+                        array($aData['Individual/Lab_ID']))->fetchRow();
+            }
+            if ($r) {
+                list($nID, $sCreatedDate) = $r;
+                // NOTE: Do not just change this error message, we are parsing for it in ajax/import_scheduler.php.
+                lovd_errorAdd('Individual/Lab_ID',
+                    'Another individual with this Lab ID already exists in the database; #' . $nID . ', imported ' . $sCreatedDate . '.');
             }
         }
 

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-27
- * Modified    : 2020-01-22
- * For LOVD    : 3.0-23
+ * Modified    : 2020-02-25
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -73,7 +73,7 @@ class LOVD_Template
     {
         // Builds up the menu array, to be used in the full text/html header.
         // Can't be in the constructor, because that one is called before we have $_SESSION.
-        global $_AUTH;
+        global $_AUTH, $_SETT;
 
         if (defined('NOT_INSTALLED') || (ROOT_PATH == '../' && substr(lovd_getProjectFile(), 0, 9) == '/install/')) {
             // In install directory.
@@ -88,7 +88,7 @@ class LOVD_Template
                         'genes_' =>
                          array(
                              '/gene_panels' => array('menu_magnifying_glass.png', 'View all gene panels', 0),
-                             '/gene_panels?create' => array('plus.png', 'Create a new gene panel', LEVEL_SUBMITTER),
+                             '/gene_panels?create' => array('plus.png', 'Create a new gene panel', $_SETT['user_level_settings']['genepanels_create']),
                              'hr',
                              '/genes' => array('menu_magnifying_glass.png', 'View all genes', 0),
                              '/gene_statistics' => array('menu_magnifying_glass.png', 'View all gene statistics', 0),

--- a/src/download.php
+++ b/src/download.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2020-02-06
- * For LOVD    : 3.0-23
+ * Modified    : 2020-02-25
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -198,7 +198,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
         $sHeader = 'Gene panel';
         $sFilter = 'genepanel';
         $ID = $_PE[2];
-        lovd_requireAuth(LEVEL_MANAGER);
+        lovd_requireAuth();
     } else {
         exit;
     }

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-02-18
- * For LOVD    : 3.0-23
+ * Modified    : 2020-02-25
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -164,8 +164,15 @@ $_SETT = array(
                 array(
                     // Checking for LEVEL_COLLABORATOR assumes lovd_isAuthorized()
                     // has already been called for gene-specific overviews.
+                    // FIXME: Many more will follow. Better use 'object_action' naming convention.
                     'delete_individual' => (LOVD_plus? LEVEL_ADMIN : LEVEL_CURATOR),
                     'delete_variant' => (LOVD_plus? LEVEL_ADMIN : LEVEL_CURATOR),
+                    'genepanels_create' => LEVEL_MANAGER,
+                    'genepanels_delete' => LEVEL_ADMIN,
+                    'genepanels_edit' => LEVEL_MANAGER,
+                    'genepanels_genes_delete' => LEVEL_MANAGER,
+                    'genepanels_genes_edit' => LEVEL_ANALYZER,
+                    'genepanels_manage_genes' => LEVEL_MANAGER,
                     // The see_nonpublic_data setting currently also defines the visibility
                     //  of the status, created* and edited* fields.
                     'see_nonpublic_data' => (LOVD_plus? LEVEL_SUBMITTER : LEVEL_COLLABORATOR),

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-02-25
+ * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -366,6 +366,14 @@ function lovd_fetchDBID ($aData)
     // function implies you've checked for it's presence.
     global $_DB, $_CONF;
 
+    // Array to remember which IDs we saw. This is to speed up the generation of
+    //  DBIDs for new variants. The search in the database for the max ID in use
+    //  may take several seconds in databases with 20M+ variants, even with an
+    //  index on DBID. If we limit the search by the DBID that we have seen
+    //  before, we can greatly speed up the query (requires an index on the DBID
+    //  column).
+    static $aDBIDsSeen = array();
+
     $sGenomeVariant = '';
     if (!empty($aData['VariantOnGenome/DNA'])) {
         $sGenomeVariant = str_replace(array('(', ')', '?'), '', $aData['VariantOnGenome/DNA']);
@@ -470,8 +478,18 @@ function lovd_fetchDBID ($aData)
                 // No genes, simple query only on TABLE_VARIANTS.
                 // 2013-02-28; 3.0-03; By querying the chromosome also we sped up this query from 0.43s to 0.09s when having 1M variants.
                 // NOTE: By adding an index on `VariantOnGenome/DBID` this query time can be reduced to 0.00s because of the LIKE on the DBID field.
+                // 2017-06-02; LOVD+ 3.0-17k; Even with an index, on a database with 22M variants, this query takes 2.2 seconds.
+                // Cache the DBIDs we saw to speed this up when we repeatedly ask for the DBIDs on the same chromosome.
                 $sSymbol = 'chr' . $aData['chromosome'];
-                $nDBIDnewNumber = $_DB->query('SELECT IFNULL(RIGHT(MAX(`VariantOnGenome/DBID`), 6), 0) + 1 FROM ' . TABLE_VARIANTS . ' AS vog WHERE vog.chromosome = ? AND `VariantOnGenome/DBID` LIKE ? AND `VariantOnGenome/DBID` REGEXP ?', array($aData['chromosome'], $sSymbol . '\_%', '^' . $sSymbol . '_[0-9]{6}$'))->fetchColumn();
+                $sSQL = 'SELECT IFNULL(RIGHT(MAX(`VariantOnGenome/DBID`), 6), 0) + 1 FROM ' . TABLE_VARIANTS . ' AS vog WHERE vog.chromosome = ? AND `VariantOnGenome/DBID` LIKE ? AND `VariantOnGenome/DBID` REGEXP ?';
+                $aArgs = array($aData['chromosome'], $sSymbol . '\_%', '^' . $sSymbol . '_[0-9]{6}$');
+                if (isset($aDBIDsSeen[$aData['chromosome']])) {
+                    $sSQL .= ' AND `VariantOnGenome/DBID` >= ?';
+                    $aArgs[] = $aDBIDsSeen[$aData['chromosome']];
+                }
+                $nDBIDnewNumber = $_DB->query($sSQL, $aArgs)->fetchColumn();
+                // Update the cache!
+                $aDBIDsSeen[$aData['chromosome']] = $sSymbol . '_' . sprintf('%06d', ($nDBIDnewNumber - 1));
             } else {
                 // 2013-02-28; 3.0-03; By using INNER JOIN to VOT and T and placing a WHERE on t.geneid we sped up this query from 0.45s to 0.00s when having 1M variants.
                 $sSymbol = $aGenes[0];

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-02-10
- * For LOVD    : 3.0-23
+ * Modified    : 2020-02-25
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1092,7 +1092,7 @@ function lovd_getTableInfoByCategory ($sCategory)
                     'table_sql' => TABLE_PHENOTYPES,
                     'table_name' => 'Phenotype',
                     'table_alias' => 'p',
-                    'shared' => true,
+                    'shared' => !LOVD_plus, // True for LOVD, false for LOVD+.
                     'unit' => 'disease', // Is also used to determine the key (diseaseid).
                 ),
             'Screening' =>
@@ -1116,7 +1116,7 @@ function lovd_getTableInfoByCategory ($sCategory)
                     'table_sql' => TABLE_VARIANTS_ON_TRANSCRIPTS,
                     'table_name' => 'Transcript Variant',
                     'table_alias' => 'vot',
-                    'shared' => true,
+                    'shared' => !LOVD_plus, // True for LOVD, false for LOVD+.
                     'unit' => 'gene', // Is also used to determine the key (geneid).
                 ),
         );

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2020-02-18
- * For LOVD    : 3.0-23
+ * Modified    : 2020-02-24
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -43,6 +43,49 @@ $sCalcVersionDB = lovd_calculateVersion($_STAT['version']);
 
 
 
+function lovd_addConditionalSQL ($sCondition, $aConditionArgs, $sSQL)
+{
+    // This function returns the given SQL surrounded by SQL conditions.
+    // This allows for a quick way to write SQL to, for instance, add a column only if it doesn't exist yet.
+
+    if (!is_array($aConditionArgs)) {
+        return array(
+            // This will cause a query error.
+            'lovd_addConditionalSQL() error; $aConditionArgs not an array.'
+        );
+    }
+
+    $aReturn = array();
+    switch ($sCondition) {
+        case 'column_not_exists':
+            // Args: Table, Column.
+            if (count($aConditionArgs) != 2) {
+                return array(
+                    // This will cause a query error.
+                    'lovd_addConditionalSQL() error; $aConditionArgs does not exactly contain two arguments.'
+                );
+            }
+            list($sTable, $sColumn) = $aConditionArgs;
+            $aReturn = array(
+                'SET @bExists := (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = "' . $sTable . '" AND COLUMN_NAME = "' . $sColumn . '")',
+                'SET @sSQL := IF(@bExists > 0, \'SELECT "INFO: Column already exists."\', "' . $sSQL . '")',
+                'PREPARE Statement FROM @sSQL',
+                'EXECUTE Statement',
+            );
+            break;
+        default:
+            return array(
+                // This will cause a query error.
+                'lovd_addConditionalSQL() error; $sCondition ' . $sCondition . ' not recognized.'
+            );
+    }
+    return $aReturn;
+}
+
+
+
+
+
 if ($sCalcVersionFiles != $sCalcVersionDB) {
     // Version of files are not equal to version of database backend.
 
@@ -61,6 +104,36 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
     $_T->printTitle();
 
     print('      Please wait while LOVD is upgrading the database backend from ' . $_STAT['version'] . ' to ' . $_SETT['system']['version'] . '.<BR><BR>' . "\n");
+
+    // Array of messages that should be displayed.
+    // Each item should be an array with arguments to the lovd_showInfoTable() function.
+    // Only the first argument is required, just like in the function itself.
+    $aUpdateMessages =
+        array(
+            '3.0-17m' => array(), // Placeholder for an LOVD+ message, defined below.
+            '3.0-17n' => array(), // Placeholder for an LOVD+ message, defined below.
+            '3.0-17o' => array(), // Placeholder for an LOVD+ message, defined below.
+        );
+
+    // LOVD+ messages should be built up separately, so that LOVDs won't show them.
+    if (LOVD_plus) {
+        $aUpdateMessages['3.0-17m'] = array(
+            'To complete the upgrade to 3.0-17m, it is <B>required</B> to run an upgrade script separately, that will convert your existing DBID values to the new format.<BR>The "hash_dbid.php" script is located in your scripts folder. Please wait for the upgrade below to finish, then click here to run the script.',
+            'stop',
+            '100%',
+            'lovd_openWindow(\'scripts/hash_dbid.php\')',
+        );
+        $aUpdateMessages['3.0-17n'] = array(
+            'If you have a cron job set up for the auto import feature, grepping for lines starting with a colon (:), then turn off this grep from now on. Output no longer is prefixed by a colon, and grepping is no longer needed because no HTML is output by the script anymore. LOVD now defaults to text/plain output for the auto importer, so you also don\'t need to request it anymore in the URL, either. See the updated INSTALL.txt for the new suggested cron job to use.',
+            'important',
+        );
+        $aUpdateMessages['3.0-17o'] = array(
+            'To complete the upgrade to 3.0-17o, you <B>should</B> run a data migration script separately, that will convert the existing gene panel history of your analyses to the new format.<BR>The "migrate_gp_filters_config.php" script is located in your scripts folder. Please wait for the upgrade below to finish, then click here to run the script.',
+            'stop',
+            '100%',
+            'lovd_openWindow(\'scripts/migrate_gp_filters_config.php\')',
+        );
+    }
 
     // Array of changes.
     $aUpdates =
@@ -763,6 +836,18 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
 
 
 
+
+
+
+    // First, print the messages belonging to the updates. Otherwise we'll have to work around the progress bar, that I don't want.
+    foreach ($aUpdateMessages as $sVersion => $aMessage) {
+        if (lovd_calculateVersion($sVersion) > $sCalcVersionDB && lovd_calculateVersion($sVersion) <= $sCalcVersionFiles && $aMessage) {
+            // Message should be displayed.
+            // Prepare default values for arguments.
+            $aMessage += array('', 'information', '100%', '', true);
+            lovd_showInfoTable($aMessage[0], $aMessage[1], $aMessage[2], $aMessage[3], $aMessage[4]);
+        }
+    }
 
     // To make sure we upgrade the database correctly, we add the current version to the list...
     if (!isset($aUpdates[$_SETT['system']['version']])) {

--- a/src/install/inc-sql-tables.php
+++ b/src/install/inc-sql-tables.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-22
- * Modified    : 2020-02-10
- * For LOVD    : 3.0-23
+ * Modified    : 2020-02-25
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -663,7 +663,7 @@ $aTableSQL =
     proxy_port SMALLINT(5) UNSIGNED,
     proxy_username VARCHAR(255) NOT NULL DEFAULT "",
     proxy_password VARCHAR(255) NOT NULL DEFAULT "",
-    logo_uri VARCHAR(100) NOT NULL DEFAULT "gfx/' . (LOVD_plus? 'LOVD_plus_logo200x50' : 'LOVD3_logo145x50') . '.jpg",
+    logo_uri VARCHAR(100) NOT NULL DEFAULT "gfx/LOVD' . (LOVD_plus? '_plus' : '3') . '_logo145x50.jpg",
     mutalyzer_soap_url VARCHAR(100) NOT NULL DEFAULT "https://mutalyzer.nl/services",
     omim_apikey VARCHAR(40) NOT NULL DEFAULT "",
     send_stats BOOLEAN NOT NULL DEFAULT 1,

--- a/src/install/index.php
+++ b/src/install/index.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-02-10
- * For LOVD    : 3.0-23
+ * Modified    : 2020-02-25
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -508,10 +508,8 @@ if ($_GET['step'] == 2 && defined('NOT_INSTALLED')) {
     // (9) Activating standard custom columns.
     $aInstallSQL['Activating LOVD standard custom columns...'] = lovd_getActivateCustomColumnQuery();
 
-    if (LOVD_plus) {
-        // Make sure the DBID column is indexed.
-        $aInstallSQL['Activating LOVD standard custom columns...'][] = 'ALTER TABLE ' . TABLE_VARIANTS . ' ADD INDEX(`VariantOnGenome/DBID`)';
-    }
+    // Make sure the DBID column is indexed.
+    $aInstallSQL['Activating LOVD standard custom columns...'][] = 'ALTER TABLE ' . TABLE_VARIANTS . ' ADD INDEX (`VariantOnGenome/DBID`)';
 
 
     // (10) Creating the "Healthy / Control" disease. Maybe later enable some more default columns? (IQ, ...)


### PR DESCRIPTION
Sync LOVD+ features.
- LOVD+ additional files now have the PLUS suffix instead of the MOD suffix.
- Added code of LOVD+ feature to import files as second screenings. This code is not active in LOVD.
- Added function for conditional SQL for the upgrade script, and the feature to show version-specific messages during upgrade.
- Added feature that speeds up generating multiple DBIDs in one page load (for instance, during import).
  - This mostly helps when an index has been placed on the DBID column, which is not on by default.
  - LOVD will now place an index on the DBID column while installing and during upgrade to 3.0-24.
  - Added the `column_exists_has_no_key` option to `lovd_addConditionalSQL()` for this.
- Added options to `user_level_settings` setting in `$_SETT`, and applied in `template.php`.
- Last small changes from LOVD+.