### PR TITLE
Improved the submission API to allow direct processing of variant-only submissions.

### DIFF
--- a/src/ajax/api_settings.php
+++ b/src/ajax/api_settings.php
@@ -1,0 +1,170 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2020-09-22
+ * Modified    : 2020-09-22
+ * For LOVD    : 3.0-25
+ *
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
+define('ROOT_PATH', '../');
+require ROOT_PATH . 'inc-init.php';
+header('Content-type: text/javascript; charset=UTF-8');
+
+// Check for basic format.
+if (PATH_COUNT != 3 || !ctype_digit($_PE[2]) || !in_array(ACTION, array('edit'))) {
+    die('alert("Error while sending data.");');
+}
+
+// Require manager clearance AND authorization on this user (manager or admin).
+if (!$_AUTH || $_AUTH['level'] < LEVEL_MANAGER || !lovd_isAuthorized('user', $_PE[2])) {
+    // If not authorized, die with error message.
+    die('alert("Lost your session. Please log in again.");');
+}
+
+// Let's download the user's data.
+$nID = sprintf('%0' . $_SETT['objectid_length']['users'] . 'd', $_PE[2]);
+$zUser = $_DB->query('SELECT id, username, api_settings FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchAssoc();
+$zUser['api_settings'] = @json_decode($zUser['api_settings'], true);
+
+if (!$zUser) {
+    // FIXME: Should we log this?
+    die('alert("Data not found.");');
+}
+
+// If we get there, we want to show the dialog for sure.
+print('// Make sure we have and show the dialog.
+if (!$("#api_settings_dialog").length) {
+    $("body").append("<DIV id=\'api_settings_dialog\' title=\'API settings for ' . $zUser['username'] . '\'></DIV>");
+}
+if (!$("#api_settings_dialog").hasClass("ui-dialog-content") || !$("#api_settings_dialog").dialog("isOpen")) {
+    $("#api_settings_dialog").dialog({draggable:false,resizable:false,minWidth:600,show:"fade",closeOnEscape:true,hide:"fade",modal:true});
+}
+
+function lovd_reloadUserVE ()
+{
+    // Reloads the VE if we\'ve changed the token info.
+    $.get("ajax/viewentry.php", { object: "User", id: "' . $nID . '" },
+        function (sData) {
+            if (sData.length > 2) {
+                $("#viewentryDiv").html("\n" + sData);
+            }
+        });
+}
+
+
+');
+
+$aFields = array(
+    'auto-schedule_submissions' => array(
+        'Auto-schedule API submissions?',
+        'Note that you\'ll need to configure automatic import of scheduled files to actually automatically import these submissions.',
+    ),
+    'allow_variant-only_submissions' => array(
+        'Allow variant-only submissions?',
+        'For data sources that aggregate data and cannot submit full case-level data.',
+    ),
+);
+$sFormEdit = '<FORM id=\'api_settings_edit_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>Please select which options you would like to enable for this user.<BR><BR><TABLE>';
+foreach ($aFields as $sField => $aText) {
+    $sFormEdit .= '<TR valign=\'top\'><TD><INPUT type=\'checkbox\' name=\'' . $sField . '\' value=\'1\'' . (empty($zUser['api_settings'][$sField])? '' : ' checked') . '></TD>' .
+        '<TD><B>' . $aText[0] . '</B><BR>' . $aText[1] . '</TD></TR>';
+}
+$sFormEdit .= '</TABLE><BR></FORM>';
+
+// Set JS variables and objects.
+print('
+var oButtonCancel = {"Cancel":function () { $(this).dialog("close"); }};
+var oButtonClose  = {"Close":function () { $(this).dialog("close"); }};
+var oButtonFormEdit = {"Edit settings":function () { $.post("' . CURRENT_PATH . '?edit", $("#api_settings_edit_form").serialize()); }};
+
+
+');
+
+
+
+
+
+if (ACTION == 'edit' && GET) {
+    // Show edit form.
+    // We do this in two steps to prevent CSRF.
+
+    $_SESSION['csrf_tokens']['api_settings_edit'] = md5(uniqid());
+    $sFormEdit = str_replace('{{CSRF_TOKEN}}', $_SESSION['csrf_tokens']['api_settings_edit'], $sFormEdit);
+
+    // Display the form, and put the right buttons in place.
+    print('
+    $("#api_settings_dialog").html("' . $sFormEdit . '<BR>");
+
+    // Select the right buttons.
+    $("#api_settings_dialog").dialog({buttons: $.extend({}, oButtonFormEdit, oButtonCancel)});
+    ');
+    exit;
+}
+
+
+
+
+
+if (ACTION == 'edit' && POST) {
+    // Process edit form.
+    // We do this in two steps to prevent CSRF.
+
+    if (empty($_POST['csrf_token']) || $_POST['csrf_token'] != $_SESSION['csrf_tokens']['api_settings_edit']) {
+        die('alert("Error while sending data, possible security risk. Try reloading the page, and loading the form again.");');
+    }
+
+    // Generate settings array.
+    $aSettings = array();
+    foreach (array_keys($aFields) as $sCol) {
+        if (!empty($_POST[$sCol])) {
+            $aSettings[$sCol] = 1;
+        }
+    }
+    if (!$aSettings) {
+        // To prevent json_encode() storing '[]'.
+        $sSettings = '{}';
+    } else {
+        $sSettings = json_encode($aSettings);
+    }
+
+    // Update!
+    if (!$_DB->query('UPDATE ' . TABLE_USERS . ' SET api_settings = ? WHERE id = ?',
+        array($sSettings, $nID), false)) {
+        die('alert("Failed to edit settings.\n' . htmlspecialchars($_DB->formatError()) . '");');
+    }
+    // If we get here, the token has been edited and stored successfully!
+    lovd_writeLog('Event', 'APISettingsEdit', 'Successfully edited API settings (' . implode(', ', array_keys($aSettings)) . ') for user #' . $nID);
+
+    // Display the form, and put the right buttons in place.
+    print('
+    $("#api_settings_dialog").html("Settings edited successfully!");
+    lovd_reloadUserVE();
+    
+    // Select the right buttons.
+    $("#api_settings_dialog").dialog({buttons: oButtonClose}); 
+    ');
+    exit;
+}
+?>

--- a/src/ajax/api_settings.php
+++ b/src/ajax/api_settings.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-09-22
- * Modified    : 2020-09-22
+ * Modified    : 2020-09-23
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -79,7 +79,11 @@ function lovd_reloadUserVE ()
 $aFields = array(
     'auto-schedule_submissions' => array(
         'Auto-schedule API submissions?',
-        'Note that you\'ll need to configure automatic import of scheduled files to actually automatically import these submissions.',
+        'Note that you\'ll need to configure automatic import of scheduled files to actually automatically process these submissions.',
+    ),
+    'Process_as_public' => array(
+        'Process data directly as Public?',
+        'Normally, new submissions are set to Pending, until a Curator publishes them. This setting will directly publish new API submissions from this user when they are processed.'
     ),
     'allow_variant-only_submissions' => array(
         'Allow variant-only submissions?',

--- a/src/ajax/api_settings.php
+++ b/src/ajax/api_settings.php
@@ -81,7 +81,7 @@ $aFields = array(
         'Auto-schedule API submissions?',
         'Note that you\'ll need to configure automatic import of scheduled files to actually automatically process these submissions.',
     ),
-    'Process_as_public' => array(
+    'process_as_public' => array(
         'Process data directly as Public?',
         'Normally, new submissions are set to Pending, until a Curator publishes them. This setting will directly publish new API submissions from this user when they are processed.'
     ),

--- a/src/ajax/auth_token.php
+++ b/src/ajax/auth_token.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-17
- * Modified    : 2017-12-11
- * For LOVD    : 3.0-21
+ * Modified    : 2020-09-25
+ * For LOVD    : 3.0-25
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -151,7 +151,8 @@ if (ACTION == 'create' && POST) {
         die('alert("Failed to create new token.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }
     // If we get here, the token has been created and stored successfully!
-    lovd_writeLog('Event', 'AuthTokenCreate', 'Successfully created new API token, expires ' . $sAuthTokenExpires);
+    lovd_writeLog('Event', 'AuthTokenCreate', 'Successfully created new API token for user #' . $nID . ', ' .
+        (!$sAuthTokenExpires? 'never expires' : 'expires ' . $sAuthTokenExpires));
 
     // Display the form, and put the right buttons in place.
     print('
@@ -202,7 +203,7 @@ if (ACTION == 'revoke' && POST) {
         die('alert("Failed to revoke token.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }
     // If we get here, the token has been revoked successfully!
-    lovd_writeLog('Event', 'AuthTokenRevoke', 'Successfully revoked current API token');
+    lovd_writeLog('Event', 'AuthTokenRevoke', 'Successfully revoked current API token for user #' . $nID);
 
     // Display the form, and put the right buttons in place.
     print('

--- a/src/class/api.php
+++ b/src/class/api.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2020-07-22
+ * Modified    : 2020-09-23
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -40,7 +40,7 @@ class LOVD_API
     // This class defines the LOVD API object, handling URL parsing and general
     //  handling of headers.
 
-    public $nVersion = 1;     // The API version. 0 for the LOVD2-style API. Higher versions are for the LOVD3-style REST API.
+    public $nVersion = 2;     // The API version. 0 for the LOVD2-style API. Higher versions are for the LOVD3-style REST API.
     public $sMethod = '';     // The used method (GET, POST, PUT, DELETE).
     public $sResource = '';   // The requested resource.
     public $nID = '';         // The ID of the requested resource.

--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2020-08-10
+ * Modified    : 2020-08-18
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -74,19 +74,31 @@ class LOVD_API_Submissions
         ),
         'pathogenicity' => array(
             // 'Unclassified' => '00', // Not allowed for submission.
+            'Benign' => '10',
             'Non-pathogenic' => '10',
+            'Likely benign' => '30',
             'Probably Not Pathogenic' => '30',
+            'VUS' => '50',
+            'Likely Pathogenic' => '70',
             'Probably Pathogenic' => '70',
             'Pathogenic' => '90',
+            'Causative' => '90',
+            'Conflicting' => '50',
+            'Unknown' => '50',
             'Not Known' => '50',
-            'Causative' => '60',
         ),
         'pathogenicity_to_classification' => array(
             'Unclassified' => 'unclassified',
+            'Benign' => 'benign',
             'Non-pathogenic' => 'benign',
+            'Likely benign' => 'likely benign',
             'Probably Not Pathogenic' => 'likely benign',
+            'VUS' => 'VUS',
+            'Likely Pathogenic' => 'likely pathogenic',
             'Probably Pathogenic' => 'likely pathogenic',
             'Pathogenic' => 'pathogenic',
+            'Conflicting' => 'conflicting',
+            'Unknown' => 'VUS',
             'Not Known' => 'VUS',
             'Causative' => 'association',
             // FIXME: Information about disease inheritance (dominant, recessive) can be stored here, too.

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2020-03-03
- * For LOVD    : 3.0-24
+ * Modified    : 2020-09-22
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -122,6 +122,7 @@ class LOVD_User extends LOVD_Object
                         'phpsessid' => array('Session ID', LEVEL_MANAGER),
                         'auth_token_' => array('API token', LEVEL_CURATOR), // Will be unset if user is not authorized on this user (i.e., not himself or manager or up).
                         'auth_token_expires_' => array('API token expiration', LEVEL_CURATOR), // Will be unset if user is not authorized on this user (i.e., not himself or manager or up).
+                        'api_settings' => array('API settings', LEVEL_MANAGER),
                         'saved_work_' => array('Saved work', LEVEL_MANAGER),
                         'curates_' => 'Curator for',
                         'collaborates_' => array('Collaborator for', LEVEL_CURATOR),
@@ -490,10 +491,13 @@ class LOVD_User extends LOVD_Object
             // Submissions...
             if (lovd_isAuthorized('user', $zData['id']) === false) {
                 // Not authorized to view hidden data for this user; so we're not manager and we're not viewing ourselves. Nevermind then.
-                unset($this->aColumnsViewEntry['entries_owned_by_'],
-                      $this->aColumnsViewEntry['entries_created_by_'],
-                      $this->aColumnsViewEntry['auth_token_'],
-                      $this->aColumnsViewEntry['auth_token_expires_']);
+                unset(
+                    $this->aColumnsViewEntry['entries_owned_by_'],
+                    $this->aColumnsViewEntry['entries_created_by_'],
+                    $this->aColumnsViewEntry['auth_token_'],
+                    $this->aColumnsViewEntry['auth_token_expires_'],
+                    $this->aColumnsViewEntry['api_settings']
+                );
             } else {
                 // Either we're viewing ourselves, or we're manager or up.
 

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2020-09-22
+ * Modified    : 2020-09-23
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -438,7 +438,7 @@ class LOVD_User extends LOVD_Object
     function prepareData ($zData = '', $sView = 'list')
     {
         // Prepares the data by "enriching" the variable received with links, pictures, etc.
-        global $_DB, $_SETT;
+        global $_AUTH, $_DB, $_SETT;
 
         if (!in_array($sView, array('list', 'entry'))) {
             $sView = 'list';
@@ -509,6 +509,10 @@ class LOVD_User extends LOVD_Object
                     $zData['auth_token_expires_'] = '<SPAN title="' . $zData['auth_token_expires'] . '">' . ($tDiff > 0? 'In ' . $sDiff : 'Expired ' . $sDiff . ' ago') . '</SPAN>';
                 } else {
                     $zData['auth_token_expires_'] = (!$zData['auth_token']? '' : '- (Never)');
+                }
+                if ($_AUTH['level'] >= LEVEL_MANAGER && lovd_isAuthorized('user', $zData['id'])) {
+                    $zData['api_settings'] = '<SPAN style="float:right;">(<A href="#" onclick="$.get(\'ajax/api_settings.php/' . $zData['id'] . '?edit\').fail(function(){alert(\'Error viewing settings, please try again later.\');}); return false;">Change</A>)</SPAN>' .
+                        $zData['api_settings'];
                 }
 
                 // Since we're manager or viewing ourselves, we don't need to check for the data status of the data.

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2020-07-28
+ * Modified    : 2020-09-22
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -675,6 +675,14 @@ class LOVD_Object
 
         if (!is_array($aData) || !$aData) {
             return '(no data)';
+        }
+
+        // Handle simple setting arrays differently.
+        if (!$nNesting && current(array_unique(array_values($aData))) == 1) {
+            // This is a simple array with just settings that are turned on.
+            return implode('<BR>', array_map(function ($sKey) {
+                return ucfirst(str_replace('_', ' ', $sKey)) . ' <IMG src="gfx/mark_1.png" alt="" width="11" height="11">';
+            }, array_keys($aData)));
         }
 
         $s = '<TABLE class="S11" width="100%">';

--- a/src/import.php
+++ b/src/import.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2020-08-10
+ * Modified    : 2020-09-23
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2348,7 +2348,7 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
             //  that all data is attached to an individual.
             $sSQL = '';
             $aIDs = array();
-            if (count($aParsed['Individuals']['data'])) {
+            if (!empty($aParsed['Individuals']['data'])) {
                 // Individuals were submitted.
                 // Collect genes and the individual IDs.
                 // If no genes are available, we'll email the managers.
@@ -2367,7 +2367,7 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
                                    AND s.individualid IN (?' . str_repeat(', ?', count($aIDs) - 1) . ')
                                  GROUP BY t.geneid
                                  ORDER BY t.geneid';
-            } elseif (count($aParsed['Variants_On_Genome']['data'])) {
+            } elseif (!empty($aParsed['Variants_On_Genome']['data'])) {
                 // We have separate variants instead.
                 // Collect genes and the variant IDs.
                 // If no genes are available, we'll email the managers.

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-09-11
+ * Modified    : 2020-09-22
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -161,7 +161,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-24',
+                            'version' => '3.0-24b',
                           ),
                 'user_levels' =>
                      array(

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2020-07-09
- * For LOVD    : 3.0-24
+ * Modified    : 2020-09-22
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -788,6 +788,9 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                          'UPDATE ' . TABLE_LINKS . ' SET replace_text = "<A href=\"https://pubmed.ncbi.nlm.nih.gov/[2]\" target=\"_blank\">[1]</A>" WHERE name = "PubMed" AND replace_text = "<A href=\"https://www.ncbi.nlm.nih.gov/pubmed/[2]\" target=\"_blank\">[1]</A>"',
                      )
                  ),
+                 '3.0-24b' => array(
+                     'ALTER TABLE ' . TABLE_USERS . ' ADD COLUMN api_settings TEXT AFTER auth_token_expires',
+                 )
              );
 
     if ($sCalcVersionDB < lovd_calculateVersion('3.0-alpha-01')) {

--- a/src/install/inc-sql-tables.php
+++ b/src/install/inc-sql-tables.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-22
- * Modified    : 2020-02-25
- * For LOVD    : 3.0-24
+ * Modified    : 2020-09-22
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -80,6 +80,7 @@ $aTableSQL =
     password_force_change BOOLEAN NOT NULL DEFAULT 0,
     auth_token CHAR(32),
     auth_token_expires DATETIME,
+    api_settings TEXT,
     phpsessid CHAR(32),
     saved_work TEXT,
     level TINYINT(1) UNSIGNED NOT NULL DEFAULT 1,

--- a/tests/selenium_tests/admin_tests/verify_full_download.php
+++ b/tests/selenium_tests/admin_tests/verify_full_download.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-21
- * Modified    : 2020-07-20
+ * Modified    : 2020-09-28
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -94,7 +94,7 @@ class VerifyFullDownloadTest extends LOVDSeleniumWebdriverBaseTestCase
         // Now compare the two files.
         $this->assertEquals(
             file_get_contents(ROOT_PATH . '../tests/test_data_files/AdminTestSuiteResult.txt'),
-            preg_replace('/^### LOVD-version [0-9]{4}-[0-9]{3} /', '### LOVD-version ????-??? ',
+            preg_replace('/^### LOVD-version [0-9]{4}-[0-9a-z]{3} /', '### LOVD-version ????-??? ',
                 preg_replace('/\b[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\b/', '0000-00-00 00:00:00', file_get_contents('/tmp/' . $sDownloadFile)))
         );
     }

--- a/tests/selenium_tests/shared_tests/submission_API.php
+++ b/tests/selenium_tests/shared_tests/submission_API.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-20
- * Modified    : 2020-06-08
- * For LOVD    : 3.0-24
+ * Modified    : 2020-09-28
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -210,7 +210,7 @@ class SubmissionAPITest extends LOVDSeleniumWebdriverBaseTestCase
         $aResult = json_decode($sResult, true);
 
         $this->assertEquals(array(), $aResult['errors']);
-        $this->assertContains('Data successfully scheduled for import.',
+        $this->assertContains('Data successfully stored for import.',
             implode(';', $aResult['messages']));
         $this->assertStringEndsWith ('202 Accepted', $http_response_header[0]);
     }


### PR DESCRIPTION
#### Improved the submission API to allow direct processing of variant-only submissions.
- Added the `api_settings` column to the users table.
  - Version bump to 3.0-24b.
- Display the API settings on the user account's detailed view and added a link in the Users VE to edit the API settings.
- Added new ajax script to store API settings for users.
  - These are dynamic settings, and we can add or change settings without having to alter the user table anymore.
- Added setting for allowing variant-only submissions.
- Added setting for auto-scheduling submissions.
  - Also, updated the return message of the API to make this difference clear, but only for API v2.
    - Updated test for this.
- Added setting for directly publishing new API submissions.

Closes #462.

#### Also:
- Added additional pathogenicity values, mapping to already existing effects and classifications.
  - This is just to extend VarioML with more logical values.
- Added user ID to the log entries generated by `ajax/auth_token.php`, so that you can actually see it when a manager or admin does this for a user other than themselves.
- Fixed tests; Made the download test handle sub releases like `3.0-24b`.