### PR TITLE
Fix transcript sorting in gene-specific views.

### DIFF
--- a/src/view.php
+++ b/src/view.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-12-05
- * Modified    : 2020-03-26
+ * Modified    : 2020-06-16
  * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -48,9 +48,12 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
     // URL: /view/DMD/NM_004006.2
     // View all entries in a specific gene, affecting a specific trancript, with all joinable data.
 
-    $qGene = $_DB->query('SELECT g.id, count(t.id) FROM ' . TABLE_GENES . ' AS g LEFT OUTER JOIN ' .
-                         TABLE_TRANSCRIPTS . ' AS t ON g.id = t.geneid WHERE g.id = ?',
-                         array(rawurldecode($_PE[1])));
+    $qGene = $_DB->query('
+        SELECT g.id, COUNT(t.id)
+        FROM ' . TABLE_GENES . ' AS g
+          LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON g.id = t.geneid
+        WHERE g.id = ?
+        GROUP BY g.id', array(rawurldecode($_PE[1])));
     list($sGene, $nTranscripts) = $qGene->fetchRow();
 
     if ($sGene) {
@@ -61,12 +64,15 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
             define('FORMAT_ALLOW_TEXTPLAIN', true);
         }
 
-        // Overview is given per transcript. If there is only one, it will be mentioned. If there are more, you will be able to select which one you'd like to see.
+        // Overview is given per transcript. If there is only one, it will be mentioned.
+        // If there are more, you will be able to select which one you'd like to see.
         $aTranscriptsWithVariants = $_DB->query(
             'SELECT t.id, t.id_ncbi
              FROM ' . TABLE_TRANSCRIPTS . ' AS t
                INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid)
-             WHERE t.geneid = ? ORDER BY t.id_ncbi', array($sGene))->fetchAllCombine();
+             WHERE t.geneid = ?
+             GROUP BY t.id
+             ORDER BY COUNT(vot.id) DESC, t.id ASC', array($sGene))->fetchAllCombine();
         $nTranscriptsWithVariants = count($aTranscriptsWithVariants);
 
         // If NM is mentioned, check if exists for this gene. If not, reload page without NM. Otherwise, restrict $aTranscriptsWithVariants.


### PR DESCRIPTION
When viewing a gene's variants, choose which transcript to display based on the VOT count, not the NCBI ID.
- Fixed the same sorting bug in the full gene's view.
- The VOT count is used to sort API results as well since #410, so this makes the GUI consistent with the API.
- Closes #420.