### PR TITLE
Added feature to download a submission.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 
 env:
   # Let Selenium use Firefox driver.
-  - LOVD_SELENIUM_DRIVER=firefox
+  # - LOVD_SELENIUM_DRIVER=firefox # 2020-07-21: Disabled, Travis' FF has been failing for weeks, reason unknown.
   # Let Selenium use Chrome driver.
   - LOVD_SELENIUM_DRIVER=chrome
 

--- a/src/download.php
+++ b/src/download.php
@@ -156,7 +156,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
 
     } elseif ($_PE[1] == 'all' && $_PE[2] == 'mine' && PATH_COUNT == 3) {
         // Own data.
-        $sFileName = 'owned_data';
+        $sFileName = 'owned_data_' . $_AUTH['id'];
         $sHeader = 'Owned data';
         $sFilter = 'owner';
         $ID = $_AUTH['id'];
@@ -173,7 +173,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
 
     } elseif ($_PE[1] == 'all' && $_PE[2] == 'user' && PATH_COUNT == 4 && ctype_digit($_PE[3])) {
         // Data owned by other.
-        $sFileName = 'owned_data';
+        $sFileName = 'owned_data_' . $_PE[3];
         $sHeader = 'Owned data';
         $sFilter = 'owner';
         $ID = $_PE[3];

--- a/src/download.php
+++ b/src/download.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2020-02-25
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-17
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -99,7 +99,7 @@ if (ACTION || PATH_COUNT < 2) {
 
 
 
-if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'mine', 'user')))) ||
+if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'mine', 'submission', 'user')))) ||
     ($_PE[1] == 'columns' && PATH_COUNT <= 3) ||
     ($_PE[1] == 'diseases' && PATH_COUNT == 2) ||
     ($_PE[1] == 'genes' && PATH_COUNT == 2) ||
@@ -107,6 +107,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
     // URL: /download/all
     // URL: /download/all/gene/IVD
     // URL: /download/all/mine
+    // URL: /download/all/submission/00000001
     // URL: /download/all/user/00001
     // URL: /download/columns
     // URL: /download/columns/(VariantOnGenome|VariantOnTranscript|Individual|...)
@@ -133,7 +134,8 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
         $sFileName = 'full_download';
         $sHeader = 'Full data';
         lovd_requireAuth(LEVEL_MANAGER);
-    } elseif ($_PE[1] == 'all' && $_PE[2] == 'gene'  && PATH_COUNT == 4 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[3]))) {
+
+    } elseif ($_PE[1] == 'all' && $_PE[2] == 'gene' && PATH_COUNT == 4 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[3]))) {
         // Gene database contents.
         $sFileName = 'full_download_' . $_PE[3];
         $sHeader = 'Full data';
@@ -151,6 +153,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
                     'to see non-public data.' . "\r\n");
             }
         }
+
     } elseif ($_PE[1] == 'all' && $_PE[2] == 'mine' && PATH_COUNT == 3) {
         // Own data.
         $sFileName = 'owned_data';
@@ -158,6 +161,16 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
         $sFilter = 'owner';
         $ID = $_AUTH['id'];
         lovd_requireAuth();
+
+    } elseif ($_PE[1] == 'all' && $_PE[2] == 'submission' && PATH_COUNT == 4 && ctype_digit($_PE[3])) {
+        // Data from a single submission.
+        $sFileName = 'submission_' . $_PE[3];
+        $sHeader = 'Full data';
+        $sFilter = 'individual';
+        $ID = $_PE[3];
+        lovd_isAuthorized('individual', $_PE[3]);
+        lovd_requireAuth(LEVEL_OWNER);
+
     } elseif ($_PE[1] == 'all' && $_PE[2] == 'user' && PATH_COUNT == 4 && ctype_digit($_PE[3])) {
         // Data owned by other.
         $sFileName = 'owned_data';
@@ -171,6 +184,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
         $sFileName = 'custom_columns';
         $sHeader = 'Custom column';
         lovd_requireAuth(LEVEL_MANAGER);
+
     } elseif ($_PE[1] == 'columns' && in_array($_PE[2], array('Individual', 'Phenotype', 'Screening', 'VariantOnGenome', 'VariantOnTranscript'))) {
         // FIXME; Is there a better way checking if it's a valid category?
         // Category given.
@@ -209,7 +223,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
     print('### LOVD-version ' . lovd_calculateVersion($_SETT['system']['version']) . ' ### ' . $sHeader . ' download ### To import, do not remove or alter this header ###' . "\r\n");
     if ($sFilter == 'owner') {
         print('## Filter: (created_by = ' . $ID . ' || owned_by = ' . $ID . ')' . "\r\n");
-    } elseif (in_array($sFilter, array('category', 'gene', 'genepanel', 'gene_public'))) {
+    } elseif (in_array($sFilter, array('category', 'gene', 'genepanel', 'gene_public', 'individual'))) {
         print('## Filter: (' . $sFilter . ' = ' . $ID . ')' . "\r\n");
     }
     print('# charset = UTF-8' . "\r\n\r\n");
@@ -427,6 +441,62 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
                     $aObjects[$sObject]['hide_columns'][] = $aHiddenCol['id'];
                 }
             }
+
+        } elseif ($sFilter == 'individual') {
+            // Remove objects that we're not interested in.
+            unset($aObjects['Columns'], $aObjects['Gen2Dis']);
+            // Change the order of filtering.
+            $aObjectsToBeFiltered =
+                array(
+                    'Individuals',
+                    'Ind2Dis',
+                    'Phenotypes',
+                    'Diseases',
+                    'Screenings',
+                    'Scr2Gene',
+                    'Scr2Var',
+                    'Variants',
+                    'Variants_On_Transcripts',
+                    'Transcripts',
+                    'Genes',
+                );
+            $aObjects['Individuals']['filters']['id'] = $ID;
+            $aObjects['Individuals']['filter_other']['Ind2Dis']['individualid'] = 'id';
+            $aObjects['Ind2Dis']['filter_other']['Diseases']['id'] = 'diseaseid';
+            $aObjects['Phenotypes']['filters']['individualid'] = $ID;
+            $aObjects['Phenotypes']['filter_other']['Diseases']['id'] = 'diseaseid';
+            $aObjects['Diseases']['comments'][] = 'For reference only, not part of the selected data set';
+            $aObjects['Diseases']['settings'][] = 'ignore_for_import';
+            $aObjects['Diseases']['hide_columns'] =
+                array(
+                    'created_by', 'created_date', 'edited_by', 'edited_date',
+                );
+            $aObjects['Screenings']['filters']['individualid'] = $ID;
+            $aObjects['Screenings']['filter_other']['Scr2Gene']['screeningid'] = 'id';
+            $aObjects['Screenings']['filter_other']['Scr2Var']['screeningid'] = 'id';
+            $aObjects['Scr2Gene']['filter_other']['Genes']['id'] = 'geneid';
+            $aObjects['Scr2Var']['filter_other']['Variants']['id'] = 'variantid';
+            $aObjects['Variants']['filter_other']['Variants_On_Transcripts']['id'] = 'id';
+            $aObjects['Variants_On_Transcripts']['filter_other']['Transcripts']['id'] = 'transcriptid';
+            $aObjects['Transcripts']['comments'][] = 'For reference only, not part of the selected data set';
+            $aObjects['Transcripts']['settings'][] = 'ignore_for_import';
+            $aObjects['Transcripts']['filter_other']['Genes']['id'] = 'geneid';
+            $aObjects['Transcripts']['hide_columns'] =
+                array(
+                    'id_mutalyzer', 'position_c_mrna_start', 'position_c_mrna_end', 'position_c_cds_end',
+                    'position_g_mrna_start', 'position_g_mrna_end', 'created_by', 'created_date', 'edited_by',
+                    'edited_date',
+                );
+            $aObjects['Genes']['comments'][] = 'For reference only, not part of the selected data set';
+            $aObjects['Genes']['settings'][] = 'ignore_for_import';
+            $aObjects['Genes']['hide_columns'] =
+                array(
+                    'imprinting', 'refseq_genomic', 'refseq_UD', 'reference', 'url_homepage', 'url_external',
+                    'allow_download', 'show_hgmd', 'show_genecards', 'show_genetests',
+                    'note_index', 'note_listing', 'refseq', 'refseq_url', 'disclaimer', 'disclaimer_text',
+                    'header', 'header_align', 'footer', 'footer_align', 'created_by', 'created_date',
+                    'edited_by', 'edited_date', 'updated_by', 'updated_date',
+                );
         }
 
     } elseif ($_PE[1] == 'columns') {

--- a/src/download.php
+++ b/src/download.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2020-07-17
+ * Modified    : 2020-07-20
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -35,7 +35,7 @@ define('ROOT_PATH', './');
 require ROOT_PATH . 'inc-init.php';
 set_time_limit(60*5); // Very large, but not infinite.
 
-//header('Content-type: text/plain; charset=UTF-8');
+
 
 
 
@@ -268,16 +268,15 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
 
         // Apply filters and filter order, for user-specific download.
         if ($sFilter == 'owner') {
-            // In user-specific download, we don't care about the relationship between genes and diseases.
-            // (Genes will be shown if its transcripts are shown, Diseases will be shown if its individuals are shown)
-            unset($aObjects['Gen2Dis']);
-            // Change the order of filtering, so we can filter the data that's just for reference last.
+            // Remove objects that we're not interested in.
+            unset($aObjects['Columns'], $aObjects['Gen2Dis']);
+            // Change the order of filtering.
             $aObjectsToBeFiltered =
                 array(
                     'Individuals',
                     'Ind2Dis',
-                    'Diseases',
                     'Phenotypes',
+                    'Diseases',
                     'Screenings',
                     'Scr2Gene',
                     'Variants',
@@ -286,17 +285,17 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
                     'Genes',
                     'Scr2Var',
                 );
-            unset($aObjects['Columns']); // Custom columns don't matter when it's about somebody's data only.
             $aObjects['Individuals']['filters']['owner'] = $ID;
             $aObjects['Individuals']['filter_other']['Ind2Dis']['individualid'] = 'id';
             $aObjects['Ind2Dis']['filter_other']['Diseases']['id'] = 'diseaseid';
+            $aObjects['Phenotypes']['filters']['owner'] = $ID;
+            $aObjects['Phenotypes']['filter_other']['Diseases']['id'] = 'diseaseid';
             $aObjects['Diseases']['comments'][] = 'For reference only, not part of the selected data set';
             $aObjects['Diseases']['settings'][] = 'ignore_for_import';
             $aObjects['Diseases']['hide_columns'] =
                 array(
                     'created_by', 'created_date', 'edited_by', 'edited_date',
                 );
-            $aObjects['Phenotypes']['filters']['owner'] = $ID;
             $aObjects['Screenings']['filters']['owner'] = $ID;
             $aObjects['Screenings']['filter_other']['Scr2Gene']['screeningid'] = 'id';
             $aObjects['Screenings']['filter_other']['Scr2Var']['screeningid'] = 'id';

--- a/src/download.php
+++ b/src/download.php
@@ -586,6 +586,11 @@ foreach ($aObjectsToBeFiltered as $sObject) {
     $aObjects[$sObject]['args']  = $aArgs;
 
     // If prefetch is requested, request data right here. We will then loop through the results to create the filters for the other objects.
+    // FIXME: Prefetching is slow and memory intensive. It would be way more efficient
+    //  to build the query such that we prefetch the filters instead of the data.
+    //  When downloading my data, to display the genes I need to prefetch VOG, VOT, and transcripts.
+    //  I could also fetch the IDs in VOT from my own VOGs, then get all
+    //   transcript IDs from all VOT IDs, then get all gene IDs.
     if ($aSettings['prefetch'] || count($aSettings['filter_other'])) {
         $aObjects[$sObject]['data'] = $_DB->query($aObjects[$sObject]['query'], $aObjects[$sObject]['args'])->fetchAllAssoc();
 

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2020-03-25
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-17
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -125,6 +125,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
             $aNavigation['phenotypes?create&amp;target=' . $nID] = array('menu_plus.png', 'Add phenotype information to individual', 1);
         }
         $aNavigation['screenings?create&amp;target=' . $nID]     = array('menu_plus.png', 'Add screening to individual', 1);
+        $aNavigation['download/all/submission/' . $nID]          = array('menu_save.png', 'Download submission in LOVD3 format', 1);
         if ($_AUTH['level'] >= $_SETT['user_level_settings']['delete_individual']) {
             $aNavigation[CURRENT_PATH . '?delete']               = array('cross.png', 'Delete individual entry', 1);
         }

--- a/tests/selenium_tests/admin_tests/verify_full_download.php
+++ b/tests/selenium_tests/admin_tests/verify_full_download.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-21
- * Modified    : 2020-05-26
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-20
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -94,7 +94,8 @@ class VerifyFullDownloadTest extends LOVDSeleniumWebdriverBaseTestCase
         // Now compare the two files.
         $this->assertEquals(
             file_get_contents(ROOT_PATH . '../tests/test_data_files/AdminTestSuiteResult.txt'),
-            preg_replace('/\b[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\b/', '0000-00-00 00:00:00', file_get_contents('/tmp/' . $sDownloadFile))
+            preg_replace('/^### LOVD-version [0-9]{4}-[0-9]{3} /', '### LOVD-version ????-??? ',
+                preg_replace('/\b[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\b/', '0000-00-00 00:00:00', file_get_contents('/tmp/' . $sDownloadFile)))
         );
     }
 }

--- a/tests/selenium_tests/shared_tests/create_gene_IVD.php
+++ b/tests/selenium_tests/shared_tests/create_gene_IVD.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-03-04
- * Modified    : 2020-06-17
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-20
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
@@ -62,6 +62,7 @@ class CreateGeneIVDTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->waitForElement(WebDriverBy::name('hgnc_id'), 5);
         $this->enterValue('hgnc_id', 'IVD');
         $this->submitForm('Continue');
+        $this->waitForElement(WebDriverBy::xpath('//select[@name="active_transcripts[]"]'));
 
         $this->selectValue('active_transcripts[]', 'NM_002225.3');
         $this->check('show_hgmd');

--- a/tests/test_data_files/AdminTestSuiteResult.txt
+++ b/tests/test_data_files/AdminTestSuiteResult.txt
@@ -1,4 +1,4 @@
-### LOVD-version 3000-230 ### Full data download ### To import, do not remove or alter this header ###
+### LOVD-version ????-??? ### Full data download ### To import, do not remove or alter this header ###
 # charset = UTF-8
 
 ## Columns ## Do not remove or alter this header ##


### PR DESCRIPTION
Added feature to download a submission.
- Added download format for a single submission.
- Added link to the new download format from the Individual VE, for data owners only.

Also:
- Added the user's ID to the file name when downloading all of your own or somebody else's data.
- Fixed bug; User-specific downloads didn't include the Diseases that Phenotype entries were linked to, only Diseases that Individuals were linked to.
- Added a FIXME for speeding up downloads and making them less memory intensive.
  - I think it's quite a lot of work and I don't have time for this at the moment, so I've documented what is necessary and we'll do it later.
- Fixed download test, LOVD's version from the download template mismatched the current version.
- Added more waiting time to the gene creation test, as the HGNC APIs are very slow now and the test was failing.
- Disable tests using FireFox, as the Travis version breaks all tests for an unknown reason.




Closes #436.