### PR TITLE
Small fixes.

### DIFF
--- a/src/announcements.php
+++ b/src/announcements.php
@@ -43,7 +43,7 @@ if ($_AUTH) {
 
 
 if (PATH_COUNT == 1 && !ACTION) {
-    // URL: /announcements
+    // URL: /announcements
     // View all entries.
 
     define('PAGE_TITLE', 'System announcements');
@@ -66,7 +66,7 @@ if (PATH_COUNT == 1 && !ACTION) {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /announcements/00001
+    // URL: /announcements/00001
     // View specific entry.
 
     $nID = sprintf('%05d', $_PE[1]);
@@ -98,7 +98,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
 
 
 if (PATH_COUNT == 1 && ACTION == 'create') {
-    // URL: /announcements?create
+    // URL: /announcements?create
     // URL: /announcements?register
     // Create a new announcement.
 
@@ -193,7 +193,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
-    // URL: /announcements/00001?edit
+    // URL: /announcements/00001?edit
     // Edit specific entry.
 
     $nID = sprintf('%05d', $_PE[1]);
@@ -286,7 +286,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
-    // URL: /announcements/00001?delete
+    // URL: /announcements/00001?delete
     // Delete a specific announcement.
 
     $nID = sprintf('%05d', $_PE[1]);

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1413,7 +1413,7 @@
    older than 3.0-beta-06 or newer.
  * Fixed bug; Wrong DBIDs were predicted because of a bug introduced in r221
    (3.0-beta-08) that should have prevented exactly that.
- * The 'Human-readable reference sequence location' field on the gene data entry
+ * The 'Human-readable reference sequence location' field on the gene data entry
    form now also allows local URLs.
  * Links to the reference sequences from the gene homepage are now opened in a
    new window.

--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2020-06-03
- * For LOVD    : 3.0-24
+ * Modified    : 2020-08-10
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1680,7 +1680,7 @@ class LOVD_API_Submissions
                 $sMessage .= (!$sMessage ? '' : ', ') . $n . ' ' . $sObject;
             }
         }
-        $sMessage = preg_replace('/, ([^,]+)/', " and $1", $sMessage);
+        $sMessage = preg_replace('/, ([^,]+)$/', ", and $1", $sMessage);
         lovd_writeLog('Event', 'API:SubmissionCreate', 'Created LOVD import file ' . $sFileName . ' using LOVD API v' . $this->API->nVersion . ' (' . $sMessage . ')', $this->zAuth['id']);
 
         $nBytes = filesize($_INI['paths']['data_files'] . '/' . $sFileName);

--- a/src/columns.php
+++ b/src/columns.php
@@ -43,8 +43,8 @@ if ($_AUTH) {
 
 
 if (PATH_COUNT < 3 && !ACTION) {
-    // URL: /columns
-    // URL: /columns/(VariantOnGenome|VariantOnTranscript|Individual|...)
+    // URL: /columns
+    // URL: /columns/(VariantOnGenome|VariantOnTranscript|Individual|...)
     // View all columns.
 
     if (!empty($_PE[1])) {
@@ -109,8 +109,8 @@ if (PATH_COUNT < 3 && !ACTION) {
 
 
 if (PATH_COUNT > 2 && !ACTION) {
-    // URL: /columns/VariantOnGenome/DNA
-    // URL: /columns/Phenotype/Blood_pressure/Systolic
+    // URL: /columns/VariantOnGenome/DNA
+    // URL: /columns/Phenotype/Blood_pressure/Systolic
     // View specific column.
 
     $aCol = $_PE;
@@ -152,7 +152,7 @@ if (PATH_COUNT > 2 && !ACTION) {
 
 
 if (PATH_COUNT == 2 && ACTION == 'order') {
-    // URL: /columns/Individual?order
+    // URL: /columns/Individual?order
     // Change in what order the columns will be shown in a viewList/viewEntry.
 
     $sCategory = $_PE[1];
@@ -252,7 +252,7 @@ if (PATH_COUNT == 2 && ACTION == 'order') {
 
 
 if (PATH_COUNT == 1 && ACTION == 'data_type_wizard') {
-    // URL: /columns?data_type_wizard
+    // URL: /columns?data_type_wizard
     // Show form type forms and send info back.
 
     define('TAB_SELECTED', 'setup');
@@ -640,7 +640,7 @@ if (PATH_COUNT == 1 && ACTION == 'data_type_wizard') {
 
 
 if (PATH_COUNT == 1 && ACTION == 'create') {
-    // URL: /columns?create
+    // URL: /columns?create
     // Create a new column.
 
     define('TAB_SELECTED', 'setup');
@@ -826,8 +826,8 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
 
 
 if (PATH_COUNT > 2 && ACTION == 'edit') {
-    // URL: /columns/VariantOnGenome/DNA?edit
-    // URL: /columns/Phenotype/Blood_pressure/Systolic?edit
+    // URL: /columns/VariantOnGenome/DNA?edit
+    // URL: /columns/Phenotype/Blood_pressure/Systolic?edit
     // Edit specific column.
 
     define('TAB_SELECTED', 'setup');
@@ -1369,8 +1369,8 @@ lovd_requireAUTH(LEVEL_MANAGER);
 
 
 if (PATH_COUNT > 2 && ACTION == 'add') {
-    // URL: /columns/VariantOnGenome/DNA?add
-    // URL: /columns/Phenotype/Blood_pressure/Systolic?add
+    // URL: /columns/VariantOnGenome/DNA?add
+    // URL: /columns/Phenotype/Blood_pressure/Systolic?add
     // Add specific column to the data table, and enable.
 
     $aCol = $_PE;
@@ -1748,8 +1748,8 @@ if (!isset($_GET['in_window'])) {
 
 
 if (PATH_COUNT > 2 && ACTION == 'remove') {
-    // URL: /columns/VariantOnGenome/DNA?remove
-    // URL: /columns/Phenotype/Blood_pressure/Systolic?remove
+    // URL: /columns/VariantOnGenome/DNA?remove
+    // URL: /columns/Phenotype/Blood_pressure/Systolic?remove
     // Disable specific custom column.
 
     $aCol = $_PE;
@@ -2093,8 +2093,8 @@ if (PATH_COUNT > 2 && ACTION == 'remove') {
 
 
 if (PATH_COUNT > 2 && ACTION == 'delete') {
-    // URL: /columns/VariantOnGenome/DNA?delete
-    // URL: /columns/Phenotype/Blood_pressure/Systolic?delete
+    // URL: /columns/VariantOnGenome/DNA?delete
+    // URL: /columns/Phenotype/Blood_pressure/Systolic?delete
     // Drop specific custom column.
 
     define('TAB_SELECTED', 'setup');

--- a/src/configuration.php
+++ b/src/configuration.php
@@ -60,10 +60,10 @@ if (ACTION) {
 
 
 
-// URL: /configuration
-// URL: /configuration/DMD
-// URL: /configuration/GENETHATDOESNOTEXIST
-// URL: /configuration/DMD/something_that_should_not_be_there
+// URL: /configuration
+// URL: /configuration/DMD
+// URL: /configuration/GENETHATDOESNOTEXIST
+// URL: /configuration/DMD/something_that_should_not_be_there
 // Force user to select different gene.
 
 // Only when the path is correct (gene given that exists or no gene given but we've got one in session) and authorization is OK, we don't block.
@@ -124,7 +124,7 @@ if (!(PATH_COUNT <= 2 && $_SESSION['currdb'] && lovd_isAuthorized('gene', $_SESS
 
 
 
-// URL: /configuration/DMD
+// URL: /configuration/DMD
 // View all gene-specific configuration options, like downloads, graphs, custom column settings, etc.
 
 $_T->printHeader();

--- a/src/diseases.php
+++ b/src/diseases.php
@@ -45,7 +45,7 @@ if ($_AUTH) {
 
 
 if (PATH_COUNT == 1 && !ACTION) {
-    // URL: /diseases
+    // URL: /diseases
     // View all entries.
 
     // Check if we are looking for diseases associated with the currently selected gene.
@@ -85,7 +85,7 @@ if (PATH_COUNT == 1 && !ACTION) {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /diseases/00001
+    // URL: /diseases/00001
     // View specific entry.
 
     $nID = sprintf('%05d', $_PE[1]);
@@ -151,7 +151,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
 
 
 if (PATH_COUNT == 2 && !ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /diseases/DMD
+    // URL: /diseases/DMD
     // Try to find a disease by its abbreviation and forward.
     // When we have multiple hits, refer to listView.
 
@@ -178,7 +178,7 @@ if (PATH_COUNT == 2 && !ctype_digit($_PE[1]) && !ACTION) {
 
 
 if (PATH_COUNT == 1 && ACTION == 'create') {
-    // URL: /diseases?create
+    // URL: /diseases?create
     // Create a new entry.
 
     define('PAGE_TITLE', 'Create a new disease information entry');
@@ -304,7 +304,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
-    // URL: /diseases/00001?edit
+    // URL: /diseases/00001?edit
     // Edit a specific entry.
 
     $nID = sprintf('%05d', $_PE[1]);
@@ -438,7 +438,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
-    // URL: /diseases/00001?delete
+    // URL: /diseases/00001?delete
     // Delete specific entry.
 
     $nID = sprintf('%05d', $_PE[1]);
@@ -567,7 +567,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
 
 
 if (PATH_COUNT == 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && !ACTION) {
-    // URL: /diseases/00001/columns
+    // URL: /diseases/00001/columns
     // View enabled columns for this disease.
 
     $nID = sprintf('%05d', $_PE[1]);
@@ -597,8 +597,8 @@ if (PATH_COUNT == 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && !ACTION) 
 
 
 if (PATH_COUNT > 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && !ACTION) {
-    // URL: /diseases/00001/columns/IQ
-    // URL: /diseases/00001/columns/Blood_pressure/Systolic
+    // URL: /diseases/00001/columns/IQ
+    // URL: /diseases/00001/columns/Blood_pressure/Systolic
     // View specific enabled column for this disease.
 
     $sUnit = 'disease';
@@ -637,8 +637,8 @@ if (PATH_COUNT > 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && !ACTION) {
 
 
 if (PATH_COUNT > 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && ACTION == 'edit') {
-    // URL: /diseases/00001/columns/IQ?edit
-    // URL: /diseases/00001/columns/Blood_pressure/Systolic?edit
+    // URL: /diseases/00001/columns/IQ?edit
+    // URL: /diseases/00001/columns/Blood_pressure/Systolic?edit
     // View specific enabled column for this disease.
 
     $sUnit = 'disease';
@@ -742,7 +742,7 @@ if (PATH_COUNT > 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && ACTION == 
 
 
 if (PATH_COUNT == 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && ACTION == 'order') {
-    // URL: /diseases/00001/columns?order
+    // URL: /diseases/00001/columns?order
     // Change order of enabled columns for this disease.
 
     $nID = sprintf('%05d', $_PE[1]);

--- a/src/docs/index.php
+++ b/src/docs/index.php
@@ -37,7 +37,7 @@ require ROOT_PATH . 'inc-init.php';
 
 
 if (PATH_COUNT == 1 && !ACTION) {
-    // URL: /docs
+    // URL: /docs
     // Provide link to PDF and HTML file.
 
     define('PAGE_TITLE', 'LOVD' . (LOVD_plus? '+' : ' 3.0') . ' documentation');

--- a/src/download.php
+++ b/src/download.php
@@ -110,7 +110,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
     // URL: /download/all/submission/00000001
     // URL: /download/all/user/00001
     // URL: /download/columns
-    // URL: /download/columns/(VariantOnGenome|VariantOnTranscript|Individual|...)
+    // URL: /download/columns/(VariantOnGenome|VariantOnTranscript|Individual|...)
     // URL: /download/diseases
     // URL: /download/genes
     // URL: /download/gene_panels/00001

--- a/src/genes.php
+++ b/src/genes.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2020-02-06
- * For LOVD    : 3.0-23
+ * Modified    : 2020-08-10
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -956,7 +956,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
                 foreach ($aDone as $sSection => $n) {
                     $sMessage .= (!$sMessage? '' : ', ') . $n . ' ' . $sSection;
                 }
-                $sMessage = 'deleted ' . preg_replace('/, ([^,]+)/', " and $1", $sMessage);
+                $sMessage = 'deleted ' . preg_replace('/, ([^,]+)$/', ", and $1", $sMessage);
             } else {
                 $sMessage = 'no data to delete';
             }

--- a/src/genes.php
+++ b/src/genes.php
@@ -135,7 +135,7 @@ function lovd_prepareCuratorLogMessage($sGeneID, $aCurators, $aAllowEdit, $aShow
 
 
 if (PATH_COUNT == 1 && !ACTION) {
-    // URL: /genes
+    // URL: /genes
     // View all entries.
 
     // Managers are allowed to download this list...
@@ -183,7 +183,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
 
 
 if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])) && !ACTION) {
-    // URL: /genes/DMD
+    // URL: /genes/DMD
     // View specific entry.
 
     $sID = rawurldecode($_PE[1]);
@@ -258,7 +258,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
 
 
 if (PATH_COUNT == 1 && ACTION == 'create') {
-    // URL: /genes?create
+    // URL: /genes?create
     // Create a new entry.
 
     define('PAGE_TITLE', 'Create a new gene information entry');
@@ -660,7 +660,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
 
 
 if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])) && ACTION == 'edit') {
-    // URL: /genes/DMD?edit
+    // URL: /genes/DMD?edit
     // Edit an entry.
 
     $sID = rawurldecode($_PE[1]);
@@ -844,7 +844,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
 
 
 if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])) && ACTION == 'empty') {
-    // URL: /genes/DMD?empty
+    // URL: /genes/DMD?empty
     // Empty the gene database (delete all variants and associated data).
 
     $sID = rawurldecode($_PE[1]);
@@ -1008,7 +1008,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
 
 
 if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])) && ACTION == 'delete') {
-    // URL: /genes/DMD?delete
+    // URL: /genes/DMD?delete
     // Drop specific entry.
 
     $sID = rawurldecode($_PE[1]);
@@ -1116,7 +1116,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
 
 
 if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])) && $_PE[2] == 'columns' && !ACTION) {
-    // URL: /genes/DMD/columns
+    // URL: /genes/DMD/columns
     // View enabled columns for this gene.
 
     $sID = rawurldecode($_PE[1]);
@@ -1146,8 +1146,8 @@ if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
 
 
 if (PATH_COUNT > 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])) && $_PE[2] == 'columns' && !ACTION) {
-    // URL: /genes/DMD/columns/DNA
-    // URL: /genes/DMD/columns/GVS/Function
+    // URL: /genes/DMD/columns/DNA
+    // URL: /genes/DMD/columns/GVS/Function
     // View specific enabled column for this gene.
 
     $sUnit = 'gene';
@@ -1186,8 +1186,8 @@ if (PATH_COUNT > 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])
 
 
 if (PATH_COUNT > 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])) && $_PE[2] == 'columns' && ACTION == 'edit') {
-    // URL: /genes/DMD/columns/DNA?edit
-    // URL: /genes/DMD/columns/GVS/Function?edit
+    // URL: /genes/DMD/columns/DNA?edit
+    // URL: /genes/DMD/columns/GVS/Function?edit
     // Edit specific enabled column for this gene.
 
     $sUnit = 'gene';
@@ -1291,7 +1291,7 @@ if (PATH_COUNT > 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])
 
 
 if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])) && $_PE[2] == 'columns' && ACTION == 'order') {
-    // URL: /genes/DMD/columns?order
+    // URL: /genes/DMD/columns?order
     // Change order of enabled columns for this gene.
 
     $sID = rawurldecode($_PE[1]);
@@ -1384,7 +1384,7 @@ if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
 
 
 if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])) && $_PE[2] == 'graphs' && !ACTION) {
-    // URL: /genes/DMD/graphs
+    // URL: /genes/DMD/graphs
     // Show different graphs about this gene; variant type (DNA, RNA & Protein level), ...
 
     $sID = rawurldecode($_PE[1]);
@@ -1504,7 +1504,7 @@ if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
 
 
 if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])) && in_array(ACTION, array('authorize', 'sortCurators'))) {
-    // URL: /genes/DMD?authorize
+    // URL: /genes/DMD?authorize
     // URL: /genes/DMD?sortCurators
     // Authorize users to be curators or collaborators for this gene, and/or define the order in which they're shown.
 

--- a/src/import.php
+++ b/src/import.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2020-05-28
- * For LOVD    : 3.0-24
+ * Modified    : 2020-08-10
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -2843,7 +2843,7 @@ if (!lovd_isCurator($_SESSION['currdb'])) {
                     foreach ($aDone as $sSection => $n) {
                         $sMessage .= (!$sMessage? '' : ', ') . $n . ' ' . $sSection;
                     }
-                    $sMessage = preg_replace('/, ([^,]+)/', " and $1", $sMessage);
+                    $sMessage = preg_replace('/, ([^,]+)$/', ", and $1", $sMessage);
                 } else {
                     $sMessage = 'new links only';
                 }

--- a/src/import.php
+++ b/src/import.php
@@ -45,7 +45,7 @@ if (LOVD_plus) {
 
 
 if (ACTION == 'schedule' && PATH_COUNT == 1) {
-    // URL: /import?schedule
+    // URL: /import?schedule
     // Schedule files for import.
     define('LOG_EVENT', 'ImportSchedule');
     define('PAGE_TITLE', 'Schedule files for import');
@@ -414,7 +414,7 @@ if (ACTION == 'schedule' && PATH_COUNT == 1) {
 
 
 if (ACTION == 'download_scheduled_file' && PATH_COUNT == 1 && !empty($_GET['file'])) {
-    // URL: /import?download_scheduled_file&file=LOVD_API_submission_00001_2017-11-01_13:47:02.955519.lovd
+    // URL: /import?download_scheduled_file&file=LOVD_API_submission_00001_2017-11-01_13:47:02.955519.lovd
     // Download files from data directory.
     // This code could go into download.php, but that's currently quite specific
     //  for LOVD data, generated out of the database.
@@ -450,7 +450,7 @@ if (ACTION == 'download_scheduled_file' && PATH_COUNT == 1 && !empty($_GET['file
 
 
 if (ACTION == 'autoupload_scheduled_file' && PATH_COUNT == 1) {
-    // URL: /import?autoupload_scheduled_file
+    // URL: /import?autoupload_scheduled_file
     // This URL forces FORMAT to be text/plain.
     // All unneeded output will be prevented.
     define('FORMAT_ALLOW_TEXTPLAIN', true); // To allow automatic data loading.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-08-10
+ * Modified    : 2020-08-11
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -806,7 +806,8 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
             array($sTranscriptID, $sTranscriptID))->fetchColumn();
         if (!$aTranscriptOffsets[$sTranscriptID]) {
             // Transcript not configured correctly.
-            return false;
+            // Don't die here; we might not even need these positions. We'll die later if we do.
+            $sTranscriptID = '';
         }
     } elseif ($sTranscriptID === false) {
         // If the transcript ID is passed as false, we are asked to ignore not having the transcript.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-07-16
+ * Modified    : 2020-08-10
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -817,7 +817,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
     // Isolate the position(s) from the variant. We don't support combined variants.
     // We're not super picky, and would therefore approve of c.1_2A>C; we also
     //  don't check for the end of the variant, it may contain bases, or not.
-    if (preg_match('/^([cgmn])\.(\()?([\-\*]?\d+)([-+](?:\d+|\?))?(?:_([\-\*]?\d+)([-+](?:\d+|\?))?)?([ACGT]>[ACGT]|con|del(?:ins)?|dup|inv|ins|\|(?:gom|lom|met=))(.*)(?(2)\))/', $sVariant, $aRegs)) {
+    if (preg_match('/^([cgmn])\.(\()?([\-\*]?\d+)([-+](?:\d+|\?))?(?:_([\-\*]?\d+)([-+](?:\d+|\?))?)?([ACGT]>[ACGT]|con|del(?:ins)?|dup|inv|ins|\|(?:gom|lom|met=)|=)(.*)(?(2)\))/', $sVariant, $aRegs)) {
         //             1 = Prefix; indicates what kind of positions we can expect, and what we'll output.
         //                       2 = Do we have an opening parenthesis?
         //                            3 = Start position, might be negative or in the 3' UTR.
@@ -837,8 +837,8 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
 
             if ($sSuffix) {
                 // Suffix not allowed in some cases.
-                if (strpos($sVariant, '>') !== false || $sVariant == 'inv' || substr($sVariant, 0, 1) == '|') {
-                    // No suffix allowed for substitutions or inversions.
+                if (strpos($sVariant, '>') !== false || $sVariant == 'inv' || substr($sVariant, 0, 1) == '|' || $sVariant == '=') {
+                    // No suffix allowed for substitutions, inversions, methylation or WT calls.
                     return false;
                 } elseif ($sVariant == 'con' && !preg_match('/^([NX][CMR]_[0-9]{6}\.[0-9]+:)?([0-9]+|[0-9]+[+-][0-9]+)_([0-9]+|[0-9]+[+-][0-9]+)$/', $sSuffix)) {
                     // Gene conversions require position fields.

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -44,8 +44,8 @@ if ($_AUTH) {
 
 
 if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) {
-    // URL: /individuals
-    // URL: /individuals/DMD
+    // URL: /individuals
+    // URL: /individuals/DMD
     // View all entries.
 
     if (!empty($_PE[1])) {
@@ -97,7 +97,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /individuals/00000001
+    // URL: /individuals/00000001
     // View specific entry.
 
     $nID = sprintf('%08d', $_PE[1]);
@@ -230,7 +230,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
 
 
 if (PATH_COUNT == 1 && ACTION == 'create') {
-    // URL: /individuals?create
+    // URL: /individuals?create
     // Create a new entry.
 
     define('PAGE_TITLE', 'Create a new individual information entry');
@@ -344,8 +344,8 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'publish'))) {
-    // URL: /individuals/00000001?edit
-    // URL: /individuals/00000001?publish
+    // URL: /individuals/00000001?edit
+    // URL: /individuals/00000001?publish
     // Edit an entry.
 
     $nID = sprintf('%08d', $_PE[1]);
@@ -532,7 +532,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
-    // URL: /individuals/00000001?delete
+    // URL: /individuals/00000001?delete
     // Drop specific entry.
 
     $nID = sprintf('%08d', $_PE[1]);

--- a/src/links.php
+++ b/src/links.php
@@ -44,7 +44,7 @@ if ($_AUTH) {
 
 
 if (PATH_COUNT == 1 && !ACTION) {
-    // URL: /links
+    // URL: /links
     // View all entries.
 
     define('PAGE_TITLE', 'Custom links');
@@ -67,7 +67,7 @@ if (PATH_COUNT == 1 && !ACTION) {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /links/001
+    // URL: /links/001
     // View specific entry.
 
     $nID = sprintf('%03d', $_PE[1]);
@@ -98,7 +98,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
 
 
 if (PATH_COUNT == 1 && ACTION == 'create') {
-    // URL: /links?create
+    // URL: /links?create
     // Create a new entry.
 
     define('PAGE_TITLE', 'Create a new custom link');
@@ -206,7 +206,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
-    // URL: /links/001?edit
+    // URL: /links/001?edit
     // Edit specific entry.
 
     $nID = sprintf('%03d', $_PE[1]);
@@ -339,7 +339,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
-    // URL: /links/001?delete
+    // URL: /links/001?delete
     // Delete specific entry.
 
     $nID = sprintf('%03d', $_PE[1]);

--- a/src/logs.php
+++ b/src/logs.php
@@ -39,7 +39,7 @@ if ($_AUTH) {
     require ROOT_PATH . 'inc-upgrade.php';
 }
 
-// URL: /logs
+// URL: /logs
 // View all log entries.
 
 define('PAGE_TITLE', 'System log entries');

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -44,7 +44,7 @@ if ($_AUTH) {
 
 
 if (PATH_COUNT == 1 && !ACTION) {
-    // URL: /phenotypes
+    // URL: /phenotypes
     // Not supported, forward user to disease-specific overview.
     header('Location: ' . lovd_getInstallURL() . $_PE[0] . '/disease?search_phenotypes=' . urlencode('!0'));
     exit;
@@ -55,7 +55,7 @@ if (PATH_COUNT == 1 && !ACTION) {
 
 
 if (PATH_COUNT == 2 && $_PE[1] == 'disease' && !ACTION) {
-    // URL: /phenotypes/disease
+    // URL: /phenotypes/disease
     // Present users the list of diseases to choose from, to view the phenotype entries for this disease.
 
     define('PAGE_TITLE', 'Select a disease to view all phenotype entries');
@@ -77,7 +77,7 @@ if (PATH_COUNT == 2 && $_PE[1] == 'disease' && !ACTION) {
 
 
 if (PATH_COUNT == 3 && $_PE[1] == 'disease' && ctype_digit($_PE[2]) && !ACTION) {
-    // URL: /phenotypes/disease/00001
+    // URL: /phenotypes/disease/00001
     // View all phenotype entries for a certain disease.
 
     $nDiseaseID = sprintf('%05d', $_PE[2]);
@@ -107,7 +107,7 @@ if (PATH_COUNT == 3 && $_PE[1] == 'disease' && ctype_digit($_PE[2]) && !ACTION) 
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /phenotypes/0000000001
+    // URL: /phenotypes/0000000001
     // View specific entry.
 
     $nID = sprintf('%010d', $_PE[1]);
@@ -147,7 +147,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
 
 
 if (PATH_COUNT == 1 && ACTION == 'create' && !empty($_GET['target']) && ctype_digit($_GET['target'])) {
-    // URL: /phenotypes?create&target=00000001
+    // URL: /phenotypes?create&target=00000001
     // Create a new entry.
 
     // FIXME; ik vind nog steeds dat vooral het begin van deze code nog enigszins rommelig is.
@@ -356,8 +356,8 @@ if (PATH_COUNT == 1 && ACTION == 'create' && !empty($_GET['target']) && ctype_di
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'publish'))) {
-    // URL: /phenotypes/0000000001?edit
-    // URL: /phenotypes/0000000001?publish
+    // URL: /phenotypes/0000000001?edit
+    // URL: /phenotypes/0000000001?publish
     // Edit an entry.
 
     $nID = sprintf('%010d', $_PE[1]);
@@ -504,7 +504,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
-    // URL: /phenotypes/0000000001?delete
+    // URL: /phenotypes/0000000001?delete
     // Drop specific entry.
 
     $nID = sprintf('%010d', $_PE[1]);

--- a/src/references.php
+++ b/src/references.php
@@ -53,8 +53,8 @@ $sReference = implode('/', array_slice($aPathElements, 1));
 
 
 if (!ACTION && (!$sReference || strpos($sReference, ':') === false)) {
-    // URL: /references
-    // URL: /references/DMD
+    // URL: /references
+    // URL: /references/DMD
     // View all entries (optionally restricted by gene).
 
     // STUB.
@@ -66,10 +66,10 @@ if (!ACTION && (!$sReference || strpos($sReference, ':') === false)) {
 
 
 if (PATH_COUNT >= 2 && (substr($sReference, 0, 4) == 'DOI:' || substr($sReference, 0, 5) == 'PMID:')) {
-    // URL: /references/DOI:.....
-    // URL: /references/DOI:...../image
-    // URL: /references/PMID:.....
-    // URL: /references/PMID:...../image
+    // URL: /references/DOI:.....
+    // URL: /references/DOI:...../image
+    // URL: /references/PMID:.....
+    // URL: /references/PMID:...../image
     // View specific DOI or PMID.
 
     if (substr($sReference, 0, 4) == 'DOI:') {

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -44,8 +44,8 @@ if ($_AUTH) {
 
 
 if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) {
-    // URL: /screenings
-    // URL: /screenings/DMD
+    // URL: /screenings
+    // URL: /screenings/DMD
     // View all entries.
 
     if (!empty($_PE[1])) {
@@ -92,7 +92,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /screenings/0000000001
+    // URL: /screenings/0000000001
     // View specific entry.
 
     $nID = sprintf('%010d', $_PE[1]);
@@ -158,7 +158,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
 
 
 if (PATH_COUNT == 1 && ACTION == 'create' && isset($_GET['target']) && ctype_digit($_GET['target'])) {
-    // URL: /screenings?create
+    // URL: /screenings?create
     // Create a new entry.
 
     define('LOG_EVENT', 'ScreeningCreate');
@@ -315,7 +315,7 @@ if (PATH_COUNT == 1 && ACTION == 'create' && isset($_GET['target']) && ctype_dig
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
-    // URL: /screenings/0000000001?edit
+    // URL: /screenings/0000000001?edit
     // Edit an entry.
 
     $nID = sprintf('%010d', $_PE[1]);
@@ -495,7 +495,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
-    // URL: /screenings/0000000001?confirmVariants
+    // URL: /screenings/0000000001?confirmVariants
     // Confirm existing variant entries within the same individual.
 
     $nID = sprintf('%010d', $_PE[1]);
@@ -667,7 +667,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'removeVariants') {
-    // URL: /screenings/0000000001?removeVariants
+    // URL: /screenings/0000000001?removeVariants
     // Remove variants from a screening entry.
 
     $nID = sprintf('%010d', $_PE[1]);
@@ -828,7 +828,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'removeVariants') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
-    // URL: /screenings/0000000001?delete
+    // URL: /screenings/0000000001?delete
     // Drop specific entry.
 
     $nID = sprintf('%010d', $_PE[1]);

--- a/src/settings.php
+++ b/src/settings.php
@@ -45,7 +45,7 @@ lovd_requireAUTH(LEVEL_MANAGER);
 
 
 if (PATH_COUNT == 1 && ACTION == 'edit') {
-    // URL: /settings?edit
+    // URL: /settings?edit
     // Edit system settings.
 
     define('PAGE_TITLE', 'Edit system settings');

--- a/src/submit.php
+++ b/src/submit.php
@@ -81,7 +81,7 @@ function lovd_prepareSubmitData ($sDataType, $aData) {
 
 
 if (PATH_COUNT == 1 && !ACTION) {
-    // URL: /submit
+    // URL: /submit
     // Submission process
 
     // 2012-07-10; 3.0-beta-07; Submitters are no longer allowed to add variants without individual data.

--- a/src/transcripts.php
+++ b/src/transcripts.php
@@ -44,8 +44,8 @@ if ($_AUTH) {
 
 
 if (!ACTION && (empty($_PE[1]) || preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1])))) {
-    // URL: /transcripts
-    // URL: /transcripts/DMD
+    // URL: /transcripts
+    // URL: /transcripts/DMD
     // View all entries.
 
     if (empty($_PE[1])) {
@@ -83,7 +83,7 @@ if (!ACTION && (empty($_PE[1]) || preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldec
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /transcripts/00001
+    // URL: /transcripts/00001
     // View specific entry.
 
     $nID = sprintf('%08d', $_PE[1]);
@@ -126,7 +126,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
 
 
 if (PATH_COUNT == 2 && !ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /transcripts/NM_004006.2
+    // URL: /transcripts/NM_004006.2
     // Try to find a transcripts by its NCBI ID and forward.
     // When we have multiple hits, refer to listView.
 
@@ -535,7 +535,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
-    // URL: /transcripts/00001?delete
+    // URL: /transcripts/00001?delete
     // Drop specific entry.
 
     $nID = sprintf('%08d', $_PE[1]);

--- a/src/users.php
+++ b/src/users.php
@@ -45,7 +45,7 @@ if ($_AUTH) {
 
 
 if (PATH_COUNT == 1 && !ACTION) {
-    // URL: /users
+    // URL: /users
     // View all entries.
 
     // Managers are allowed to download this list...
@@ -74,7 +74,7 @@ if (PATH_COUNT == 1 && !ACTION) {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /users/00001
+    // URL: /users/00001
     // View specific entry.
 
     $nID = sprintf('%05d', $_PE[1]);
@@ -166,7 +166,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
 
 
 if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
-    // URL: /users?create
+    // URL: /users?create
     // URL: /users?register
     // Create a new user, or self-register a new submitter.
 
@@ -665,7 +665,7 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
-    // URL: /users/00001?edit
+    // URL: /users/00001?edit
     // Edit specific entry.
 
     $nID = sprintf('%05d', $_PE[1]);
@@ -782,7 +782,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'change_password') {
-    // URL: /users/00001?change_password
+    // URL: /users/00001?change_password
     // Change a user's password.
 
     $nID = sprintf('%05d', $_PE[1]);
@@ -881,7 +881,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'change_password') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
-    // URL: /users/00001?delete
+    // URL: /users/00001?delete
     // Delete a specific user.
 
     $nID = sprintf('%05d', $_PE[1]);

--- a/src/variants.php
+++ b/src/variants.php
@@ -107,8 +107,8 @@ if (!ACTION && !empty($_GET['select_db'])) {
 
 if (!ACTION && (empty($_PE[1]) ||
         preg_match('/^(chr[0-9A-Z]{1,2})(?::([0-9]+)-([0-9]+))?$/', $_PE[1], $aRegionArgs))) {
-    // URL: /variants
-    // URL: /variants/chrX
+    // URL: /variants
+    // URL: /variants/chrX
     // URL: /variants/chr3:20-200000
     // View all genomic variant entries, optionally restricted by chromosome.
 
@@ -191,7 +191,7 @@ if (PATH_COUNT == 2 && $_PE[1] == 'in_gene' && !ACTION) {
 
 
 if (PATH_COUNT == 3 && $_PE[1] == 'upload' && ctype_digit($_PE[2]) && !ACTION) {
-    // URL: /variants/upload/123451234567890
+    // URL: /variants/upload/123451234567890
     // View all genomic variant entries that were submitted in the given upload.
 
     $nID = sprintf('%015d', $_PE[2]);
@@ -354,7 +354,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
-    // URL: /variants/0000000001
+    // URL: /variants/0000000001
     // View specific entry.
 
     $nID = sprintf('%010d', $_PE[1]);
@@ -640,7 +640,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
     define('LOG_EVENT', 'VariantCreate');
 
     if (!isset($_GET['reference'])) {
-        // URL: /variants?create
+        // URL: /variants?create
         // Select whether you want to create a variant on the genome or on a transcript.
         define('PAGE_TITLE', 'Create a new variant entry');
         $_T->printHeader();
@@ -980,7 +980,7 @@ if (PATH_COUNT == 2 && $_PE[1] == 'upload' && ACTION == 'create') {
     // We already called lovd_requireAUTH(LEVEL_MANAGER).
 
     if (!isset($_GET['type'])) {
-        // URL: /variants/upload?create
+        // URL: /variants/upload?create
         // Select whether you want to upload a VCF or SeattleSeq file.
 
         define('PAGE_TITLE', 'Upload variant data');
@@ -2383,8 +2383,8 @@ if (PATH_COUNT == 2 && $_PE[1] == 'upload' && ACTION == 'create') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'publish')) && !LOVD_plus) {
-    // URL: /variants/0000000001?edit
-    // URL: /variants/0000000001?publish
+    // URL: /variants/0000000001?edit
+    // URL: /variants/0000000001?publish
     // Edit an entry.
 
     $nID = sprintf('%010d', $_PE[1]);
@@ -2724,7 +2724,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
-    // URL: /variants/0000000001?delete
+    // URL: /variants/0000000001?delete
     // Drop specific entry.
 
     $nID = sprintf('%010d', $_PE[1]);
@@ -2817,7 +2817,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'search_global') {
-    // URL: /variants/0000000001?search_global
+    // URL: /variants/0000000001?search_global
     // Search an entry in other public LOVDs.
 
     $nID = sprintf('%010d', $_PE[1]);
@@ -2896,8 +2896,8 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'search_global') {
 
 
 if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('delete_non-preferred_transcripts', 'map'))) {
-    // URL: /variants/0000000001?delete_non-preferred_transcripts
-    // URL: /variants/0000000001?map
+    // URL: /variants/0000000001?delete_non-preferred_transcripts
+    // URL: /variants/0000000001?map
     // Map a variant to additional transcripts, or remove transcripts from the variant.
 
     $nID = sprintf('%010d', $_PE[1]);


### PR DESCRIPTION
Small fixes.
- Fixed bug; Replacement of "A, B, C" to "A, B and C" was done badly.
  - The replacement wasn't done because of an error in the regexp, but also the grammar was bad. The result should be "A, B, and C".
- Replaced non-breaking spaces everywhere in the source code with normal spaces.
- Allow for `lovd_getVariantInfo()` to recognize WT calls.
- When passing a badly configured transcript to `lovd_getVariantInfo()`, don't always die.
  - We might not even need the positions from the database. Die only when we do.
  - This allows using badly configured transcripts for variants in the 5' UTR and the CDS.