### PR TITLE
Improved the "forgot your password" feature.

### DIFF
--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-20
- * Modified    : 2020-07-10
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-27
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -101,7 +101,8 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
             // Update database.
             $_DB->query('UPDATE ' . TABLE_USERS . ' SET password_autogen = MD5(?) WHERE username = ?', array($sPasswd, $_POST['username']));
 
-            lovd_writeLog('Auth', LOG_EVENT, $_SERVER['REMOTE_ADDR'] . ' (' . lovd_php_gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') successfully reset password for account ' . $_POST['username']);
+            lovd_writeLog('Auth', LOG_EVENT, $_SERVER['REMOTE_ADDR'] . ' (' . lovd_php_gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') successfully reset password for account ' .
+                $_POST['username'] . ($_POST['username'] == $zData['username']? '' : ' (' . $zData['username'] . ')'));
 
             // Send email confirmation.
             $aTo = array(array($zData['name'], $zData['email']));

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -108,9 +108,15 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
             $aTo = array(array($zData['name'], $zData['email']));
 
             $sMessage = 'Dear ' . $zData['name'] . ',' . "\n\n" .
-                        'Your password from your LOVD account has been reset, as requested. Your new, randomly generated, password can be found below. Please log in to LOVD and choose a new password.' . "\n\n" .
-                        'Below is a copy of your updated account information.' . "\n\n" .
-                        'If you did not request a new password, you can disregard this message. Your old password will continue to function normally. However, you may then want to report this email to the Database administrator ' . $_SETT['admin']['name'] . ', email: ' . str_replace(array("\r\n", "\r", "\n"), ' or ', trim($_SETT['admin']['email'])) . ', who can investigate possible misuse of the system.' . "\n\n";
+                        'Your password from your LOVD account has been reset, as requested. ' .
+                        'Your username and your new, randomly generated, password can be found below. ' .
+                        'Please log in to LOVD and choose a new password.' . "\n\n" .
+                        'If you did not request a new password, you can disregard this message. ' .
+                        'Your old password will continue to function normally. ' .
+                        'However, you may then want to report this email to the Database administrator ' .
+                            $_SETT['admin']['name'] . ', email: ' . str_replace(array("\r\n", "\r", "\n"),
+                                ' or ', trim($_SETT['admin']['email'])) .
+                            ', who can investigate possible misuse of the system.' . "\n\n";
 
             // Add the location of the database, so that the user can just click the link.
             if ($_CONF['location_url']) {
@@ -121,9 +127,10 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
                          '    LOVD ' . $_SETT['system']['version'] . ' system at ' . $_CONF['institute'] . "\n\n";
 
             // Array containing the unlock code field.
-            $a['password_autogen'] = $sPasswd;
+            $zData['password_autogen'] = $sPasswd;
             $aMailFields = array(
-                            'a',
+                            'zData',
+                            'username' => 'Your username',
                             'password_autogen' => 'New password / unlocking code',
                            );
 


### PR DESCRIPTION
Improved the "forgot your password" feature:
- When resetting your password using an email address, mention the account's username in the log entry so we can still find these resets.
- Updated password reset email body, clarifying the text and adding the current username to the output.
- Closes #448.