### PR TITLE
Improved the Variant Validation script.

### DIFF
--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2020-06-24
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-16
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -179,7 +179,8 @@ class LOVD_VV
 
                 } elseif ($aVariant['position_start_intron'] && $aVariant['position_end_intron']
                     && abs($aVariant['position_start_intron']) > 5 && abs($aVariant['position_end_intron']) > 5
-                    && ($aVariant['position_start'] == $aVariant['position_end'] || $aVariant['position_start'] == ($aVariant['position_end'] + 1))) {
+                    && ($aVariant['position_start'] == $aVariant['position_end']
+                        || ($aVariant['position_start'] + 1) == $aVariant['position_end'])) {
                     // Deep intronic.
                     $aMapping['RNA'] = 'r.(=)';
                     $aMapping['protein'] = 'p.(=)';

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -475,6 +475,9 @@ class LOVD_VV
                     default:
                         // Unhandled flag. "processing_error" can still be
                         //  thrown, if all transcripts fail.
+                        // FIXME: I've seen "submission_warning" when submitting
+                        //  NC_000011.9:g.2018812_2024740|lom; it got split in
+                        //  two (see #206) and "lom" threw a submission_warning.
                         // FIXME: NC_000003.11:g.169482398_169482471del   fails.
                         // FIXME: NC_000007.13:g.50468071G>A throws one, and has
                         //  10 failing transcripts. I guess sometimes you can't
@@ -599,7 +602,17 @@ class LOVD_VV
             return $aData;
 
         } else {
-            // Failure.
+            // Failure. This happens when VV fails hard or if we can't find our
+            //  input back in the output. This happened with #206; |lom variants
+            //  are split into two variants; the location and "lom".
+            // Catch the methylation-related variants and provide some output.
+            if (strpos($sVariant, '|') !== false) {
+                // VV failed because of #206.
+                $aData = $this->aResponse;
+                $aData['errors']['ESYNTAX'] = 'Methylation variants are currently not supported.';
+                return $aData;
+            }
+
             return false;
         }
     }

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2020-06-11
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-16
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -82,6 +82,12 @@ function lovd_fixHGVS ($sVariant, $sType = 'g')
     // g.(1234_2345)del doesn't need those parentheses.
     if (preg_match('/^([gm])\.\((\d+_\d+)\)(con|del(?:ins)?|dup|inv|ins)(.*)/', $sVariant, $aRegs)) {
         return lovd_fixHGVS($aRegs[1] . '.' . $aRegs[2] . $aRegs[3] . $aRegs[4]);
+    }
+
+    // Too many prefixes due to copy/paste errors?
+    // g.12345_g.23456del to g.12345_23456del.
+    if (substr_count($sVariant, $sType . '.') > 1) {
+        return lovd_fixHGVS($sType . '.' . str_replace($sType . '.', '', $sVariant));
     }
 
     // Maybe positions are in wrong order?

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -565,7 +565,7 @@ class LOVD_VVAnalyses {
 
                                 // Compare the current protein value with the new protein prediction.
                                 if (str_replace('*', 'Ter', $aVOT['protein']) != $aVVVot['data']['protein']) {
-                                    if (in_array($aVOT['protein'], array('', 'p.?', 'p.fs', 'p.fs?', 'p.fs*', 'p.(fs)'))) {
+                                    if (in_array($aVOT['protein'], array('', 'p.?', 'p.fs', 'p.fs?', 'p.fs*', 'p.(fs)', 'p.(fs*)'))) {
                                         // Overwrite the protein field if it's different and not so interesting,
                                         //  we assume to have something better.
                                         $aUpdate['transcripts'][$sTranscript]['protein'] = $aVVVot['data']['protein'];
@@ -952,7 +952,7 @@ class LOVD_VVAnalyses {
 
                                 // Compare the current protein value with the new protein prediction.
                                 if (str_replace('*', 'Ter', $aVOT['protein']) != $aVVVot['data']['protein']) {
-                                    if (in_array($aVOT['protein'], array('', 'p.?', 'p.fs', 'p.fs?', 'p.fs*', 'p.(fs)'))) {
+                                    if (in_array($aVOT['protein'], array('', 'p.?', 'p.fs', 'p.fs?', 'p.fs*', 'p.(fs)', 'p.(fs*)'))) {
                                         // Overwrite the protein field if it's different and not so interesting,
                                         //  we assume to have something better.
                                         $aUpdate['transcripts'][$sTranscript]['protein'] = $aVVVot['data']['protein'];

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-09
- * Modified    : 2020-07-16
+ * Modified    : 2020-07-21
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -38,6 +38,7 @@
 // FIXME: The RNA and protein handling part (EREF vs standard), have increased
 //  to have quite some overlap; fix that?
 // FIXME: Memory usage never gets high, so just remove that code and that bar?
+// FIXME: Also check RNA and protein descriptions when the cDNA is OK!
 
 define('ROOT_PATH', '../');
 require ROOT_PATH . 'inc-init.php';
@@ -651,7 +652,8 @@ class LOVD_VVAnalyses {
                         || !$sTranscript
                         || $aVariant['vots'][$sTranscript]['DNA']
                         == $aVV['data']['transcript_mappings'][$sTranscript]['DNA']
-                        || substr($aVV['data']['transcript_mappings'][$sTranscript]['DNA'], -1) == '=') {
+                        || substr($aVV['data']['transcript_mappings'][$sTranscript]['DNA'], -1) == '='
+                        || strpos($aVV['data']['transcript_mappings'][$sTranscript]['DNA'], '>') !== false) {
                         // Match, or WT.
                         unset($aVV['warnings']['WGAP']);
                     }

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -862,9 +862,10 @@ class LOVD_VVAnalyses {
                         // We get lots of EMISMATCH/EREF errors because the VOT variant
                         //  is actually c.=, something Mutalyzer can't see.
                         foreach (array('DNA', 'RNA', 'protein') as $sField) {
-                            if (in_array($aVOT[$sField], array('', '-', 'c.?', 'r.?', 'p.?'))
-                                || ($bVKGL && $aVOT[$sField] != $aVV['data']['transcript_mappings'][$sTranscript][$sField])) {
-                                // The current field is pretty much bogus, just overwrite it.
+                            if ($aVOT[$sField] != $aVV['data']['transcript_mappings'][$sTranscript][$sField]
+                                && ($bVKGL || in_array($aVOT[$sField], array('', '-', 'c.?', 'r.?', 'p.?')))) {
+                                // Overwrite VOT data if this is a VKGL entry,
+                                //  or if the current field is pretty much bogus.
                                 if (!isset($aUpdate['transcripts'])) {
                                     $aUpdate['transcripts'] = array();
                                 }

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-09
- * Modified    : 2020-07-14
+ * Modified    : 2020-07-15
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -639,8 +639,14 @@ class LOVD_VVAnalyses {
                 if (isset($aVV['warnings']['WGAP'])) {
                     // Ignore WGAP warnings when the predicted cDNA is the same
                     //  as the current cDNA, or when the predicted cDNA is WT.
-                    $sTranscript = key($aVariant['vots']);
-                    if ($aVariant['vots'][$sTranscript]['DNA']
+                    $sTranscript = current(
+                        array_intersect(
+                            array_keys($aVariant['vots']),
+                            array_keys($aVV['data']['transcript_mappings'])
+                        )
+                    );
+                    if (!$sTranscript
+                        || $aVariant['vots'][$sTranscript]['DNA']
                         == $aVV['data']['transcript_mappings'][$sTranscript]['DNA']
                         || substr($aVV['data']['transcript_mappings'][$sTranscript]['DNA'], -1) == '=') {
                         // Match, or WT.

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -565,7 +565,7 @@ class LOVD_VVAnalyses {
 
                                 // Compare the current protein value with the new protein prediction.
                                 if (str_replace('*', 'Ter', $aVOT['protein']) != $aVVVot['data']['protein']) {
-                                    if (in_array($aVOT['protein'], array('', 'p.?', 'p.fs', 'p.fs?', 'p.fs*', 'p.(fs)', 'p.(fs*)'))) {
+                                    if (in_array($aVOT['protein'], array('', 'p.?', 'p.fs', 'p.fs?', 'p.fs*', 'p.fsX', 'p.(fs)', 'p.(fs*)'))) {
                                         // Overwrite the protein field if it's different and not so interesting,
                                         //  we assume to have something better.
                                         $aUpdate['transcripts'][$sTranscript]['protein'] = $aVVVot['data']['protein'];
@@ -955,7 +955,7 @@ class LOVD_VVAnalyses {
 
                                 // Compare the current protein value with the new protein prediction.
                                 if (str_replace('*', 'Ter', $aVOT['protein']) != $aVVVot['data']['protein']) {
-                                    if (in_array($aVOT['protein'], array('', 'p.?', 'p.fs', 'p.fs?', 'p.fs*', 'p.(fs)', 'p.(fs*)'))) {
+                                    if (in_array($aVOT['protein'], array('', 'p.?', 'p.fs', 'p.fs?', 'p.fs*', 'p.fsX', 'p.(fs)', 'p.(fs*)'))) {
                                         // Overwrite the protein field if it's different and not so interesting,
                                         //  we assume to have something better.
                                         $aUpdate['transcripts'][$sTranscript]['protein'] = $aVVVot['data']['protein'];

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-09
- * Modified    : 2020-06-25
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-14
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -366,7 +366,7 @@ class LOVD_VVAnalyses {
                     // If we do get a failure, just try again.
                     $aVV = false;
                     for ($i = 0; (!$aVV && $i < 5); $i ++) {
-                        sleep($i); // Sleep on second or later try.
+                        sleep($i*2); // Sleep on second or later try.
                         $aVV = $_VV->verifyGenomic($sVariant,
                             array(
                                 'map_to_transcripts' => true,

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -707,7 +707,7 @@ class LOVD_VVAnalyses {
 
                 // If we can, fill in or correct the hg38 prediction.
                 if ($this->bDNA38 && $aVV['data']['DNA38_clean']) {
-                    if (!$aVariant['DNA38']) {
+                    if (!$aVariant['DNA38'] || $aVariant['DNA38'] == 'g.?') {
                         // We didn't have a hg38 description yet. Just fill it in.
                         $aUpdate['DNA38'] = $aVV['data']['DNA38_clean'];
                     } elseif ($aVariant['DNA38'] != $aVV['data']['DNA38_clean']) {

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -643,6 +643,15 @@ class LOVD_VVAnalyses {
                         unset($aVV['warnings']['WGAP']);
                     }
                 }
+                if (isset($aVV['warnings']['WFLAG'])) {
+                    // Ignore WFLAG warnings for flag=processing_error, this
+                    //  happens whenever UTA suggests a transcript that VV
+                    //  cannot map to, which happens plenty.
+                    if (strpos($aVV['warnings']['WFLAG'], 'VV Flag not handled: processing_error.') === 0) {
+                        $aVariant['vots'] = array();
+                        unset($aVV['warnings']['WFLAG']);
+                    }
+                }
                 if ($aVV['warnings']) {
                     $this->panic($aVariant, array_merge_recursive($aVV,
                         array('data' => array('DNA_clean' => substr(strstr($aVV['data']['DNA'], ':'), 1)))),

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -639,13 +639,16 @@ class LOVD_VVAnalyses {
                 if (isset($aVV['warnings']['WGAP'])) {
                     // Ignore WGAP warnings when the predicted cDNA is the same
                     //  as the current cDNA, or when the predicted cDNA is WT.
+                    // Also, all VKGL variants will just be overwritten as we
+                    //  know they are detected on the genome.
                     $sTranscript = current(
                         array_intersect(
                             array_keys($aVariant['vots']),
                             array_keys($aVV['data']['transcript_mappings'])
                         )
                     );
-                    if (!$sTranscript
+                    if ($bVKGL
+                        || !$sTranscript
                         || $aVariant['vots'][$sTranscript]['DNA']
                         == $aVV['data']['transcript_mappings'][$sTranscript]['DNA']
                         || substr($aVV['data']['transcript_mappings'][$sTranscript]['DNA'], -1) == '=') {

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -199,7 +199,11 @@ class LOVD_VVAnalyses {
         );
         if ($this->bDNA38) {
             $aDiff[(!$aVariant['DNA38']? '(DNA38)' : $aVariant['DNA38'])] =
-                (!isset($aVV['data']['genome_mappings']['hg38']['DNA'])? '' : $aVV['data']['genome_mappings']['hg38']['DNA']);
+                (isset($aVV['data']['DNA38_clean'])? $aVV['data']['DNA38_clean'] :
+                    (!isset($aVV['data']['genomic_mappings']['hg38'])? '' :
+                        (count($aVV['data']['genomic_mappings']['hg38']) == 1?
+                            substr(strstr($aVV['data']['genomic_mappings']['hg38'][0], ':'), 1) :
+                            $aVV['data']['genomic_mappings']['hg38'])));
         }
         // Because of using array_merge_recursive() to merge $aVV and $aVVVOT,
         //  we may have ended up with arrays.


### PR DESCRIPTION
Improved the Variant Validation script.
- Increased the sleep on a failure with a factor two, which should reduce the number of failures.
- Added code that handles `WFLAG` warnings because of processing errors.
  - There's nothing we can do, continue so at least we'll have a hg38 mapping (hopefully).
- Fixed broken display of hg38 DNA prediction when panicking.
- Improved comparing transcript predictions when checking WGAP warnings.
  - Don't take LOVD's first transcript but take the first transcript both the LOVD record and the VV prediction have in common.
- Overwrite protein values also when LOVD record has `p.(fs*)` but we have something better.
- Overwrite LOVD's hg38 value if all it contains is `g.?`.
- Overwrite protein values also when LOVD record has `p.fsX` but we have something better.
- Fixed bug; DNA, RNA, and protein fields could be emptied by the variant validation script.
  - If we were updating a VOT's DNA, and the VOG also contained another VOT that VV didn't recognize, that VOT's information got removed. Every field that was updated, was emptied for that VOT.
  - Fixed this by rebuilding the `$_POST` for missing VOTs. It might be too complicated to fix this in the VOT's `updateAll()`, although that would probably be more correct. However, we don't have this problem elsewhere in LOVD.
- Simplified WGAP handling; overwrite everything for VKGL entries.
- Added support for methylation variants in `lovd_getVariantInfo()`.
- Catch VV failures when sending methylation variants.
  - VV currently doesn't handle methylation variants, see openvar/variantValidator/issues/206.
  - Catch errors when this happens, and provide a nice `ESYNTAX`.
- Fixed bug; Deep intronic variants weren't recognized well, and a `p.?` was predicted instead of a `p.(=)`.
- Added support for `g.12345_g.23456del` mistakes in `lovd_fixHGVS()`.
- Ignore `WGAP` warnings also when the VOT's prediction is a simple substitution.
- Prevent continuous overwrites without actually changing something.
  - Values like `r.?` and `p.?` were triggering updates, even though nothing would be changed.