### PR TITLE
Improved the "forgot my password" feature.

### DIFF
--- a/src/login.php
+++ b/src/login.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-19
- * Modified    : 2018-01-19
- * For LOVD    : 3.0-21
+ * Modified    : 2020-07-09
+ * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -180,11 +180,6 @@ if (!empty($_POST)) {
                 if ($zUser && $zUser['login_attempts'] >= (3-1)) {
                     lovd_errorAdd('password', 'Your account is now locked, since this is the third time a wrong password was provided.');
                 }
-
-                // The "Forgot my password" option.
-                if ($_CONF['allow_unlock_accounts']) {
-                    lovd_errorAdd('', 'Did you <A href="reset_password">forget your password</A>?');
-                }
             }
         }
     }
@@ -219,17 +214,17 @@ if (!$_AUTH) {
           '        <TABLE border="0" cellpadding="0" cellspacing="0" width="275">' . "\n" .
           '          <TR align="right">' . "\n" .
           '            <TD width="100" style="padding-right : 5px;">Username</TD>' . "\n" .
-          '            <TD width="175"><INPUT type="text" name="username" size="20"></TD></TR>' . "\n" .
+          '            <TD width="175" colspan="2"><INPUT type="text" name="username" size="20"></TD></TR>' . "\n" .
           '          <TR>' . "\n" .
           '            <TD colspan="2"><IMG src="gfx/trans.png" alt="" width="1" height="1"></TD></TR>' . "\n" .
           '          <TR align="right">' . "\n" .
           '            <TD width="100" style="padding-right : 5px;">Password</TD>' . "\n" .
-          '            <TD width="175"><INPUT type="password" name="password" size="20"></TD></TR>' . "\n" .
+          '            <TD width="175" colspan="2"><INPUT type="password" name="password" size="20"></TD></TR>' . "\n" .
           '          <TR>' . "\n" .
           '            <TD colspan="2"><IMG src="gfx/trans.png" alt="" width="1" height="1"></TD></TR>' . "\n" .
           '          <TR align="right">' . "\n" .
-          '            <TD width="100">&nbsp;</TD>' . "\n" .
-          '            <TD width="175"><INPUT type="submit" value="Log in"></TD></TR></TABLE>' . "\n" .
+          '            <TD width="150" colspan="2">' . (!$_CONF['allow_unlock_accounts']? '&nbsp;' : '<A href="reset_password">Forgot your password</A>?') . '</TD>' . "\n" .
+          '            <TD width="125"><INPUT type="submit" value="Log in"></TD></TR></TABLE>' . "\n" .
           '      </FORM>' . "\n\n" .
           '      <SCRIPT type="text/javascript">' . "\n" .
           '        document.forms[\'login\'].username.focus();' . "\n" .

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -89,13 +89,6 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
             lovd_writeLog('Auth', LOG_EVENT, $_SERVER['REMOTE_ADDR'] . ' (' . lovd_php_gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') successfully reset password for account ' . $_POST['username']);
 
             // Send email confirmation.
-
-            // For submitters, we need to take the FIRST email address only.
-            if (isset($zData['submitterid'])) {
-                $aEmail = explode("\r\n", trim($zData['email']));
-                $zData['email'] = $aEmail[0];
-            }
-
             $aTo = array(array($zData['name'], $zData['email']));
 
             $sMessage = 'Dear ' . $zData['name'] . ',' . "\n\n" .
@@ -146,7 +139,6 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
 
         } else {
             unset($_POST['username']);
-            lovd_writeLog('Auth', LOG_EVENT, $_SERVER['REMOTE_ADDR'] . ' (' . lovd_php_gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') tried to reset password for denied account ' . $_POST['username']);
         }
     }
 

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-20
- * Modified    : 2018-01-19
- * For LOVD    : 3.0-21
+ * Modified    : 2020-07-10
+ * For LOVD    : 3.0-24
  *
- * Copyright   : 2004-2018 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -61,7 +61,7 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
             lovd_writeLog('Auth', LOG_EVENT, $_SERVER['REMOTE_ADDR'] . ' (' . lovd_php_gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') tried to reset password for non-existent account ' . $_POST['username']);
             print('      If you entered the username correctly, we have successfully reset your password.<BR>' . "\n" .
                   '      We\'ve sent you an email containing your new password. With this new password, you can <A href="' . ROOT_PATH . 'login">unlock your account</A> and choose a new password.<BR><BR>' . "\n" .
-                  '      If you don\'t receive this email, it is possible that the username you entered is not correct. Please double-check it.<BR><BR>' . "\n\n");
+                  '      If you don\'t receive this email, it is possible that the username you entered is not correct. Please double-check it. Another possibility is that you registered at a different LOVD installation. Accounts are not shared between different LOVD installations, so please double-check where you are registered.<BR><BR>' . "\n\n");
             $_T->printFooter();
             exit;
         }
@@ -155,7 +155,7 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
     $_T->printHeader();
     $_T->printTitle();
 
-    print('      If you forgot your password, please fill in your username here. A new random password will be generated and emailed to the known email address. You need this new password to unlock your account and choose a new password.<BR>' . "\n" .
+    print('      If you forgot your password, please fill in your username here. If an account exists that matches this information, a new random password will be generated and emailed to the known email address. You need this new password to unlock your account and choose a new password.<BR>' . "\n" .
           '      <BR>' . "\n\n");
 
     lovd_errorPrint();
@@ -167,7 +167,6 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
     $aForm = array(
                     array('POST', '', '', '', '30%', '20', '70%'),
                     array('Username', '', 'text', 'username', 20),
-                    'skip',
                     array('', '', 'submit', 'Reset password'),
                   );
     lovd_viewForm($aForm);


### PR DESCRIPTION
Improved the "forgot my password" feature.
- Added the "forgot my password" link to the login form also before trying to log in.
- Clarified on the reset password form that an email will only be sent when we find a matching account.
  - Also, users are reminded to check if this is the LOVD installation that they're registered to.
- Allow resetting an account's password as well with the account's email address.
  - If the email address is used by multiple accounts, using the username is still required.
  - Accounts, where the email address is the only address, are preferred over accounts where the address is one of the addresses.
- Removed useless code, probably present from the LOVD2 to LOVD3 code migration.

Closes #432.