### PR TITLE
Fixed lovd_fetchDBID() function.

### DIFF
--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -460,11 +460,15 @@ function lovd_fetchDBID ($aData)
                 if ($sDBIDoptionSymbol == $sDBIDnewSymbol && $sDBIDoptionNumber < $sDBIDnewNumber && $sDBIDoptionNumber != '000000') {
                     // If the symbol of the option is the same, but the number is lower (not including 000000), take it.
                     $sDBID = $sDBIDoption;
-                } elseif ($sDBIDoptionSymbol != $sDBIDnewSymbol && isset($aGenes) && in_array($sDBIDoptionSymbol, $aGenes)) {
-                    // If the symbol of the option is different and is one of the genes of the variant you are editing/creating, take it.
-                    $sDBID = $sDBIDoption;
                 } elseif (substr($sDBIDnewSymbol, 0, 3) == 'chr' && substr($sDBIDoptionSymbol, 0, 3) != 'chr') {
                     // If the symbol of the option is not a chromosome, but the current DBID is, take it.
+                    $sDBID = $sDBIDoption;
+                } elseif ($sDBIDoptionSymbol != $sDBIDnewSymbol && isset($aGenes) && in_array($sDBIDoptionSymbol, $aGenes)
+                    && (!in_array($sDBIDnewSymbol, $aGenes)
+                        || ($sDBIDoptionNumber != '000000' && $sDBIDnewNumber == '000000')
+                        || $sDBIDoptionNumber < $sDBIDnewNumber)) {
+                    // If the symbol of the option is different and is one of the genes of the variant you are editing/creating, take it.
+                    // (but only if the currently selected DBID is *not* in the gene list or if we can pick a non 000000 ID, or if the option's number is lower)
                     $sDBID = $sDBIDoption;
                 }
             }

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -392,6 +392,7 @@ function lovd_fetchDBID ($aData)
     if (!isset($aData['aTranscripts'])) {
         $aData['aTranscripts'] = array();
     }
+    $aGenes = array();
     $aTranscriptVariants = array();
     foreach ($aData['aTranscripts'] as $nTranscriptID => $aTranscript) {
         // Check for non-empty VariantOnTranscript/DNA fields.
@@ -447,7 +448,9 @@ function lovd_fetchDBID ($aData)
         foreach($aDBIDOptions as $sDBIDoption) {
             // Loop through all the options returned from the database and decide which option to take.
             preg_match('/^((.+)_(\d{6}))$/', $sDBID, $aMatches);
-            list($sDBIDnew, $sDBIDnewSymbol, $sDBIDnewNumber) = array($aMatches[1], $aMatches[2], $aMatches[3]);
+            //              2 = chr## or gene
+            //                   3 = the actual ID.
+            list($sDBIDnewSymbol, $sDBIDnewNumber) = array($aMatches[2], $aMatches[3]);
 
             if (preg_match('/^(.+)_(\d{6})$/', $sDBIDoption, $aMatches)) {
                 list($sDBIDoption, $sDBIDoptionSymbol, $sDBIDoptionNumber) = $aMatches;


### PR DESCRIPTION
Fixed the lovd_fetchDBID() function. It was, under some circumstances, generating DBIDs that are already in use.

- Fixed bug; The optimization to check for existing DBIDs only in the same gene causes problems when relevant variants are no longer connected to the gene in question.
  - The speedup is now done on the chromosome field.
- Optimize the DBID gene selection; it was always switching genes when going through the options.
  - Now it only does that when the numeric ID is lower.
- Some more optimizations in `lovd_fetchDBID()`.

Close #460.