### PR TITLE
Fixed several custom link issues.

### DIFF
--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -5,7 +5,7 @@
 % To convert the manual to an html file use: pdf2htmlEX --zoom 1.3 --embed-css 2 manual.pdf
 
 %%%%% SETTINGS FOR THE TITLE PAGE %%%%%
-\setLOVDversion{3.0-23}
+\setLOVDversion{3.0-24}
 \title{LOVD 3.0 user manual \\\vskip 0.2cm Build \LOVDversion}
 \author{Ivo F.A.C. Fokkema \\ Daan Asscheman}
 \setpointercolor{red}
@@ -61,7 +61,7 @@ With the official release of LOVD in 2004 the system had become much more dynami
 
 In 2004, LOVD became available under the open source license GPL and with the 1.1.0 release most of the text-files had been replaced by online forms
 so customizations can be performed through the web interface.
-Early in 2005 the \href{https://www.ncbi.nlm.nih.gov/pubmed/15977173}{first LOVD article} was published,
+Early in 2005 the \href{https://pubmed.ncbi.nlm.nih.gov/15977173}{first LOVD article} was published,
 and in 2005 the development of LOVD was more targeted at improving the ease of use of the system.
 \vskip \baselineskip
 
@@ -74,7 +74,7 @@ With more features being added and bugs fixed rapidly, LOVD 2.0 reached beta sta
 after which more and more users started to upgrade their 1.1.0 databases to 2.0.
 Finally, in October 2007 LOVD 2.0 reached the stable stage, after which LOVD 2.0 was continuously improved with monthly releases for two years,
 after which the releases became less frequent.
-LOVD 2.0 is described in the \href{https://www.ncbi.nlm.nih.gov/pubmed/21520333}{second LOVD paper}.
+LOVD 2.0 is described in the \href{https://pubmed.ncbi.nlm.nih.gov/21520333}{second LOVD paper}.
 \vskip \baselineskip
 
 By 2009 it had became clear that although LOVD 2.0 was a great step forward, there were still key improvements to be made.

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -379,6 +379,18 @@ class LOVD_Gene extends LOVD_Object
                                  1 => 'Right'
                                     );
 
+        // Custom links for the Reference field.
+        $aCustomLinks = $_DB->query('
+                    SELECT name, pattern_text, description
+                    FROM ' . TABLE_LINKS . ' WHERE name = ?',
+            array('PubMed'))->fetchAllAssoc();
+        $sCustomLinks = '';
+        foreach ($aCustomLinks as $aLink) {
+            $sToolTip = str_replace(array("\r\n", "\r", "\n"), '<BR>', 'Click to insert:<BR>' . $aLink['pattern_text'] . '<BR><BR>' . addslashes(htmlspecialchars($aLink['description'])));
+            $sCustomLinks .= ($sCustomLinks? ', ' : '') . '<A href="#" onmouseover="lovd_showToolTip(\'' . $sToolTip . '\');" onmouseout="lovd_hideToolTip();" onclick="lovd_insertCustomLink(this, \'' . $aLink['pattern_text'] . '\'); return false">' . $aLink['name'] . '</A>';
+        }
+        $sCustomLinks = '(Active custom link' . (count($aCustomLinks) == 1? '' : 's') . ' : ' . $sCustomLinks . ')';
+
         // Array which will make up the form table.
         $this->aFormData =
                  array(
@@ -432,7 +444,7 @@ class LOVD_Gene extends LOVD_Object
                         array('', '', 'note', 'You can use the following fields to customize the gene\'s LOVD gene homepage.'),
                         'hr',
                         array('Citation reference(s)', '', 'textarea', 'reference', 30, 3),
-                        array('', '', 'note', '(Active custom link : <A href="#" onmouseover="lovd_showToolTip(\'Click to insert:<BR>{PMID:[1]:[2]}<BR><BR>Links to abstracts in the PubMed database.<BR>[1] = The name of the author(s).<BR>[2] = The PubMed ID.\');" onmouseout="lovd_hideToolTip();" onclick="lovd_insertCustomLink(this, \'{PMID:[1]:[2]}\'); return false">Pubmed</A>)'),
+                        array('', '', 'note', $sCustomLinks),
                         array('Include disclaimer', '', 'select', 'disclaimer', 1, $aSelectDisclaimer, false, false, false),
                         array('', '', 'note', 'If you want a disclaimer added to the gene\'s LOVD gene homepage, select your preferred option here.'),
                         array('Text for own disclaimer<BR>(HTML enabled)', '', 'textarea', 'disclaimer_text', 55, 3),

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -382,8 +382,8 @@ class LOVD_Gene extends LOVD_Object
         // Custom links for the Reference field.
         $aCustomLinks = $_DB->query('
                     SELECT name, pattern_text, description
-                    FROM ' . TABLE_LINKS . ' WHERE name = ?',
-            array('PubMed'))->fetchAllAssoc();
+                    FROM ' . TABLE_LINKS . ' WHERE name IN (?, ?)',
+            array('PubMed', 'DOI'))->fetchAllAssoc();
         $sCustomLinks = '';
         foreach ($aCustomLinks as $aLink) {
             $sToolTip = str_replace(array("\r\n", "\r", "\n"), '<BR>', 'Click to insert:<BR>' . $aLink['pattern_text'] . '<BR><BR>' . addslashes(htmlspecialchars($aLink['description'])));
@@ -545,8 +545,8 @@ class LOVD_Gene extends LOVD_Object
             if (isset($zData['reference'])) {
                 $aCustomLinks = $_DB->query('
                     SELECT pattern_text, replace_text
-                    FROM ' . TABLE_LINKS . ' WHERE name = ?',
-                    array('PubMed'))->fetchAllAssoc();
+                    FROM ' . TABLE_LINKS . ' WHERE name IN (?, ?)',
+                    array('PubMed', 'DOI'))->fetchAllAssoc();
                 foreach ($aCustomLinks as $aLink) {
                     $sRegexpPattern = '/' . str_replace(array('{', '}'), array('\{', '\}'), preg_replace('/\[\d\]/', '([^:]*)', $aLink['pattern_text'])) . '/';
                     $sReplaceText = preg_replace('/\[(\d)\]/', '\$$1', $aLink['replace_text']);

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2020-06-08
+ * Modified    : 2020-07-09
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -785,6 +785,7 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                      ),
                      array(
                          'DELETE FROM ' . TABLE_EFFECT . ' WHERE id LIKE "6_" OR id LIKE "8_" OR id LIKE "_6" OR id LIKE "_8"',
+                         'UPDATE ' . TABLE_LINKS . ' SET replace_text = "<A href=\"https://pubmed.ncbi.nlm.nih.gov/[2]\" target=\"_blank\">[1]</A>" WHERE name = "PubMed" AND replace_text = "<A href=\"https://www.ncbi.nlm.nih.gov/pubmed/[2]\" target=\"_blank\">[1]</A>"',
                      )
                  ),
              );

--- a/src/install/inc-sql-links.php
+++ b/src/install/inc-sql-links.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-22
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-07-09
+ * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -31,7 +31,7 @@
 
 $aLinkSQL =
          array(
-                'PubMed' => 'INSERT INTO ' . TABLE_LINKS . ' VALUES (001, "PubMed", "{PMID:[1]:[2]}", "<A href=\"https://www.ncbi.nlm.nih.gov/pubmed/[2]\" target=\"_blank\">[1]</A>", "Links to abstracts in the PubMed database.\r\n[1] = The name of the author(s), possibly followed by the year of publication.\r\n[2] = The PubMed ID.\r\n\r\nExample:\r\n{PMID:Fokkema et al. (2011):21520333}", 0, NOW(), NULL, NULL)',
+                'PubMed' => 'INSERT INTO ' . TABLE_LINKS . ' VALUES (001, "PubMed", "{PMID:[1]:[2]}", "<A href=\"https://pubmed.ncbi.nlm.nih.gov/[2]\" target=\"_blank\">[1]</A>", "Links to abstracts in the PubMed database.\r\n[1] = The name of the author(s), possibly followed by the year of publication.\r\n[2] = The PubMed ID.\r\n\r\nExample:\r\n{PMID:Fokkema et al. (2011):21520333}", 0, NOW(), NULL, NULL)',
                 'INSERT INTO ' . TABLE_COLS2LINKS . ' VALUES ("Individual/Reference", 001)',
                 'INSERT INTO ' . TABLE_COLS2LINKS . ' VALUES ("VariantOnGenome/Reference", 001)',
                 'DbSNP' => 'INSERT INTO ' . TABLE_LINKS . ' VALUES (002, "DbSNP", "{dbSNP:[1]}", "<A href=\"https://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?rs=[1]\" target=\"_blank\">dbSNP</A>", "Links to the DbSNP database.\r\n[1] = The DbSNP ID.\r\n\r\nExamples:\r\n{dbSNP:rs193143796}\r\n{dbSNP:193143796}", 0, NOW(), NULL, NULL)',

--- a/tests/selenium_tests/shared_tests/check_custom_links.php
+++ b/tests/selenium_tests/shared_tests/check_custom_links.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-09-22
- * Modified    : 2020-06-15
+ * Modified    : 2020-07-09
  * For LOVD    : 3.0-24
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -81,7 +81,7 @@ class CheckCustomLinks extends LOVDSeleniumWebdriverBaseTestCase
 
         // Now find the tooltip that should have shown.
         $sToolTipLinkText = $this->driver->findElement(WebDriverBy::xpath('//div[@id="tooltip"]/a'))->getText();
-        $this->assertStringStartsWith('https://www.ncbi.nlm.nih.gov/pubmed/', $sToolTipLinkText);
+        $this->assertStringStartsWith('https://pubmed.ncbi.nlm.nih.gov/', $sToolTipLinkText);
     }
 }
 ?>


### PR DESCRIPTION
Fixed several custom link issues.
- Replaced hardcoded PubMed link on the gene homepage to use the databases's PubMed link, for the processing and on the gene information data entry form.
- Enabled the DOI custom link for the gene's Reference field.

Also:
- Updated the PubMed link to the new format in `install/inc-sql-links.php` and `inc-upgrade.php`.
- Updated the PubMed link to the new format in the tests.
- Updated the manual to use the new PubMed link format for our own links to PubMed.

Closes #430.