### PR TITLE
Fixed column's example width bar.

### DIFF
--- a/src/inc-js-columns.php
+++ b/src/inc-js-columns.php
@@ -4,11 +4,11 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2013-03-26
- * Modified    : 2013-03-26
- * For LOVD    : 3.0-04
+ * Modified    : 2020-06-03
+ * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2013 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -36,13 +36,13 @@ function lovd_setWidth ()
     var line = $(this).parent().parent().next().children(':last').children(':first');
     // No minimum defined here, since sometimes you just want to remove what is there and type a new number.
     // This maximum is also defined in object_columns.php and object_shared_columns.php.
-    if ($(this).attr('value') > 500) {
-        $(this).attr('value', 500);
+    if ($(this).val() > 500) {
+        $(this).val(500);
         alert('The width cannot be more than 500 pixels!');
         return false;
     }
-    $(line).attr('width', $(this).attr('value'));
-    $(line).next().next().html('(This is ' + $(this).attr('value') + ' pixels)');
+    $(line).attr('width', $(this).val());
+    $(line).next().next().html('(This is ' + $(this).val() + ' pixels)');
     return false;
 }
 

--- a/tests/selenium_tests/shared_tests/create_custom_column_phenotype.php
+++ b/tests/selenium_tests/shared_tests/create_custom_column_phenotype.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-19
- * Modified    : 2020-05-26
+ * Modified    : 2020-06-03
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -105,6 +105,7 @@ class CreateCustomColumnPhenotypeTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertValue('Age of diagnosis|The age at which the individual\'s diagnosis was confirmed, if known. Numbers lower than 10 should be prefixed by a zero and the field should always begin with years, to facilitate sorting on this column.|text|10', 'form_type');
         $this->unCheck('standard');
         $this->enterValue('width', '100');
+        $this->assertEquals('(This is 100 pixels)', $this->driver->findElement(WebDriverBy::xpath('//span[contains(text(), "(This is")]'))->getText());
         $this->unCheck('mandatory');
         $this->check('public_view');
         $this->check('public_add');


### PR DESCRIPTION
When creating or editing a custom column, the example width bar didn't change anymore when you set the column's width.
- JQuery now needs `val()` instead of `attr('value')` to get and set the input's value.
- Added a test for this feature.