### PR TITLE
Fixed the link to the NCBI sequence viewer.

### DIFF
--- a/src/class/api.php
+++ b/src/class/api.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2016-12-09
- * For LOVD    : 3.0-18
+ * Modified    : 2020-07-22
+ * For LOVD    : 3.0-25
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -154,8 +154,10 @@ class LOVD_API
             // This API also ignores the Accept header.
             $this->sFormatOutput = 'text/plain';
             // And, we only allow GET.
-            if (!GET) {
-                // Will only allow GET.
+            if (!GET && !HEAD) {
+                // Will only allow GET and HEAD.
+                // HEAD is necessary for the NCBI sequence viewer, which uses
+                //  HEAD to first check if the BED file is available.
                 // $this->aResponse['errors'][] = 'Method not allowed here.';
                 // $this->sendHeader(405, true); // Send 405 Method Not Allowed, print response, and quit.
                 // This API is LOVD2-style and shouldn't have their output changed now that we're more advanced.

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-07-13
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-22
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -847,6 +847,7 @@ if (!defined('NOT_INSTALLED')) {
     // Define constant for request method.
     define($_SERVER['REQUEST_METHOD'], true);
     @define('GET', false);
+    @define('HEAD', false);
     @define('POST', false);
     @define('PUT', false);
     @define('DELETE', false);


### PR DESCRIPTION
Fixed the link to the NCBI sequence viewer.
- It was doing a HEAD request to the BED file API before doing a GET, which wasn't supported by our API.
- Added support for HEAD requests to the LOVD2-style API, the NCBI sequence viewer loads the BED file OK.

Closes #439.