### PR TITLE
Added feature to merge entries.

### DIFF
--- a/src/ajax/merge_entries.php
+++ b/src/ajax/merge_entries.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-07-28
- * Modified    : 2020-07-29
+ * Modified    : 2020-07-30
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -343,15 +343,13 @@ if (ACTION == 'process' && !empty($_GET['workid']) && POST) {
                 } else {
                     switch ($sObjectType) {
                         case 'individuals':
-                            // Move over phenotype entries and screenings.
+                            // Move over phenotype entries, screenings, parent links, and panel ID references.
                             $_DB->query('UPDATE ' . TABLE_PHENOTYPES . ' SET individualid = ? WHERE individualid = ?', array($nMergedID, $nObjectID));
                             $_DB->query('UPDATE ' . TABLE_SCREENINGS . ' SET individualid = ? WHERE individualid = ?', array($nMergedID, $nObjectID));
-                            // Delete IND2DIS entries, we already compared them.
-                            $_DB->query('DELETE FROM ' . TABLE_IND2DIS . ' WHERE individualid = ?', array($nObjectID));
-                            // Move parent or panel ID references.
                             $_DB->query('UPDATE ' . TABLE_INDIVIDUALS . ' SET fatherid = ? WHERE fatherid = ?', array($nMergedID, $nObjectID));
                             $_DB->query('UPDATE ' . TABLE_INDIVIDUALS . ' SET motherid = ? WHERE motherid = ?', array($nMergedID, $nObjectID));
                             $_DB->query('UPDATE ' . TABLE_INDIVIDUALS . ' SET panelid = ? WHERE panelid = ?', array($nMergedID, $nObjectID));
+                            // This also deletes the IND2DIS entries.
                             $_DB->query('DELETE FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($nObjectID));
                             lovd_writeLog('Event', LOG_EVENT, 'Merged ' . rtrim($sObjectType, 's') . ' entry #' . $nObjectID . ' into entry #' . $nMergedID);
                             break;
@@ -405,7 +403,7 @@ if (ACTION == 'process' && !empty($_GET['workid']) && POST) {
 
             $aConflictingFields = array_unique($aConflictingFields);
             print('
-            $("#merge_set_dialog").html("Entries can not be merged because of conflicting values in the following field(s):<BR>' .
+            $("#merge_set_dialog").html("Entries can not be merged because of conflicting values in the following field' . (count($aConflictingFields) == 1? '' : 's') . ':<BR>' .
                 '- ' . implode('<BR>- ', $aConflictingFields) . '<BR><BR>Resolve these conflicting values first, then try again.").dialog({buttons: oButtonClose});');
         }
     }

--- a/src/ajax/merge_entries.php
+++ b/src/ajax/merge_entries.php
@@ -328,6 +328,7 @@ if (ACTION == 'process' && !empty($_GET['workid']) && POST) {
                             $aUpdatedFields[] = $sCol;
                             break;
                         case 'diseaseids':
+                        case 'variants_found':
                             // We won't just update this; any difference
                             //  is regarded a conflict.
                             if ($aMergedData[$sCol] !== $zData[$sCol]) {
@@ -338,6 +339,22 @@ if (ACTION == 'process' && !empty($_GET['workid']) && POST) {
                             if ($aMergedData[$sCol] < $zData[$sCol]) {
                                 $aMergedData[$sCol] = $zData[$sCol];
                                 $aUpdatedFields[] = $sCol;
+                            }
+                            break;
+                        case 'Screening/Template':
+                        case 'Screening/Technique':
+                            // Merge these entries; we're not so strict here.
+                            if ($aMergedData[$sCol] != $zData[$sCol]) {
+                                $sMerged = implode(';',
+                                    // array_unique() also sorts the array.
+                                    array_unique(
+                                        array_merge(
+                                            explode(';', $aMergedData[$sCol]),
+                                            explode(';', $zData[$sCol]))));
+                                if ($aMergedData[$sCol] != $sMerged) {
+                                    $aMergedData[$sCol] = $sMerged;
+                                    $aUpdatedFields[] = $sCol;
+                                }
                             }
                             break;
                         default:

--- a/src/ajax/merge_entries.php
+++ b/src/ajax/merge_entries.php
@@ -1,0 +1,72 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2020-07-28
+ * Modified    : 2020-07-28
+ * For LOVD    : 3.0-25
+ *
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
+define('ROOT_PATH', '../');
+require ROOT_PATH . 'inc-init.php';
+header('Content-type: text/javascript; charset=UTF-8');
+
+// Check for basic format.
+if (!ACTION || !in_array(ACTION, array('fromVL'))) {
+    die('alert("Error while sending data.");');
+}
+
+// Require curator clearance (any gene).
+if (!lovd_isAuthorized('gene', $_AUTH['curates'])) {
+    // If not authorized, die with error message.
+    die('alert("Lost your session. Please log in again.");');
+}
+
+
+
+// If we get there, we want to show the dialog for sure.
+print('// Make sure we have and show the dialog.
+if (!$("#merge_set_dialog").length) {
+    $("body").append("<DIV id=\'merge_set_dialog\' title=\'Merge entries\'></DIV>");
+}
+if (!$("#merge_set_dialog").hasClass("ui-dialog-content") || !$("#merge_set_dialog").dialog("isOpen")) {
+    $("#merge_set_dialog").dialog({draggable:false,resizable:false,minWidth:600,show:"fade",closeOnEscape:true,hide:"fade",modal:true});
+}
+
+
+');
+
+
+// Set JS variables and objects.
+print('
+var oButtonClose  = {"Close":function () { $(this).dialog("close"); }};
+
+
+');
+
+// Allowed types.
+$aObjectTypes = array(
+    'individuals',
+);
+?>

--- a/src/ajax/merge_entries.php
+++ b/src/ajax/merge_entries.php
@@ -137,14 +137,14 @@ function lovd_showMergeDialog ($aJob)
 
 if (ACTION == 'fromVL' && GET && !empty($_GET['vlid'])) {
     // URL: /ajax/merge_entries.php?fromVL&vlid=Individuals
-    // Fetch object IDs, and call the curation process.
+    // Fetch object IDs, and call the merging process.
 
     if (!isset($_SESSION['viewlists'][$_GET['vlid']])) {
         die('$("#merge_set_dialog").html("Data listing not found. Please try to reload the page and try again.");');
     } elseif (empty($_SESSION['viewlists'][$_GET['vlid']]['options']['merge_set'])) {
-        die('$("#merge_set_dialog").html("Data listing does not allow curation of a set.");');
+        die('$("#merge_set_dialog").html("Data listing does not allow merging entries.");');
     } elseif (empty($_SESSION['viewlists'][$_GET['vlid']]['checked'])) {
-        die('$("#merge_set_dialog").html("No entries selected yet to curate.");');
+        die('$("#merge_set_dialog").html("No entries selected yet to merge.");');
     }
 
     // Determine type.
@@ -358,8 +358,12 @@ if (ACTION == 'process' && !empty($_GET['workid']) && POST) {
             $aConflictingFields = array_unique($aConflictingFields);
             print('
             $("#merge_set_dialog").html("Entries can not be merged because of conflicting values in the following field(s):<BR>' .
-                implode('<BR>', $aConflictingFields) . '<BR><BR>Resolve these conflicting values first, then try again.").dialog({buttons: oButtonClose});');
+                '- ' . implode('<BR>- ', $aConflictingFields) . '<BR><BR>Resolve these conflicting values first, then try again.").dialog({buttons: oButtonClose});');
         }
     }
+
+    // Clear the data.
+    unset($_SESSION['work'][CURRENT_PATH][$_GET['workid']]);
+    exit;
 }
 ?>

--- a/src/ajax/merge_entries.php
+++ b/src/ajax/merge_entries.php
@@ -69,4 +69,46 @@ var oButtonClose  = {"Close":function () { $(this).dialog("close"); }};
 $aObjectTypes = array(
     'individuals',
 );
+
+
+
+
+
+if (ACTION == 'fromVL' && GET && !empty($_GET['vlid'])) {
+    // URL: /ajax/merge_entries.php?fromVL&vlid=Individuals
+    // Fetch object IDs, and call the curation process.
+
+    if (!isset($_SESSION['viewlists'][$_GET['vlid']])) {
+        die('$("#merge_set_dialog").html("Data listing not found. Please try to reload the page and try again.");');
+    } elseif (empty($_SESSION['viewlists'][$_GET['vlid']]['options']['merge_set'])) {
+        die('$("#merge_set_dialog").html("Data listing does not allow curation of a set.");');
+    } elseif (empty($_SESSION['viewlists'][$_GET['vlid']]['checked'])) {
+        die('$("#merge_set_dialog").html("No entries selected yet to curate.");');
+    }
+
+    // Determine type.
+    $sObjectType = '';
+    if (!empty($_SESSION['viewlists'][$_GET['vlid']]['row_link'])) {
+        $sObjectType = substr($_SESSION['viewlists'][$_GET['vlid']]['row_link'], 0, strpos($_SESSION['viewlists'][$_GET['vlid']]['row_link'], '/'));
+    }
+    if (!in_array($sObjectType, $aObjectTypes)) {
+        die('
+        $("#merge_set_dialog").html("Did not recognize object type. This may be a bug in LOVD; please report.");');
+    }
+
+    $aValues = array_values($_SESSION['viewlists'][$_GET['vlid']]['checked']);
+    sort($aValues);
+    $aJob = array(
+        'objects' => array(
+            $sObjectType => $aValues,
+        ),
+        'post_action' => array(
+            'go_to' => lovd_getInstallURL() . $sObjectType . '/' . $aValues[0],
+        ),
+    );
+
+    // Open dialog, and list the data types.
+    lovd_showMergeDialog($aJob);
+    exit;
+}
 ?>

--- a/src/ajax/merge_entries.php
+++ b/src/ajax/merge_entries.php
@@ -164,6 +164,8 @@ if (ACTION == 'fromVL' && GET && !empty($_GET['vlid'])) {
             $sObjectType => $aValues,
         ),
         'post_action' => array(
+            'uncheck_VL' => $_GET['vlid'],
+            'reload_VL' => $_GET['vlid'],
             'go_to' => lovd_getInstallURL() . $sObjectType . '/' . $aValues[0],
         ),
     );
@@ -350,6 +352,37 @@ if (ACTION == 'process' && !empty($_GET['workid']) && POST) {
             // Update the display.
             print('
             $("#merge_set_dialog").html("Successfully merged entries!").dialog({buttons: oButtonClose});');
+
+            // Anything more that we're supposed to do?
+            if (!empty($aJob['post_action'])) {
+                foreach ($aJob['post_action'] as $sAction => $sArg) {
+                    switch ($sAction) {
+                        case 'go_to':
+                            // Redirect to another page.
+                            print('
+                            $("#merge_set_dialog").on("dialogclose", function(event, ui) { window.location.href = "' . $sArg . '"; });');
+                            break;
+                        case 'reload_page':
+                            // Reload the entire page.
+                            print('
+                            $("#merge_set_dialog").on("dialogclose", function(event, ui) { window.location.href = window.location; });');
+                            break;
+                        case 'reload_VL':
+                            // Reload the VL.
+                            print('
+                            lovd_AJAX_viewListSubmit("' . $sArg . '");');
+                            break;
+                        case 'uncheck_VL':
+                            // Deselect all checkboxes.
+                            print('
+                            check_list["' . $sArg . '"] = "none";');
+                            break;
+                        default:
+                            print('
+                            $("#merge_set_dialog").append("<BR>Unknown post action ' . htmlspecialchars($sAction) . '");');
+                    }
+                }
+            }
 
         } else {
             // Conflicts, can't merge entries.

--- a/src/ajax/merge_entries.php
+++ b/src/ajax/merge_entries.php
@@ -427,7 +427,7 @@ if (ACTION == 'process' && !empty($_GET['workid']) && POST) {
                 }
             }
 
-            if ($aMergedData['statusid'] >= STATUS_MARKED && $aGenes) {
+            if ($nMaxStatus >= STATUS_MARKED && $aGenes) {
                 lovd_setUpdatedDate($aGenes);
             }
             $_DB->commit();

--- a/src/ajax/merge_entries.php
+++ b/src/ajax/merge_entries.php
@@ -385,7 +385,7 @@ if (ACTION == 'process' && !empty($_GET['workid']) && POST) {
                             $aValues[] = $aMergedData[$sColumn];
                         }
                         $aValues[] = $nMergedID;
-                        $_DB->query('UPDATE ' . TABLE_INDIVIDUALS . ' SET ' . $sColumns . ' WHERE id = ?', $aValues);
+                        $_DB->query('UPDATE ' . constant('TABLE_' . strtoupper($sObjectType)) . ' SET ' . $sColumns . ' WHERE id = ?', $aValues);
                     }
 
                 } else {

--- a/src/ajax/merge_entries.php
+++ b/src/ajax/merge_entries.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-07-28
- * Modified    : 2020-07-28
+ * Modified    : 2020-07-29
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -278,6 +278,13 @@ if (ACTION == 'process' && !empty($_GET['workid']) && POST) {
                         case 'edited_date':
                             $aMergedData[$sCol] = date('Y-m-d H:i:s');
                             $aUpdatedFields[] = $sCol;
+                            break;
+                        case 'diseaseids':
+                            // We won't just update this; any difference
+                            //  is regarded a conflict.
+                            if ($aMergedData[$sCol] !== $zData[$sCol]) {
+                                $aConflictingFields[] = $sCol;
+                            }
                             break;
                         case 'statusid':
                             if ($aMergedData[$sCol] < $zData[$sCol]) {

--- a/src/class/object_logs.php
+++ b/src/class/object_logs.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-28
- * Modified    : 2020-03-09
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-30
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -136,6 +136,9 @@ class LOVD_Log extends LOVD_Object
             case 'CuratorSort':
                 $zData['entry'] = preg_replace('/the ([A-Z][A-Za-z0-9-]+) gene/', 'the <A href="genes/$1">$1</A> gene', $zData['entry']);
                 $zData['entry'] = preg_replace('/#([0-9]+)\s/', '#<A href="users/$1">$1</A> ', $zData['entry']);
+                break;
+            case 'MergeEntries':
+                $zData['entry'] = preg_replace('/(Merged (individual|screening) entry #(?:[0-9]+) into entry #)([0-9]+)$/', '$1<A href="${2}s/$3">$3</A>', $zData['entry']);
                 break;
             case 'GeneCreate':
             case 'GeneEdit':

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2020-03-10
- * For LOVD    : 3.0-24
+ * Modified    : 2020-07-28
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -2238,14 +2238,16 @@ class LOVD_Object
                 'only_rows' => false,           // Only put the table rows in the output.
                 'find_and_replace' => false,    // Allow find and replace on columns.
                 'multi_value_filter' => false,  // Allow multi valued search on columns.
-                'curate_set' => false,          // Allow "curate set" option.
+                'curate_set' => false,          // Allow "curate entries" option.
+                'merge_set' => false,           // Allow "merge entries" option.
             ),
             $aOptions);
 
-        // Disallow F&R, multivalue search, and Cuate Set option when options menu is hidden.
+        // Disallow options when options menu is hidden.
         $aOptions['find_and_replace'] &= $aOptions['show_options'];
         $aOptions['multi_value_filter'] &= $aOptions['show_options'];
         $aOptions['curate_set'] &= $aOptions['show_options'];
+        $aOptions['merge_set'] &= $aOptions['show_options'];
 
         // Save viewlist options to session.
         $_SESSION['viewlists'][$sViewListID]['options'] = array_merge(
@@ -3063,6 +3065,10 @@ OPMENU
                 if ($aOptions['curate_set']) {
                     print('        // Add menu option for curating a selected set.' . "\n" .
                           '        $("#viewlistMenu_' . $sViewListID . '").append(\'<LI class="icon"><A click="lovd_AJAX_viewListSubmit(\\\'' . $sViewListID . '\\\', function(){$.get(\\\'ajax/curate_set.php?fromVL&vlid=' . $sViewListID . '\\\').fail(function(){alert(\\\'Request failed. Please try again.\\\');});});"><SPAN class="icon"></SPAN>Curate (publish) selected entries</A></LI>\');' . "\n\n");
+                }
+                if ($aOptions['merge_set']) {
+                    print('        // Add menu option for merging a selected set of entries.' . "\n" .
+                          '        $("#viewlistMenu_' . $sViewListID . '").append(\'<LI class="icon"><A click="lovd_AJAX_viewListSubmit(\\\'' . $sViewListID . '\\\', function(){$.get(\\\'ajax/merge_entries.php?fromVL&vlid=' . $sViewListID . '\\\').fail(function(){alert(\\\'Request failed. Please try again.\\\');});});"><SPAN class="icon"></SPAN>Merge selected entries</A></LI>\');' . "\n\n");
                 }
 
                 if (!LOVD_plus

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2020-07-28
+ * Modified    : 2020-07-29
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -175,6 +175,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
             'track_history' => false,
             'show_navigation' => false,
             'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
+            'merge_set' => true,
         );
         // This ViewList ID is checked in ajax/viewlist.php. Don't just change it.
         $_DATA->viewList('Screenings_for_I_VE', $aScreeningVLOptions);
@@ -537,7 +538,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
             // FIXME: All of this doesn't look right. We should first check which genes are linked to the *public variants*, if we're deleting them OR if this Ind is public.
             //  Only then can you delete the variants when requested. Now it's the other way around, and the selection isn't done right.
             // Query text.
-            // This also deletes the entries in TABLE_PHENOTYPES && TABLE_SCREENINGS && TABLE_SCR2VAR && TABLE_SCR2GENES.
+            // This also deletes the entries in TABLE_PHENOTYPES && TABLE_SCREENINGS && TABLE_SCR2VAR && TABLE_SCR2GENE.
             $_DB->beginTransaction();
             if (isset($_POST['remove_variants']) && $_POST['remove_variants'] == 'remove') {
                 $aOutput = $_DB->query('SELECT id FROM ' . TABLE_SCREENINGS . ' WHERE individualid = ?', array($nID))->fetchAllColumn();

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -116,13 +116,21 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
             WHERE name = ? AND event = ? AND log LIKE ?',
                 array('Event', 'MergeEntries', 'Merged individual entry #' . $nID . ' into %'))->fetchColumn();
         if ($nNewID) {
-            header('Location: ' . lovd_getInstallURL() . $_PE[0] . '/' . $nNewID);
+            // HTTP 301 Moved Permanently.
+            header('Location: ' . lovd_getInstallURL() . $_PE[0] . '/' . $nNewID . '?&redirected_after_merge', true, 301);
             exit;
         }
     }
 
     $_T->printHeader();
     $_T->printTitle();
+
+    if (isset($_GET['redirected_after_merge'])) {
+        // We got redirected after using an ID that got merged into this entry.
+        lovd_showInfoTable(
+            'Please note that you got redirected after using an Individual ID that no longer exists,' .
+            ' because that entry got merged into this entry.', 'warning');
+    }
 
     // Load appropriate user level for this individual.
     lovd_isAuthorized('individual', $nID);

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2020-07-17
+ * Modified    : 2020-07-28
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -84,6 +84,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
         'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
         'find_and_replace' => true,
         'curate_set' => true,
+        'merge_set' => true,
     );
     $_DATA->viewList('Individuals', $aVLOptions);
 

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -882,7 +882,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
                 $_DB->query('DELETE FROM ' . TABLE_VARIANTS . ' WHERE id IN (?' . str_repeat(', ?', count($aVariantsRemovable) - 1) . ')', $aVariantsRemovable);
             }
 
-            // This also deletes the entries in TABLE_SCR2GENES and TABLE_SCR2VAR.
+            // This also deletes the entries in TABLE_SCR2GENE and TABLE_SCR2VAR.
             $_DATA->deleteEntry($nID);
 
             if ($aGenes) {


### PR DESCRIPTION
Added feature to merge entries (Individuals and Screenings, for now).
- Enabled the merge entries option for the Individuals VL and the Screenings VL on the Individual's VE.
- The script collects the selected IDs from the given VL, prepares an array with instructions, verifies with the user, and executes the merge.
- In case of conflicts, the merge is not processed and the conflicts are listed.
- Possible post action options are loading another page, reloading the current page, reloading a VL, or unchecking all checkboxes.
- After a merge of Individuals, uncheck all checkboxes, reload the VL, and redirect to the merged entry.
- After a merge of Screenings, uncheck all checkboxes and reload the VL.
- For Screenings, safely merge differences in Template and Technique.
- For Individuals, the log entry generated by the merge is used to redirect users who use the old ID.
  - When redirected to a merged entry, notify the user so they realize they've been redirected (HTTP 301 Moved Permanently).

Closes #450.