### PR TITLE
Fixed notices and deprecated function calls.

### DIFF
--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-15
- * Modified    : 2020-01-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-03-31
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -589,6 +589,10 @@ class LOVD_CustomViewList extends LOVD_Object
                                             str_replace('the protein', 'a protein', $aLegendVarEffect[0]),
                                             str_replace('the protein', 'a protein', $aLegendVarEffect[1]))),
                               ));
+                    if ($nKeyVOTUnique !== false) {
+                        // Unique view doesn't load these cols, so we can't show them even if users bypass the cols_to_hide.
+                        unset($this->aColumnsViewList['chromosome'], $this->aColumnsViewList['allele_']);
+                    }
                     if (empty($bLoadVOGEffect)) {
                         unset($this->aColumnsViewList['vog_effect']);
                     }

--- a/src/class/object_links.php
+++ b/src/class/object_links.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-04-19
- * Modified    : 2019-02-04
- * For LOVD    : 3.0-23
+ * Modified    : 2020-03-30
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -200,8 +200,8 @@ class LOVD_Link extends LOVD_Object
                 }
 
                 // Check for reference order and/or references missing from the replacement text.
-                reset($aPatternRefs);
-                for ($i = 1; list(,$nRef) = each($aPatternRefs); $i ++) {
+                foreach ($aPatternRefs as $i => $nRef) {
+                    $i++; // References should start at 1, but array keys start at 0.
                     if ($nRef != $i) {
                         lovd_errorAdd('pattern_text', 'The link pattern is found to be incorrect. Expected reference [' . $i . '] ' . ($i == 1? 'first' : 'after [' . ($i - 1) . ']') . ', got [' . $nRef . '].');
                     }

--- a/src/import.php
+++ b/src/import.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2020-02-10
- * For LOVD    : 3.0-23
+ * Modified    : 2020-03-27
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1412,9 +1412,8 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
                     case 'Individuals_To_Diseases':
                     case 'Screenings_To_Genes':
                     case 'Screenings_To_Variants':
-                        reset($aLine);
-                        list($sCol1, $nID1) = each($aLine);
-                        list($sCol2, $nID2) = each($aLine);
+                        list($sCol1, $sCol2) = array_keys($aLine);
+                        list($nID1, $nID2) = array_values($aLine);
                         if (isset($nID1) && isset($nID2)) {
                             $zData = $_DB->query('SELECT * FROM ' . $sTableName . ' WHERE ' . $sCol1 . ' = ? AND ' . $sCol2 . ' = ?', array($nID1, $nID2))->fetchAssoc();
                         }

--- a/src/inc-lib-viewlist.php
+++ b/src/inc-lib-viewlist.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-22
- * Modified    : 2020-02-10
- * For LOVD    : 3.0-23
+ * Modified    : 2020-03-24
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -74,9 +74,9 @@ function lovd_formatSearchExpression ($sExpression, $sColumnType)
         foreach ($aORExpressions as $nORIndex => $sORExpression) {
             switch ($sColumnType) {
                 case 'TEXT':
-                    if ($sORExpression{0} == '!' && $sORExpression{1} == '=') {
+                    if (substr($sORExpression, 0, 2) == '!=') {
                         $sFormattedExpression .= 'Does not exactly match ' . trim($sORExpression, '!="');
-                    } elseif ($sORExpression{0} == '!' && $sORExpression{1} != '=') {
+                    } elseif ($sORExpression{0} == '!') {
                         $sFormattedExpression .= 'Does not contain ' . trim($sORExpression, '!=');
                     } elseif ($sORExpression{0} == '=') {
                         $sFormattedExpression .= 'Exactly matches ' . trim($sORExpression, '="');

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2020-03-10
+ * Modified    : 2020-03-25
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -376,7 +376,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
             $_DATA->updateEntry($nID, $_POST, $aFields);
 
             // Get genes which are modified only when individual and variant status is marked or public.
-            if ($zData['statusid'] >= STATUS_MARKED || $_POST['statusid'] >= STATUS_MARKED) {
+            if ($zData['statusid'] >= STATUS_MARKED || (isset($_POST['statusid']) && $_POST['statusid'] >= STATUS_MARKED)) {
                 $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                       'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
                                       'INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vog.id = vot.id) ' .

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-23
- * Modified    : 2020-03-09
+ * Modified    : 2020-03-25
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -418,7 +418,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
             $_DATA->updateEntry($nID, $_POST, $aFields);
 
             // Get genes which are modified only when phenotype, individual and variant are marked or public.
-            if ($zData['statusid'] >= STATUS_MARKED || $_POST['statusid'] >= STATUS_MARKED) {
+            if ($zData['statusid'] >= STATUS_MARKED || (isset($_POST['statusid']) && $_POST['statusid'] >= STATUS_MARKED)) {
                 $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                       'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
                                       'INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vog.id = vot.id) ' .

--- a/src/scripts/refseq_parser.php
+++ b/src/scripts/refseq_parser.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-29
- * Modified    : 2018-05-15
+ * Modified    : 2020-03-31
  * For LOVD    : 3.0-22
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Gerard C.P. Schaafsma <G.C.P.Schaafsma@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -607,7 +607,7 @@ if ($_GET['step'] == 2) {
             // 2009-03-25; 2.0-17; adapted by Gerard to avoid notices
             $nGenomicNumberIntron = (array_key_exists(0, $aIntron)? strlen($aIntron[0]) : 0);
 
-            while (list($nIntron, $sIntron) = each($aIntron)) {
+            foreach ($aIntron as $nIntron => $sIntron) {
                 if (!$sIntron) {
                     // No intronic sequence. Wouldn't know why, but whatever.
                     continue;

--- a/src/variants.php
+++ b/src/variants.php
@@ -316,7 +316,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
 
         $_DATA->sSortDefault = 'VariantOnTranscript/DNA';
         $aVLOptions = array(
-            'cols_to_skip' => array('chromosome', 'allele_'),
+            'cols_to_skip' => array('chromosome', 'allele_'), // Enforced for unique view in the object.
             'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
             'find_and_replace' => !$bUnique,
             'multi_value_filter' => $bUnique,

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2020-03-09
+ * Modified    : 2020-03-26
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -242,7 +242,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
             'SELECT t.id, t.id_ncbi
              FROM ' . TABLE_TRANSCRIPTS . ' AS t
                INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid)
-             WHERE t.geneid = ?', array($sGene))->fetchAllCombine();
+             WHERE t.geneid = ? ORDER BY t.id_ncbi', array($sGene))->fetchAllCombine();
         $nTranscriptsWithVariants = count($aTranscriptsWithVariants);
 
         // If NM is mentioned, check if exists for this gene. If not, reload page without NM. Otherwise, restrict $aTranscriptsWithVariants.
@@ -278,7 +278,8 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
 
 
     // If this gene has only one NM, show that one. Otherwise have people pick one.
-    list($nTranscriptID, $sTranscript) = each($aTranscriptsWithVariants);
+    $nTranscriptID = key($aTranscriptsWithVariants);
+    $sTranscript = current($aTranscriptsWithVariants);
     if (!$nTranscripts) {
         $sMessage = 'No transcripts found for this gene.';
     } elseif (!$nTranscriptsWithVariants) {

--- a/src/view.php
+++ b/src/view.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-12-05
- * Modified    : 2017-11-20
- * For LOVD    : 3.0-21
+ * Modified    : 2020-03-26
+ * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -66,7 +66,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
             'SELECT t.id, t.id_ncbi
              FROM ' . TABLE_TRANSCRIPTS . ' AS t
                INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid)
-             WHERE t.geneid = ?', array($sGene))->fetchAllCombine();
+             WHERE t.geneid = ? ORDER BY t.id_ncbi', array($sGene))->fetchAllCombine();
         $nTranscriptsWithVariants = count($aTranscriptsWithVariants);
 
         // If NM is mentioned, check if exists for this gene. If not, reload page without NM. Otherwise, restrict $aTranscriptsWithVariants.
@@ -98,7 +98,8 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
     $sViewListID = 'CustomVL_VIEW_' . $sGene;
 
     // If this gene has only one NM, show that one. Otherwise have people pick one.
-    list($nTranscriptID, $sTranscript) = each($aTranscriptsWithVariants);
+    $nTranscriptID = key($aTranscriptsWithVariants);
+    $sTranscript = current($aTranscriptsWithVariants);
     if (!$nTranscripts) {
         $sMessage = 'No transcripts found for this gene.';
     } elseif (!$nTranscriptsWithVariants) {


### PR DESCRIPTION
Fixed notices and deprecated function calls.
- Fixed notices that occurred when searching for just a '!' in a text field.
- Fixed notices when non-public Individuals or Phenotypes were edited by submitters.
  - This was already fixed in `variants.php` in a slightly different way, but apparently I overlooked checking other files back then.
- Removed deprecated `each()` calls from `variants.php` and `view.php`, and sorted given transcripts on NCBI ID.
- Removed deprecated `each()` calls from `import.php`, `object_links.php`, and `scripts/readingFrameChecker.php`.
- Fixed notices in unique variant view when viewers bypassed the `cols_to_skip` by loading the VL directly over ajax.