### PR TITLE
Fixed the Variant Validation script.

### DIFF
--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-09
- * Modified    : 2020-06-24
+ * Modified    : 2020-06-25
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -340,7 +340,7 @@ class LOVD_VVAnalyses {
                 $bVKGL = ($this->bRemarks && substr($aVariant['remarks'], 0, 38) == 'VKGL data sharing initiative Nederland');
 
                 // Skip variants that have already been checked and marked with an error.
-                if (strpos($aVariant['remarks'], 'Variant Error [E') === false) {
+                if (strpos($aVariant['remarks'], 'Variant Error [E') !== false) {
                     $this->nProgressCount++;
                     continue;
                 }

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -208,6 +208,15 @@ class LOVD_VVAnalyses {
                 (!$aVOT['protein']? '(protein)' : $aVOT['protein']) => (!isset($aVV['data']['transcript_mappings'][$sTranscript])? '' : $aVV['data']['transcript_mappings'][$sTranscript]['protein']),
             );
         }
+        // Because of using array_merge_recursive() to merge $aVV and $aVVVOT,
+        //  we might have ended up with arrays.
+        foreach ($aDiff['transcripts'] as $sTranscript => $aTranscript) {
+            foreach (array('DNA', 'RNA', 'protein') as $sField) {
+                if (is_array($aTranscript[$sField]) && count(array_unique($aTranscript[$sField])) == 1) {
+                    $aDiff['transcripts'][$sTranscript][$sField] = $aTranscript[$sField][0];
+                }
+            }
+        }
         $sDiff = print_r($aDiff, true);
         die('<PRE>' . $sDiff . '</PRE>
       <SCRIPT type="text/javascript">

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -624,11 +624,13 @@ class LOVD_VVAnalyses {
                 unset($aVV['warnings']['WCORRECTED']);
                 unset($aVV['warnings']['WROLLFORWARD']);
                 if (isset($aVV['warnings']['WGAP'])) {
-                    // Ignore WGAP warnings when the predicted cDNA is the same as the current cDNA.
+                    // Ignore WGAP warnings when the predicted cDNA is the same
+                    //  as the current cDNA, or when the predicted cDNA is WT.
                     $sTranscript = key($aVariant['vots']);
                     if ($aVariant['vots'][$sTranscript]['DNA']
-                        == $aVV['data']['transcript_mappings'][$sTranscript]['DNA']) {
-                        // Match.
+                        == $aVV['data']['transcript_mappings'][$sTranscript]['DNA']
+                        || substr($aVV['data']['transcript_mappings'][$sTranscript]['DNA'], -1) == '=') {
+                        // Match, or WT.
                         unset($aVV['warnings']['WGAP']);
                     }
                 }

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -201,21 +201,21 @@ class LOVD_VVAnalyses {
             $aDiff[(!$aVariant['DNA38']? '(DNA38)' : $aVariant['DNA38'])] =
                 (!isset($aVV['data']['genome_mappings']['hg38']['DNA'])? '' : $aVV['data']['genome_mappings']['hg38']['DNA']);
         }
+        // Because of using array_merge_recursive() to merge $aVV and $aVVVOT,
+        //  we may have ended up with arrays.
+        foreach ($aVV['data']['transcript_mappings'] as $sTranscript => $aTranscript) {
+            foreach (array('DNA', 'RNA', 'protein') as $sField) {
+                if (is_array($aTranscript[$sField]) && count(array_unique($aTranscript[$sField])) == 1) {
+                    $aVV['data']['transcript_mappings'][$sTranscript][$sField] = $aTranscript[$sField][0];
+                }
+            }
+        }
         foreach ($aVariant['vots'] as $sTranscript => $aVOT) {
             $aDiff['transcripts'][$sTranscript] = array(
                 (!$aVOT['DNA']? '(DNA)' : $aVOT['DNA']) => (!isset($aVV['data']['transcript_mappings'][$sTranscript])? '' : $aVV['data']['transcript_mappings'][$sTranscript]['DNA']),
                 (!$aVOT['RNA']? '(RNA)' : $aVOT['RNA']) => (!isset($aVV['data']['transcript_mappings'][$sTranscript])? '' : $aVV['data']['transcript_mappings'][$sTranscript]['RNA']),
                 (!$aVOT['protein']? '(protein)' : $aVOT['protein']) => (!isset($aVV['data']['transcript_mappings'][$sTranscript])? '' : $aVV['data']['transcript_mappings'][$sTranscript]['protein']),
             );
-        }
-        // Because of using array_merge_recursive() to merge $aVV and $aVVVOT,
-        //  we might have ended up with arrays.
-        foreach ($aDiff['transcripts'] as $sTranscript => $aTranscript) {
-            foreach (array('DNA', 'RNA', 'protein') as $sField) {
-                if (is_array($aTranscript[$sField]) && count(array_unique($aTranscript[$sField])) == 1) {
-                    $aDiff['transcripts'][$sTranscript][$sField] = $aTranscript[$sField][0];
-                }
-            }
         }
         $sDiff = print_r($aDiff, true);
         die('<PRE>' . $sDiff . '</PRE>


### PR DESCRIPTION
Fixed the Variant Validation script.
- Fixed bug; Instead of skipping variants with logged errors, it was skipping variants without logged errors.
- Ignore WGAP warnings when the predicted cDNA change is actually WT.
- Updated `panic()` code a bit; because of using `array_merge_recursive()` to merge `$aVV` and `$aVVVOT`, we may have ended up with arrays.