### PR TITLE
Fixed mapping to genome feature.

### DIFF
--- a/src/columns.php
+++ b/src/columns.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-03-04
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-07-23
+ * For LOVD    : 3.0-25
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -662,23 +662,23 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                     'options' =>
                          array(
                              array(
-                                    'onclick'     => 'javascript:$(\'#optionForm input\').attr(\'value\', \'Individual\'); $(\'#optionForm\').submit();',
+                                    'onclick'     => 'javascript:$(\'#optionForm input\').val(\'Individual\'); $(\'#optionForm\').submit();',
                                     'option_text' => '<B>Information on the individual, not related to disease</B>, not changing over time, such as date of birth',
                                   ),
                              array(
-                                    'onclick'     => 'javascript:$(\'#optionForm input\').attr(\'value\', \'Phenotype\'); $(\'#optionForm\').submit();',
+                                    'onclick'     => 'javascript:$(\'#optionForm input\').val(\'Phenotype\'); $(\'#optionForm\').submit();',
                                     'option_text' => '<B>Information on the phenotype, related to disease</B>, possibly changing over time, such as blood pressure',
                                   ),
                              array(
-                                    'onclick'     => 'javascript:$(\'#optionForm input\').attr(\'value\', \'Screening\'); $(\'#optionForm\').submit();',
+                                    'onclick'     => 'javascript:$(\'#optionForm input\').val(\'Screening\'); $(\'#optionForm\').submit();',
                                     'option_text' => '<B>Information on the detection of new variants</B>, such as detection technique or laboratory conditions',
                                   ),
                              array(
-                                    'onclick'     => 'javascript:$(\'#optionForm input\').attr(\'value\', \'VariantOnGenome\'); $(\'#optionForm\').submit();',
+                                    'onclick'     => 'javascript:$(\'#optionForm input\').val(\'VariantOnGenome\'); $(\'#optionForm\').submit();',
                                     'option_text' => '<B>Information on the variant(s) found, in general or on the genomic level</B>, such as restriction site change',
                                   ),
                              array(
-                                    'onclick'     => 'javascript:$(\'#optionForm input\').attr(\'value\', \'VariantOnTranscript\'); $(\'#optionForm\').submit();',
+                                    'onclick'     => 'javascript:$(\'#optionForm input\').val(\'VariantOnTranscript\'); $(\'#optionForm\').submit();',
                                     'option_text' => '<B>Information on the variant(s) found, specific for the transcript level</B>, such as predicted effect on protein level',
                                   ),
                               ),
@@ -1185,7 +1185,7 @@ if (PATH_COUNT > 2 && ACTION == 'edit') {
 <SCRIPT type="text/javascript">
 function lovd_checkSubmittedForm ()
 {
-    if ($('input[name="mysql_type"]').attr('value') != '<?php echo $zData['mysql_type'] ?>') {
+    if ($('input[name="mysql_type"]').val() != '<?php echo $zData['mysql_type'] ?>') {
         return window.confirm('<?php echo $sJSMessage ?>');
     }
 }

--- a/src/inc-js-variants.php
+++ b/src/inc-js-variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-11-08
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2020-07-23
+ * For LOVD    : 3.0-25
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -237,7 +237,7 @@ function lovd_convertPosition (oElement)
                                 var oInput = $('#variantForm input[id_ncbi="' + aVariant[1] + '"]');
                                 if (oInput[0] != undefined) {
                                     // If the transcript returned by mutalyzer is present in the form, fill in the respons from mutalyzer.
-                                    oInput.attr('value', aVariant[2]);
+                                    oInput.val(aVariant[2]);
                                     oInput.siblings('img:first').attr({
                                         src: 'gfx/check.png',
                                         alt: 'Valid HGVS syntax!',
@@ -253,7 +253,7 @@ function lovd_convertPosition (oElement)
                                         lovd_getProteinChange(oProtein);
                                     } else {
                                         // Transcript is disabled, empty the protein field.
-                                        oProtein.attr('value', '');
+                                        oProtein.val('');
                                     }
                                 }
                             }
@@ -266,7 +266,7 @@ function lovd_convertPosition (oElement)
                         var aVariant = /:([gm]\..+)$/.exec(sData);
                         if (aVariant != null) {
                             var oInput = $('#variantForm input[name="VariantOnGenome/DNA"]');
-                            oInput.attr('value', aVariant[1]);
+                            oInput.val(aVariant[1]);
                             oInput.siblings('img:first').attr({
                                 src: 'gfx/check.png',
                                 alt: 'Valid HGVS syntax!',
@@ -319,7 +319,7 @@ function lovd_getProteinChange (oElement)
     // Function that can predict a protein description of a variant based on a transcript DNA field.
 
     var oThisProtein = $(oElement).parent().find('input:first');
-    $(oThisProtein).attr('value', '');
+    $(oThisProtein).val('');
     $(oThisProtein).removeClass();
     $(oThisProtein).siblings('img:first').attr({
         src: 'gfx/lovd_loading.gif',
@@ -330,7 +330,7 @@ function lovd_getProteinChange (oElement)
     var nTranscriptID = $(oThisProtein).attr('name').substring(0, <?php echo $_SETT['objectid_length']['transcripts']; ?>);
     var oThisDNA = $(oElement).parent().parent().siblings().find('input[name="' + nTranscriptID + '_VariantOnTranscript/DNA"]');
     var oThisRNA = $(oElement).parent().parent().siblings().find('input[name="' + nTranscriptID + '_VariantOnTranscript/RNA"]');
-    $(oThisRNA).attr('value', '');
+    $(oThisRNA).val('');
     $(oThisRNA).removeClass();
 
     $.get('ajax/check_variant.php', { reference: aUDrefseqs[aTranscripts[nTranscriptID][1]],
@@ -447,8 +447,8 @@ function lovd_getProteinChange (oElement)
                             title: 'Prediction OK! Click to see result on Mutalyzer.'
                         }).show();
                     }
-                    $(oThisRNA).attr('value', aData['predict']['RNA']);
-                    $(oThisProtein).attr('value', aData['predict']['protein']);
+                    $(oThisRNA).val(aData['predict']['RNA']);
+                    $(oThisProtein).val(aData['predict']['protein']);
                     lovd_highlightInput(oThisRNA);
                     lovd_highlightInput(oThisProtein);
 

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2020-06-16
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-23
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -2708,7 +2708,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
           '          for (i in aTranscripts) {' . "\n" .
           '            var oDNA = $(\'input[name="\' + i + \'_VariantOnTranscript/DNA"]\');' . "\n" .
           '            var oProtein = $(\'input[name="\' + i + \'_VariantOnTranscript/Protein"]\');' . "\n" .
-          '            if ($(oDNA).attr("value") && !$(oProtein).attr("value")) {' . "\n" .
+          '            if ($(oDNA).val() && !$(oProtein).val()) {' . "\n" .
           '              $(oProtein).siblings(\'button:eq(0)\').show();' . "\n" .
           '            }' . "\n" .
           '          }' . "\n" .

--- a/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
+++ b/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-02-17
- * Modified    : 2020-05-27
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-23
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
@@ -437,6 +437,22 @@ abstract class LOVDSeleniumWebdriverBaseTestCase extends PHPUnit_Framework_TestC
                 sleep(1);
             }
         }
+    }
+
+
+
+
+
+    protected function waitForValueContains ($oElement, $sValue, $nTimeOut = WEBDRIVER_MAX_WAIT_DEFAULT)
+    {
+        // Convenience function to let the webdriver wait for a standard amount
+        //  of time for an expected value in the given element.
+        if (is_string($oElement)) {
+            $oElement = WebDriverBy::xpath('//input[@name="' . $oElement . '"]');
+        }
+
+        return $this->waitUntil(
+            WebDriverExpectedCondition::elementValueContains($oElement, $sValue), $nTimeOut);
     }
 
 

--- a/tests/selenium_tests/shared_tests/create_submission_individual_with_IVA.php
+++ b/tests/selenium_tests/shared_tests/create_submission_individual_with_IVA.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-15
- * Modified    : 2020-05-26
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-23
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -216,7 +216,7 @@ class CreateSubmissionIndividualWithIVATest extends LOVDSeleniumWebdriverBaseTes
         $this->driver->findElement(WebDriverBy::cssSelector('button.mapVariant'))->click();
 
         // Wait until RNA description field is filled after AJAX request, and check all values.
-        $this->waitForElement(WebDriverBy::xpath('//input[@name="00000001_VariantOnTranscript/RNA"][contains(@value, "r.")]'));
+        $this->waitForValueContains('00000001_VariantOnTranscript/RNA', 'r.');
         $this->assertValue('r.(=)', '00000001_VariantOnTranscript/RNA');
         $this->assertValue('p.(=)', '00000001_VariantOnTranscript/Protein');
         $this->selectValue('00000001_effect_reported', 'Does not affect function');

--- a/tests/selenium_tests/shared_tests/create_summary_variant_located_within_gene_with_multiple_transcripts.php
+++ b/tests/selenium_tests/shared_tests/create_summary_variant_located_within_gene_with_multiple_transcripts.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-02-17
- * Modified    : 2020-05-26
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-23
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -105,8 +105,7 @@ class CreateSummaryVariantLocatedWithinGeneWithMultipleTranscriptsTest extends L
         $this->driver->findElement(WebDriverBy::cssSelector('button.mapVariant'))->click();
 
         // Wait until RNA description field is filled after AJAX request, and check all values.
-        $this->waitForElement(WebDriverBy::xpath(
-            '//input[@name="00000002_VariantOnTranscript/RNA"][contains(@value, "r.")]'));
+        $this->waitForValueContains('00000002_VariantOnTranscript/RNA', 'r.');
         $this->assertValue('r.(?)', '00000002_VariantOnTranscript/RNA');
         $this->assertValue('p.(His367Leu)', '00000002_VariantOnTranscript/Protein');
         $this->selectValue('00000002_effect_reported', 'Effect unknown');
@@ -114,8 +113,7 @@ class CreateSummaryVariantLocatedWithinGeneWithMultipleTranscriptsTest extends L
 
         // Fill in XM_005274514.1 transcript (ID #00000003).
         $this->enterValue('00000003_VariantOnTranscript/Exon', '6i');
-        $this->waitForElement(WebDriverBy::xpath(
-            '//input[@name="00000003_VariantOnTranscript/RNA"][contains(@value, "r.")]'));
+        $this->waitForValueContains('00000003_VariantOnTranscript/RNA', 'r.');
         $this->assertValue('c.1001-715A>T', '00000003_VariantOnTranscript/DNA');
         $this->assertValue('r.(=)', '00000003_VariantOnTranscript/RNA');
         $this->assertValue('p.(=)', '00000003_VariantOnTranscript/Protein');

--- a/tests/selenium_tests/shared_tests/manage_transcripts_for_variant.php
+++ b/tests/selenium_tests/shared_tests/manage_transcripts_for_variant.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-19
- * Modified    : 2020-06-15
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-23
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -104,7 +104,7 @@ class ManageTranscriptsForVariantTest extends LOVDSeleniumWebdriverBaseTestCase
     {
         $this->waitUntil(WebDriverExpectedCondition::urlMatches('/\/src\/variants\/[0-9]+\?edit\#[0-9]+$/'));
         $this->driver->findElement(WebDriverBy::cssSelector('button.proteinChange'))->click();
-        $this->waitForElement(WebDriverBy::xpath('//input[contains(@name, "_VariantOnTranscript/RNA")][contains(@value, "r.")]'));
+        $this->waitForValueContains(WebDriverBy::xpath('//input[contains(@name, "_VariantOnTranscript/RNA")]'), 'r.');
         $this->enterValue('password', 'test1234');
         $this->submitForm('Edit variant entry');
 


### PR DESCRIPTION
Fixed mapping to genome feature, which wasn't working if the genomic DNA field was emptied.
- This was caused by jQuery no longer supporting `attr('value')` calls, but wanting `val()` calls instead.
- Replaced all `attr('value')` calls throughout LOVD with `val()` calls.

Closes #444.

#### Edit: This broke the tests, so:
- jQuery now uses `val()` to set fields instead of `attr("value")`, which means we can't use xpath anymore to wait for certain values.
  - Added `waitForValueContains()` convenience function to wait until a certain element's value contains the given string.
  - Replaced `waitForElement()` calls with xpaths based on the value with the new `waitForValueContains()` convenience function.