### PR TITLE
Fixed link to Ensembl by removing the name we added to it.

### DIFF
--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2020-07-08
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-22
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -663,7 +663,9 @@ class LOVD_Gene extends LOVD_Object
                     $sURLEnsembl = 'http://www.ensembl.org/Homo_sapiens/Location/View?r=' . $zData['chromosome'] . ':' . ($zData['position_g_mrna_start'] - 50) . '-' . ($zData['position_g_mrna_end'] + 50) . ';contigviewbottom=url:';
                 }
                 // The weird addition in the end is to fake a proper name in Ensembl.
-                $sURLEnsembl .= $sURLBedFile . rawurlencode('&name=/' . $zData['id'] . ' variants');
+                // $sURLEnsembl .= $sURLBedFile . rawurlencode('&name=/' . $zData['id'] . ' variants');
+                // The name can not be configured anymore, anything I tried, failed.
+                $sURLEnsembl .= $sURLBedFile;
                 $zData['ensembl'] = 'Show variants in the Ensembl Genome Browser (<A href="' . $sURLEnsembl . '=labels" target="_blank">full view</A>, <A href="' . $sURLEnsembl . '=normal" target="_blank">compact view</A>)';
                 $zData['ncbi'] = 'Show distribution histogram of variants in the <A href="https://www.ncbi.nlm.nih.gov/projects/sviewer/?id=' . $_SETT['human_builds'][$_CONF['refseq_build']]['ncbi_sequences'][$zData['chromosome']] . '&amp;v=' . ($zData['position_g_mrna_start'] - 100) . ':' . ($zData['position_g_mrna_end'] + 100) . '&amp;content=7&amp;url=' . $sURLBedFile . '" target="_blank">NCBI Sequence Viewer</A>';
 


### PR DESCRIPTION
Fixed link to Ensembl by removing the name we added to it.
- The Ensembl genome browser ignores the BED track's name, and just puts "bed". The previous method we used to configure the name doesn't work anymore, it breaks the loading of the track. The documentation does not mention how to name your track, and anything that I've tried failed.

Closes #438.