### PR TITLE
Improved the Variant Validator scripts.

### DIFF
--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2020-06-11
+ * Modified    : 2020-06-23
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -444,25 +444,36 @@ class LOVD_VV
                     case 'processing_error':
                         // This happens, for instance, when we ask to select a
                         //  transcript that this variant actually doesn't map on.
-                        // If that is the case, retry without this transcript.
+                        // Also, sometimes VV (well, UTA) gives us a transcript
+                        //  voluntarily, but VV can't map our variant with it.
+                        $aFailingTranscripts = array();
+                        foreach ($aJSON[$sVariant]['hgvs_t_and_p'] as $sTranscript => $aTranscript) {
+                            if (!empty($aTranscript['transcript_variant_error'])) {
+                                $aFailingTranscripts[] = $sTranscript;
+                            }
+                        }
+
+                        // If not all our transcripts failed, just remove the ones that did.
+                        if (count($aFailingTranscripts) < count($aJSON[$sVariant]['hgvs_t_and_p'])) {
+                            foreach ($aFailingTranscripts as $sTranscript) {
+                                unset($aJSON[$sVariant]['hgvs_t_and_p'][$sTranscript]);
+                            }
+                            // Continue.
+                            break;
+                        }
+
+                        // If we have selected transcripts, they all failed.
+                        // If that is the case, retry without selecting any.
                         if (is_array($aOptions['select_transcripts'])
                             && count($aOptions['select_transcripts'])) {
-                            $bRetry = false;
-                            foreach ($aOptions['select_transcripts'] as $nKey => $sTranscript) {
-                                if (!empty($aJSON[$sVariant]['hgvs_t_and_p'][$sTranscript]['transcript_variant_error'])) {
-                                    // We selected a transcript and it's giving issues.
-                                    unset($aOptions['select_transcripts'][$nKey]);
-                                    $bRetry = true;
-                                }
-                            }
-                            if ($bRetry) {
-                                return $this->verifyGenomic($sVariant, $aOptions);
-                            }
+                            unset($aOptions['select_transcripts']);
+                            return $this->verifyGenomic($sVariant, $aOptions);
                         }
                         // No break; if we don't catch the error above here,
                         //  we want the error below.
                     default:
                         // Unhandled flag. I know "processing_error" can be thrown, in theory.
+                        // FIXME: NC_000007.13:g.50468071G>A throws one, and has 10 failing transcripts. I guess sometimes you can't go around this.
                         $aData['errors']['EFLAG'] = 'VV Flag not recognized: ' . $aJSON['flag'] . '. This indicates a feature is missing in LOVD.';
                         break;
                 }

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2020-06-23
+ * Modified    : 2020-06-24
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -441,6 +441,7 @@ class LOVD_VV
                         }
                         break;
                     case 'porcessing_error': // Typo, still present in test instance 2020-06-02.
+                        $aJSON['flag'] = 'processing_error';
                     case 'processing_error':
                         // This happens, for instance, when we ask to select a
                         //  transcript that this variant actually doesn't map on.
@@ -472,9 +473,17 @@ class LOVD_VV
                         // No break; if we don't catch the error above here,
                         //  we want the error below.
                     default:
-                        // Unhandled flag. I know "processing_error" can be thrown, in theory.
-                        // FIXME: NC_000007.13:g.50468071G>A throws one, and has 10 failing transcripts. I guess sometimes you can't go around this.
-                        $aData['errors']['EFLAG'] = 'VV Flag not recognized: ' . $aJSON['flag'] . '. This indicates a feature is missing in LOVD.';
+                        // Unhandled flag. "processing_error" can still be
+                        //  thrown, if all transcripts fail.
+                        // FIXME: NC_000003.11:g.169482398_169482471del   fails.
+                        // FIXME: NC_000007.13:g.50468071G>A throws one, and has
+                        //  10 failing transcripts. I guess sometimes you can't
+                        //  go around this.
+                        if ($aJSON['flag'] == 'processing_error') {
+                            $aData['warnings']['WFLAG'] = 'VV Flag not handled: ' . $aJSON['flag'] . '. This happens when UTA passes transcripts that VV cannot map to.';
+                        } else {
+                            $aData['errors']['EFLAG'] = 'VV Flag not recognized: ' . $aJSON['flag'] . '. This indicates a feature is missing in LOVD.';
+                        }
                         break;
                 }
             }

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-09
- * Modified    : 2020-06-22
+ * Modified    : 2020-06-23
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -568,7 +568,7 @@ class LOVD_VVAnalyses {
                                     } else {
                                         // We don't know what to do here.
                                         // Merge $aVV with $aVVVot's data, so we can see what VV's suggestion is for the DNA, RNA and protein.
-                                        $this->panic($aVariant, array_merge($aVV,
+                                        $this->panic($aVariant, array_merge_recursive($aVV,
                                             array('data' => array('transcript_mappings' => array($sTranscript => $aVVVot['data'])))),
                                             'While handling EREF error, found that also cDNA and protein are different; cDNA can be fixed, but I don\'t know what to do with the protein field.');
                                     }
@@ -625,8 +625,9 @@ class LOVD_VVAnalyses {
                     }
                 }
                 if ($aVV['warnings']) {
-                    $this->panic($aVariant, $aVV, 'Warnings found: {' .
-                        implode(';',
+                    $this->panic($aVariant, array_merge_recursive($aVV,
+                        array('data' => array('DNA_clean' => substr(strstr($aVV['data']['DNA'], ':'), 1)))),
+                        'Warnings found: {' . implode(';',
                             array_map(function ($sKey, $sVal) {
                                 return $sKey . ':' . $sVal;
                             }, array_keys($aVV['warnings']), $aVV['warnings'])) . '}.');
@@ -924,7 +925,7 @@ class LOVD_VVAnalyses {
                                     } else {
                                         // We don't know what to do here.
                                         // Merge $aVV with $aVVVot's data, so we can see what VV's suggestion is for the DNA, RNA and protein.
-                                        $this->panic($aVariant, array_merge($aVV,
+                                        $this->panic($aVariant, array_merge_recursive($aVV,
                                             array('data' => array('transcript_mappings' => array($sTranscript => $aVVVot['data'])))),
                                             'cDNA and protein are different; cDNA can be fixed, but I don\'t know what to do with the protein field.');
                                     }

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-09
- * Modified    : 2020-06-23
+ * Modified    : 2020-06-24
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -362,7 +362,15 @@ class LOVD_VVAnalyses {
                             array(
                                 'map_to_transcripts' => true,
                                 'predict_protein' => true,
-                                'select_transcripts' => array_keys($aVariant['vots']), // Restrict transcripts to speed up liftover.
+                                // Restrict transcripts to speed up liftover,
+                                //  but only when we don't have already a lot.
+                                // Sending too many transcripts, often not
+                                //  mapped by VV anyway, will just trigger a
+                                //  processing_error, and make the call take
+                                //  forever or even fail.
+                                // See their #204 for more details.
+                                'select_transcripts' => (count($aVariant['vots']) > 5?
+                                    array() : array_keys($aVariant['vots'])),
                                 'lift_over' => ($_CONF['refseq_build'] == 'hg19' && $this->bDNA38),
                             ));
                     }

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -339,6 +339,12 @@ class LOVD_VVAnalyses {
                 usleep(100000); // FIXME: Remove later?
                 $bVKGL = ($this->bRemarks && substr($aVariant['remarks'], 0, 38) == 'VKGL data sharing initiative Nederland');
 
+                // Skip variants that have already been checked and marked with an error.
+                if (strpos($aVariant['remarks'], 'Variant Error [E') === false) {
+                    $this->nProgressCount++;
+                    continue;
+                }
+
                 // Call VV and get all information we need; mappings to
                 //  transcripts, protein predictions and even mappings to hg38
                 //  if we have that field.

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -386,12 +386,13 @@ class LOVD_VVAnalyses {
                         $this->nProgressCount ++; // To show progress.
                         continue;
                     } elseif (isset($aVV['errors']['ESYNTAX'])
-                        && preg_match('(\^|[?;]|con|ins\([0-9]+\)$|ins[0-9]+$|ins\[N[CGM]|\([0-9]+_[0-9]+\)|\[[0-9]+\]$)', $sVariant)) {
+                        && preg_match('(\^|\||[?;]|con|ins\([0-9]+\)$|ins[0-9]+$|ins\[N[CGM]|\([0-9]+_[0-9]+\)|\[[0-9]+\]$)', $sVariant)) {
                         // We received an ESYNTAX, but the variant has a common
                         //  problem that we, nor VV, can handle.
                         // We can't do anything, so just skip them.
-                        // (variant with uncertain position, allele notation,
-                        //  insertion with only length mentioned)
+                        // (variant^variant, methylation, variant with uncertain
+                        //  position, allele notation, conversion, insertion
+                        //  with only length or other refseq mentioned)
                         $this->nProgressCount ++; // To show progress.
                         continue; // Then continue to the next variant.
 

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-09
- * Modified    : 2020-06-11
+ * Modified    : 2020-06-22
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -350,7 +350,8 @@ class LOVD_VVAnalyses {
                     //  reason for the script to stop.
                     // If we do get a failure, just try again.
                     $aVV = false;
-                    for ($i = 0; (!$aVV && $i < 2); $i ++) {
+                    for ($i = 0; (!$aVV && $i < 5); $i ++) {
+                        sleep($i); // Sleep on second or later try.
                         $aVV = $_VV->verifyGenomic($sVariant,
                             array(
                                 'map_to_transcripts' => true,

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -563,6 +563,8 @@ class LOVD_VVAnalyses {
                                         // We have similar protein values. We already know the cDNA changed.
                                         // VV probably knows better because of the updated cDNA.
                                         $aUpdate['transcripts'][$sTranscript]['protein'] = $aVVVot['data']['protein'];
+                                    } elseif ($aVOT['protein'] == 'p.(=)' && preg_match('/[0-9]+[+-][0-9]+dup/', $aVOT['DNA'])) {
+                                        // Intronic dups sometimes have a p.(=) while VV produces a p.?. We trust the submitter knew better.
                                     } else {
                                         // We don't know what to do here.
                                         // Merge $aVV with $aVVVot's data, so we can see what VV's suggestion is for the DNA, RNA and protein.
@@ -917,6 +919,8 @@ class LOVD_VVAnalyses {
                                         // We have similar protein values. We already know the cDNA changed.
                                         // VV probably knows better because of the updated cDNA.
                                         $aUpdate['transcripts'][$sTranscript]['protein'] = $aVVVot['data']['protein'];
+                                    } elseif ($aVOT['protein'] == 'p.(=)' && preg_match('/[0-9]+[+-][0-9]+dup/', $aVOT['DNA'])) {
+                                        // Intronic dups sometimes have a p.(=) while VV produces a p.?. We trust the submitter knew better.
                                     } else {
                                         // We don't know what to do here.
                                         // Merge $aVV with $aVVVot's data, so we can see what VV's suggestion is for the DNA, RNA and protein.

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -643,7 +643,20 @@ class LOVD_VVAnalyses {
                         // We have a hg38 DNA column, and this variant has only one hg38 mapping.
                         $aVV['data']['DNA38_clean'] = substr(strstr($aVV['data']['genomic_mappings']['hg38'][0], ':'), 1);
                     } else {
-                        $this->panic($aVariant, $aVV, 'Multiple hg38 mappings given for variant.');
+                        // If we're selecting the transcripts that LOVD uses, we
+                        //  not only speed up the process, but also influence
+                        //  the liftover. So this error usually happens when our
+                        //  transcripts don't work because we're mapped too far
+                        //  away from them.
+                        // Example: NC_000008.10:g.32159191G>C (our mappings fail)
+                        // Example: NC_000001.10:g.19975658C>T (here, our two transcripts actually work)
+                        //    Idem: NC_000002.11:g.128407597G>A
+                        // FIXME: Skipping this error for now; it happens quite
+                        //  frequently, and we anyway currently don't know what
+                        //  to pick. We can work on that, removing transcripts
+                        //  for which we don't trust the VCF fields or that are
+                        //  mapping the variant deep intronic.
+                        // $this->panic($aVariant, $aVV, 'Multiple hg38 mappings given for variant.');
                     }
                 }
 


### PR DESCRIPTION
Improved the Variant Validator scripts. Our validation script is now working through chromosome 8. Implementing what we've learned so far.

#### Improved the Variant Validator class.
- Improved handling processing errors.
  - If there are transcripts that work, remove the ones that don't. Otherwise, if we have selected transcripts, retry without doing so.
  - When a processing error occurs because we failed to handle it, throw a warning (`WFLAG`) instead of an error (`EFLAG`).



#### Improved the variant validation script.
- Variants keep randomly failing; increase tries but implement an incremental sleep as well.
- Ignoring methylation variants, as they can't be processed anyway.
- Skip variants that have already been checked and marked with an error.
- Accept existing `p.(=)` variant descriptions for intronic dups even when VV thinks a `p.?` is more suitable.
- Fixed bug; Panics sometimes didn't mention the corrected genomic DNA description.
  - This was either because it wasn't calculated yet, or because `array_merge()` overwrote the value; used `array_merge_recursive()` instead.
- Silently skipping multiple hg38 mappings for now.
  - This happens quite frequently; documented some cases in the code.
- Don't let the variant fixing script send transcripts when we have more than five.
  - The risk is too high that these transcripts aren't really mapping to the variant, and VV is just going to spend more time on it, or even fail.
  - See openvar/variantValidator#204.