### PR TITLE
WIP: Quick curation and Curate submission features.

### DIFF
--- a/src/ajax/curate_set.php
+++ b/src/ajax/curate_set.php
@@ -1,0 +1,157 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2020-03-04
+ * Modified    : 2020-03-05
+ * For LOVD    : 3.0-24
+ *
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
+define('ROOT_PATH', '../');
+require ROOT_PATH . 'inc-init.php';
+header('Content-type: text/javascript; charset=UTF-8');
+
+// Check for basic format.
+if (!ACTION || !in_array(ACTION, array('fromVL'))) {
+    die('alert("Error while sending data.");');
+}
+
+// Require curator clearance (any gene).
+if (!lovd_isAuthorized('gene', $_AUTH['curates'])) {
+    // If not authorized, die with error message.
+    die('alert("Lost your session. Please log in again.");');
+}
+
+
+
+// If we get there, we want to show the dialog for sure.
+print('// Make sure we have and show the dialog.
+if (!$("#curate_set_dialog").length) {
+    $("body").append("<DIV id=\'curate_set_dialog\' title=\'Curate (publish) entries\'></DIV>");
+}
+if (!$("#curate_set_dialog").hasClass("ui-dialog-content") || !$("#curate_set_dialog").dialog("isOpen")) {
+    $("#curate_set_dialog").dialog({draggable:false,resizable:false,minWidth:600,show:"fade",closeOnEscape:true,hide:"fade",modal:true});
+}
+
+
+');
+
+
+// Set JS variables and objects.
+print('
+var oButtonClose  = {"Close":function () { $(this).dialog("close"); }};
+
+
+');
+
+// Allowed types.
+$aObjectTypes = array(
+    'variants' => array(),
+);
+
+
+
+
+
+function lovd_showCurationDialog ($aJob)
+{
+    // Receives a job description, shows the dialog, and calls the process.
+
+    $sDialog = 'Checking and publishing entries, please wait...<BR><BR><TABLE>';
+    foreach ($aJob['objects'] as $sObjectType => $aObjects) {
+        $sDialog .= '<TR><TD valign=top rowspan=' . count($aObjects) . '><B>' . $sObjectType . '</B></TD>';
+        foreach ($aObjects as $nKey => $nObjectID) {
+            $sDialog .= (!$nKey? '' : '<TR>') . '<TD>#' . $nObjectID . '</TD><TD id=' . $sObjectType . '_' . $nObjectID . '_status></TD></TR>';
+        }
+    }
+    $sDialog .= '</TABLE>';
+
+    print('
+    $("#curate_set_dialog").html("' . $sDialog . '<BR>");
+
+    // Select the right buttons.
+    $("#curate_set_dialog").dialog({buttons: $.extend({}, oButtonClose)});
+    ');
+
+    // Store data in SESSION. I don't really want to POST it over.
+    if (!isset($_SESSION['work'][CURRENT_PATH])) {
+        $_SESSION['work'][CURRENT_PATH] = array();
+    }
+
+    // Clean up old work IDs...
+    while (count($_SESSION['work'][CURRENT_PATH]) >= 5) {
+        unset($_SESSION['work'][CURRENT_PATH][min(array_keys($_SESSION['work'][CURRENT_PATH]))]);
+    }
+
+    // Generate an unique workID that is sortable.
+    $nWorkID = (string) microtime(true);
+    $_SESSION['work'][CURRENT_PATH][$nWorkID]['job'] = $aJob;
+
+    print('
+    $.get("' . CURRENT_PATH . '?process&workid=' . $nWorkID . '").fail(function(){alert("Request failed. Please try again.");});
+    
+    ');
+    exit;
+}
+
+
+
+
+
+if (ACTION == 'fromVL' && GET) {
+    // URL: /ajax/curate_set.php?fromVL&vlid=VOG
+    // Fetch object types and object IDs, and call the curation process.
+
+    if (!isset($_SESSION['viewlists'][$_GET['vlid']])) {
+        die('alert("Data listing not found. Please try to reload the page and try again.");');
+    } elseif (empty($_SESSION['viewlists'][$_GET['vlid']]['options']['curate_set'])) {
+        die('alert("Data listing does not allow curation of a set.");');
+    } elseif (empty($_SESSION['viewlists'][$_GET['vlid']]['checked'])) {
+        die('alert("No entries selected yet to curate.");');
+    }
+
+    // Determine type.
+    $sObjectType = '';
+    if (!empty($_SESSION['viewlists'][$_GET['vlid']]['row_link'])) {
+        $sObjectType = substr($_SESSION['viewlists'][$_GET['vlid']]['row_link'], 0, strpos($_SESSION['viewlists'][$_GET['vlid']]['row_link'], '/'));
+    }
+    if (!isset($aObjectTypes[$sObjectType])) {
+        // FIXME: Try the ViewListID?
+        die('alert("Did not recognize object type. This may be a bug in LOVD; please report.");');
+    }
+
+    $aJob = array(
+        'objects' => array(
+            $sObjectType => $_SESSION['viewlists'][$_GET['vlid']]['checked'],
+        ),
+        'post_action' => array(
+            'reload_VL' => $_GET['vlid'],
+        ),
+    );
+
+    // Open dialog, and list the data types.
+    lovd_showCurationDialog($aJob);
+    exit;
+}
+?>

--- a/src/ajax/curate_set.php
+++ b/src/ajax/curate_set.php
@@ -127,11 +127,11 @@ if (ACTION == 'fromVL' && GET) {
     // Fetch object types and object IDs, and call the curation process.
 
     if (!isset($_SESSION['viewlists'][$_GET['vlid']])) {
-        die('alert("Data listing not found. Please try to reload the page and try again.");');
+        die('$("#curate_set_dialog").html("Data listing not found. Please try to reload the page and try again.");');
     } elseif (empty($_SESSION['viewlists'][$_GET['vlid']]['options']['curate_set'])) {
-        die('alert("Data listing does not allow curation of a set.");');
+        die('$("#curate_set_dialog").html("Data listing does not allow curation of a set.");');
     } elseif (empty($_SESSION['viewlists'][$_GET['vlid']]['checked'])) {
-        die('alert("No entries selected yet to curate.");');
+        die('$("#curate_set_dialog").html("No entries selected yet to curate.");');
     }
 
     // Determine type.
@@ -141,7 +141,8 @@ if (ACTION == 'fromVL' && GET) {
     }
     if (!isset($aObjectTypes[$sObjectType])) {
         // FIXME: Try the ViewListID?
-        die('alert("Did not recognize object type. This may be a bug in LOVD; please report.");');
+        die('
+        $("#curate_set_dialog").html("Did not recognize object type. This may be a bug in LOVD; please report.");');
     }
 
     $aJob = array(

--- a/src/ajax/curate_set.php
+++ b/src/ajax/curate_set.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-04
- * Modified    : 2020-03-06
+ * Modified    : 2020-03-09
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -309,14 +309,28 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
                 $("#' . $sObjectType . '_' . $nObjectID . '_status").html("<IMG src=gfx/' . ($zData['statusid'] < STATUS_OK? 'cross' : 'check_orange') . '.png>");
                 $("#' . $sObjectType . '_' . $nObjectID . '_errors").html("' . addslashes($_ERROR['messages'][1]) . (count($_ERROR['messages']) <= 2? '' : ' (' . (count($_ERROR['messages']) - 2) . ' more)') . '");');
             }
-
-            // Clear the data.
-            unset($_SESSION['work'][CURRENT_PATH][$_GET['workid']]);
         }
     }
 
+    // Anything more that we're supposed to do?
+    if (!empty($aJob['post_action'])) {
+        foreach ($aJob['post_action'] as $sAction => $sArg) {
+            switch ($sAction) {
+                case 'reload_VL':
+                    print('
+                    lovd_AJAX_viewListSubmit("' . $sArg . '");');
+                    break;
+                default:
+                    print('
+                    $("#curate_set_dialog").append("<BR>Unknown post action ' . htmlspecialchars($sAction) . '");');
+            }
+        }
+    }
+
+    // Clear the data.
+    unset($_SESSION['work'][CURRENT_PATH][$_GET['workid']]);
+
     // FIXME: When X time has passed ($tStart), then end this page load and call another Ajax query with the same work ID. So make sure you UNSET what we've done already!!!
     // OR, is this not necessary? Perhaps it's all so fast, that it's not important?
-
 }
 ?>

--- a/src/ajax/curate_set.php
+++ b/src/ajax/curate_set.php
@@ -66,11 +66,10 @@ var oButtonClose  = {"Close":function () { $(this).dialog("close"); }};
 ');
 
 // Allowed types.
-// FIXME: If I won't have settings here, might as well change the keys in values.
 $aObjectTypes = array(
-    'individuals' => array(),
-    'phenotypes' => array(),
-    'variants' => array(),
+    'individuals',
+    'phenotypes',
+    'variants',
 );
 
 
@@ -142,8 +141,7 @@ if (ACTION == 'fromVL' && GET) {
     if (!empty($_SESSION['viewlists'][$_GET['vlid']]['row_link'])) {
         $sObjectType = substr($_SESSION['viewlists'][$_GET['vlid']]['row_link'], 0, strpos($_SESSION['viewlists'][$_GET['vlid']]['row_link'], '/'));
     }
-    if (!isset($aObjectTypes[$sObjectType])) {
-        // FIXME: Try the ViewListID?
+    if (!in_array($sObjectType, $aObjectTypes)) {
         die('
         $("#curate_set_dialog").html("Did not recognize object type. This may be a bug in LOVD; please report.");');
     }
@@ -194,10 +192,6 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
         'mandatory_password' => false,  // Password field is not mandatory.
         'trim_fields' => false,         // No trimming of whitespace.
     );
-
-    // We cannot flush, because the browser will only execute the JS when we're done completely.
-    // We also don't want to let the user wait too long, so if this takes a while, we need to split this task.
-    $tStart = microtime(true);
 
     $aJob = $_SESSION['work'][CURRENT_PATH][$_GET['workid']]['job'];
     foreach ($aJob['objects'] as $sObjectType => $aObjects) {
@@ -379,7 +373,9 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
         foreach ($aJob['post_action'] as $sAction => $sArg) {
             switch ($sAction) {
                 case 'reload_VL':
+                    // Reload the VL. But first, deselect all checkboxes.
                     print('
+                    check_list["' . $sArg . '"] = "none";
                     lovd_AJAX_viewListSubmit("' . $sArg . '");');
                     break;
                 default:
@@ -391,8 +387,5 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
 
     // Clear the data.
     unset($_SESSION['work'][CURRENT_PATH][$_GET['workid']]);
-
-    // FIXME: When X time has passed ($tStart), then end this page load and call another Ajax query with the same work ID. So make sure you UNSET what we've done already!!!
-    // OR, is this not necessary? Perhaps it's all so fast, that it's not important?
 }
 ?>

--- a/src/ajax/curate_set.php
+++ b/src/ajax/curate_set.php
@@ -82,7 +82,10 @@ function lovd_showCurationDialog ($aJob)
     foreach ($aJob['objects'] as $sObjectType => $aObjects) {
         $sDialog .= '<TR><TD valign=top rowspan=' . count($aObjects) . '><B>' . $sObjectType . '</B></TD>';
         foreach ($aObjects as $nKey => $nObjectID) {
-            $sDialog .= (!$nKey? '' : '<TR>') . '<TD>#' . $nObjectID . '</TD><TD id=' . $sObjectType . '_' . $nObjectID . '_status></TD></TR>';
+            $sDialog .= (!$nKey? '' : '<TR>') .
+                '<TD valign=top>#' . $nObjectID . '</TD>' .
+                '<TD valign=top id=' . $sObjectType . '_' . $nObjectID . '_status></TD>' .
+                '<TD id=' . $sObjectType . '_' . $nObjectID . '_errors></TD></TR>';
         }
     }
     $sDialog .= '</TABLE>';
@@ -91,8 +94,7 @@ function lovd_showCurationDialog ($aJob)
     $("#curate_set_dialog").html("' . $sDialog . '<BR>");
 
     // Select the right buttons.
-    $("#curate_set_dialog").dialog({buttons: $.extend({}, oButtonClose)});
-    ');
+    $("#curate_set_dialog").dialog({buttons: $.extend({}, oButtonClose)});');
 
     // Store data in SESSION. I don't really want to POST it over.
     if (!isset($_SESSION['work'][CURRENT_PATH])) {
@@ -109,9 +111,7 @@ function lovd_showCurationDialog ($aJob)
     $_SESSION['work'][CURRENT_PATH][$nWorkID]['job'] = $aJob;
 
     print('
-    $.get("' . CURRENT_PATH . '?process&workid=' . $nWorkID . '").fail(function(){alert("Request failed. Please try again.");});
-    
-    ');
+    $.get("' . CURRENT_PATH . '?process&workid=' . $nWorkID . '").fail(function(){alert("Request failed. Please try again.");});');
     exit;
 }
 

--- a/src/ajax/curate_set.php
+++ b/src/ajax/curate_set.php
@@ -206,6 +206,16 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
         foreach ($aObjects as $nKey => $nObjectID) {
             // Loop through the individual records, loading the data, running checkFields(), and running the update.
 
+            // First check if we're authorized at all on this entry.
+            if (!lovd_isAuthorized('variant', $nObjectID, false)) {
+                // Oops, no, we're not. This should not really be possible, since the menu should be turned off if
+                //  you're not authorized. So this suggests foul play. But either way, block this.
+                print('
+                $("#' . $sObjectType . '_' . $nObjectID . '_status").html("<IMG src=gfx/cross.png>");
+                $("#' . $sObjectType . '_' . $nObjectID . '_errors").html("You are not authorized to curate this entry.");');
+                continue;
+            }
+
             $_POST = array(
                 'statusid' => STATUS_OK,
                 'edited_by' => $_AUTH['id'],
@@ -291,18 +301,8 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
                 $("#' . $sObjectType . '_' . $nObjectID . '_errors").html("' . addslashes($_ERROR['messages'][1]) . (count($_ERROR['messages']) <= 2? '' : ' (' . (count($_ERROR['messages']) - 2) . ' more)') . '");');
             }
 
-
-
-            // FIXME: Per entry, check RIGHTS! Make sure we know for sure that the user is authorized on these entries!!!
-
-
-
-
-
-
-
-
-
+            // Clear the data.
+            unset($_SESSION['work'][CURRENT_PATH][$_GET['workid']]);
         }
     }
 

--- a/src/ajax/curate_set.php
+++ b/src/ajax/curate_set.php
@@ -146,12 +146,21 @@ if (ACTION == 'fromVL' && GET) {
 
     $aJob = array(
         'objects' => array(
-            $sObjectType => $_SESSION['viewlists'][$_GET['vlid']]['checked'],
+            $sObjectType => array_values($_SESSION['viewlists'][$_GET['vlid']]['checked']),
         ),
         'post_action' => array(
             'reload_VL' => $_GET['vlid'],
         ),
     );
+
+    // Variants in a VOG/VOT view, sometimes have checked IDs that include the VOT's transcript ID. Fix that.
+    if ($sObjectType == 'variants' && strpos($aJob['objects']['variants'][0], ':') !== false) {
+        foreach ($aJob['objects']['variants'] as $nKey => $sID) {
+            $aJob['objects']['variants'][$nKey] = str_pad(strstr($sID, ':', true), $_SETT['objectid_length']['variants'], '0', STR_PAD_LEFT);
+        }
+        // Values can be non-unique due to multiple transcripts.
+        $aJob['objects']['variants'] = array_unique($aJob['objects']['variants']);
+    }
 
     // Open dialog, and list the data types.
     lovd_showCurationDialog($aJob);

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2020-02-24
+ * Modified    : 2020-03-10
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -63,7 +63,7 @@ class LOVD_Individual extends LOVD_Custom
         // SQL code for loading an entry for an edit form.
         $this->sSQLLoadEntry = 'SELECT i.*, ' .
                                'uo.name AS owned_by_, ' .
-                               'GROUP_CONCAT(DISTINCT i2d.diseaseid ORDER BY i2d.diseaseid SEPARATOR ";") AS active_diseases_ ' .
+                               'GROUP_CONCAT(DISTINCT i2d.diseaseid ORDER BY i2d.diseaseid SEPARATOR ";") AS _active_diseases ' .
                                'FROM ' . TABLE_INDIVIDUALS . ' AS i ' .
                                'LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid) ' .
                                'LEFT OUTER JOIN ' . TABLE_USERS . ' AS uo ON (i.owned_by = uo.id) ' .

--- a/src/class/object_logs.php
+++ b/src/class/object_logs.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-28
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-03-09
+ * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -167,6 +167,9 @@ class LOVD_Log extends LOVD_Object
                 break;
             case 'TranscriptEdit':
                 $zData['entry'] = preg_replace('/(entry) (#)?([0-9]+) /', '$1 $2<A href="transcripts/$3">$3</A> ', $zData['entry']);
+                break;
+            case 'QuickCurate':
+                $zData['entry'] = preg_replace('/(Curated (.+) information entry) (#)?([0-9]+)( .+)?$/', '$1 $3<A href="${2}s/$4">$4</A>$5', $zData['entry']);
                 break;
             case 'ShareAccess':
                 $zData['entry'] = preg_replace('/(user) (#)?([0-9]+)/', '$1 $2<A href="users/$3">$3</A>', $zData['entry']);

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2020-02-10
- * For LOVD    : 3.0-23
+ * Modified    : 2020-03-04
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -2236,12 +2236,14 @@ class LOVD_Object
                 'only_rows' => false,           // Only put the table rows in the output.
                 'find_and_replace' => false,    // Allow find and replace on columns.
                 'multi_value_filter' => false,  // Allow multi valued search on columns.
+                'curate_set' => false,          // Allow "curate set" option.
             ),
             $aOptions);
 
-        // Disallow F&R and multivalue search when options menu is hidden.
+        // Disallow F&R, multivalue search, and Cuate Set option when options menu is hidden.
         $aOptions['find_and_replace'] &= $aOptions['show_options'];
         $aOptions['multi_value_filter'] &= $aOptions['show_options'];
+        $aOptions['curate_set'] &= $aOptions['show_options'];
 
         // Save viewlist options to session.
         $_SESSION['viewlists'][$sViewListID]['options'] = array_merge(
@@ -3053,6 +3055,12 @@ $sMVSOption
 
 OPMENU
 );
+
+                if ($aOptions['curate_set']) {
+                    print('        // Add menu option for curating a selected set.' . "\n" .
+                          '        $("#viewlistMenu_' . $sViewListID . '").append(\'<LI class="icon"><A click="lovd_AJAX_viewListSubmit(\\\'' . $sViewListID . '\\\', function(){$.get(\\\'ajax/curate_set.php?fromVL&vlid=' . $sViewListID . '\\\').fail(function(){alert(\\\'Request failed. Please try again.\\\');});});"><SPAN class="icon"></SPAN>Curate (publish) selected entries</A></LI>\');' . "\n\n");
+                }
+
                 if (!LOVD_plus
                     || empty($_INSTANCE_CONFIG['viewlists']['restrict_downloads'])
                     || (!empty($_INSTANCE_CONFIG['viewlists'][$sViewListID]['allow_download_from_level'])

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2020-03-04
+ * Modified    : 2020-03-10
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -430,7 +430,9 @@ class LOVD_Object
             }
 
             // Mandatory fields, as defined by child object.
-            if (in_array($sName, $this->aCheckMandatory) && (!isset($aData[$sName]) || $aData[$sName] === '')) {
+            // Empty multiple selection fields are not sent by the browser, but they are by the quick curation code,
+            //  so we have to check for an empty array() as well. Just make sure we don't complain about '0'.
+            if (in_array($sName, $this->aCheckMandatory) && (!isset($aData[$sName]) || $aData[$sName] === '' || $aData[$sName] === array())) {
                 lovd_errorAdd($sName, 'Please fill in the \'' . $sHeader . '\' field.');
                 $aErroredFields[$sName] = true;
             }

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -2506,6 +2506,8 @@ class LOVD_Object
                             // 2015-09-18; 3.0-14; We need to run rawurldecode() or else Columns are not selectable this way.
                             $aSessionViewList['checked'][] = rawurldecode($zData['row_id']);
                         }
+                        // Now, unique() the list since we don't want to keep adding the same IDs.
+                        $aSessionViewList['checked'] = array_unique($aSessionViewList['checked']);
                     } elseif ($_GET['ids_changed'] == 'none') {
                         // If the unselect all button was clicked, reset the 'checked' array.
                         $aSessionViewList['checked'] = array();

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2020-02-10
- * For LOVD    : 3.0-23
+ * Modified    : 2020-03-10
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -336,12 +336,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
     // If we're publishing... pretend the form has been sent with a different status.
     if (GET && ACTION == 'publish') {
         $_POST = $zData;
-        if ($zData['active_diseases_']) {
-            $_POST['active_diseases'] = explode(';', $zData['active_diseases_']);
-        } else {
-            // An array with an empty string as a value doesn't get past the checkFields() since '' is not a valid option.
-            $_POST['active_diseases'] = array();
-        }
         $_POST['statusid'] = STATUS_OK;
     }
 
@@ -395,14 +389,9 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
             lovd_writeLog('Event', LOG_EVENT, 'Edited individual information entry ' . $nID);
 
             // Change linked diseases?
-            // Diseases the gene is currently linked to.
-            // FIXME; we moeten afspraken op papier zetten over de naamgeving van velden, ik zou hier namelijk geen _ achter plaatsen.
-            //   Een idee zou namelijk zijn om loadEntry()/viewEntry() automatisch velden te laten exploden afhankelijk van hun naam. Is dat wat?
-            $aDiseases = explode(';', $zData['active_diseases_']);
-
             // Remove diseases.
             $aToRemove = array();
-            foreach ($aDiseases as $nDisease) {
+            foreach ($zData['active_diseases'] as $nDisease) {
                 if ($nDisease && !in_array($nDisease, $_POST['active_diseases'])) {
                     // User has requested removal...
                     $aToRemove[] = $nDisease;
@@ -422,7 +411,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
             $aSuccess = array();
             $aFailed = array();
             foreach ($_POST['active_diseases'] as $nDisease) {
-                if (!in_array($nDisease, $aDiseases)) {
+                if (!in_array($nDisease, $zData['active_diseases'])) {
                     // Add disease to gene.
                     $q = $_DB->query('INSERT IGNORE INTO ' . TABLE_IND2DIS . ' VALUES (?, ?)', array($nID, $nDisease), false);
                     if (!$q) {
@@ -466,8 +455,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
     } else {
         // Load current values.
         $_POST = array_merge($_POST, $zData);
-        // Load connected diseases.
-        $_POST['active_diseases'] = explode(';', $_POST['active_diseases_']);
         if ($zData['statusid'] < STATUS_HIDDEN) {
             $_POST['statusid'] = STATUS_OK;
         }

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -83,6 +83,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
         'cols_to_skip' => $aColsToHide,
         'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
         'find_and_replace' => true,
+        'curate_set' => true,
     );
     $_DATA->viewList('Individuals', $aVLOptions);
 

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -114,8 +114,11 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     $aNavigation = array();
     if ($_AUTH && $_AUTH['level'] >= LEVEL_OWNER) {
         $aNavigation[CURRENT_PATH . '?edit']                     = array('menu_edit.png', 'Edit individual entry', 1);
-        if ($zData['statusid'] < STATUS_OK && $_AUTH['level'] >= LEVEL_CURATOR) {
-            $aNavigation[CURRENT_PATH . '?publish']              = array('check.png', ($zData['statusid'] == STATUS_MARKED? 'Remove mark from' : 'Publish (curate)') . ' individual entry', 1);
+        if ($_AUTH['level'] >= LEVEL_CURATOR) {
+            if ($zData['statusid'] < STATUS_OK) {
+                $aNavigation[CURRENT_PATH . '?publish']          = array('check.png', ($zData['statusid'] == STATUS_MARKED? 'Remove mark from' : 'Publish (curate)') . ' individual entry', 1);
+            }
+            $aNavigation['javascript:$.get(\'ajax/curate_set.php?bySubmission&id=' . $_PE[1] . '\').fail(function(){alert(\'Request failed. Please try again.\');});'] = array('check.png', 'Publish (curate) entire submission', 1);
         }
         // You can only add phenotype information to this individual, when there are phenotype columns enabled.
         if ($_DB->query('SELECT COUNT(*) FROM ' . TABLE_IND2DIS . ' AS i2d INNER JOIN ' . TABLE_SHARED_COLS . ' AS sc USING(diseaseid) WHERE i2d.individualid = ?', array($nID))->fetchColumn()) {

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-23
- * Modified    : 2020-02-10
- * For LOVD    : 3.0-23
+ * Modified    : 2020-03-09
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -91,8 +91,10 @@ if (PATH_COUNT == 3 && $_PE[1] == 'disease' && ctype_digit($_PE[2]) && !ACTION) 
     $_GET['search_diseaseid'] = $nDiseaseID;
     $aVLOptions = array(
         'cols_to_skip' => array('diseaseid'),
+        // We can't enable curator authorization, as phenotype entries authorize through their individual's variants.
         'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
         'find_and_replace' => true,
+        'curate_set' => true,
     );
     $_DATA->viewList('Phenotypes_for_Disease_' . $nDiseaseID, $aVLOptions);
 

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2020-03-04
+ * Modified    : 2020-03-09
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -170,6 +170,7 @@ if (PATH_COUNT == 2 && $_PE[1] == 'in_gene' && !ACTION) {
     $aVLOptions = array(
         'cols_to_skip' => array('name', 'id_protein_ncbi'),
         'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+        'curate_set' => true,
     );
     $_DATA->viewList('CustomVL_IN_GENE', $aVLOptions);
 
@@ -318,6 +319,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
             'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
             'find_and_replace' => !$bUnique,
             'multi_value_filter' => $bUnique,
+            'curate_set' => !$bUnique,
         );
         $_DATA->viewList($sViewListID, $aVLOptions);
 

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2020-02-10
- * For LOVD    : 3.0-23
+ * Modified    : 2020-03-04
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -141,6 +141,7 @@ if (!ACTION && (empty($_PE[1]) ||
         'cols_to_skip' => $aColsToHide,
         'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
         'find_and_replace' => true,
+        'curate_set' => true,
     );
     $_DATA->viewList('VOG', $aVLOptions);
     $_T->printFooter();


### PR DESCRIPTION
Quick curation and Curate submission features.
- Added the "Curate (publish) selected entries" option in the Options menu of several VLs.
- Opens a dialog which shows the entries that need to be curated, and the curation results.
- Public entries are checked as well, and any possible errors are displayed.
- Non-public entries are published when no errors have occurred.
- Gene timestamps are updated when entries are published.
- Added "Publish (curate) entire submission" feature to the Individuals' VE Options menu.

Also:
- Cleaned up a badly named variable, which caused a lot of unnecessary code.
- Adapted `objects.php` to get mandatory multiple selection fields checked properly. Empty arrays were not regarded as empty fields since normally the browser doesn't send these arrays.
- Fixed bug; The "Select all ... entries" feature for VLs kept adding IDs to the list, without running `array_unique()`.

Closes #225.