### PR TITLE
Fixed many small issues.

### DIFF
--- a/src/ajax/mobidetails.php
+++ b/src/ajax/mobidetails.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-10-01
- * Modified    : 2020-10-05
+ * Modified    : 2020-10-06
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -120,7 +120,7 @@ if (ACTION == 'check') {
         // Close dialog.
         $("#mobidetails_dialog").dialog("close");
         // Open window.
-        lovd_openWindow("' . $aJSON['url'] . '", "MobiDetails_' . $aJSON['mobidetails_id'] . '", 1000, 800);
+        lovd_openWindow("' . $aJSON['url'] . '", "_blank");
         ');
         exit;
     }
@@ -177,7 +177,7 @@ if (ACTION == 'confirm' && POST) {
         // Close dialog.
         $("#mobidetails_dialog").dialog("close");
         // Open window.
-        lovd_openWindow("' . $aJSON['url'] . '", "MobiDetails_' . $aJSON['mobidetails_id'] . '", 1000, 800);
+        lovd_openWindow("' . $aJSON['url'] . '", "_blank");
         ');
         exit;
     }

--- a/src/ajax/mobidetails.php
+++ b/src/ajax/mobidetails.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-10-01
- * Modified    : 2020-10-01
+ * Modified    : 2020-10-05
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -79,6 +79,7 @@ if (!$("#mobidetails_dialog").hasClass("ui-dialog-content") || !$("#mobidetails_
 ');
 
 $sFormConfirmation = '<FORM id=\'mobidetails_confirm_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>MobiDetails has not seen this variant before and still needs to generate the annotation. This may take a while. Confirm you want this variant annotated by MobiDetails by clicking the button below.<BR><BR></FORM>';
+$sFormConfirmationNoKey = 'MobiDetails has not seen this variant before and still needs to generate the annotation. However, this LOVD instance doesn\'t have an MobiDetails API key configured yet, so it can not send the variant to MobiDetails. Please contact the Curator and ask to have an MobiDetails API key registered in the LOVD System Settings.<BR><BR>';
 
 // Set JS variables and objects.
 print('
@@ -125,13 +126,23 @@ if (ACTION == 'check') {
     }
 
     // If we're here, the variant doesn't exist yet.
-    // Display the form, and put the right buttons in place.
-    print('
-    $("#mobidetails_dialog").html("' . $sFormConfirmation . '<BR>");
+    if ($_CONF['md_apikey']) {
+        // Display the form, and put the right buttons in place.
+        print('
+        $("#mobidetails_dialog").html("' . $sFormConfirmation . '<BR>");
 
-    // Select the right buttons.
-    $("#mobidetails_dialog").dialog({buttons: $.extend({}, oButtonFormConfirm, oButtonCancel)});
-    ');
+        // Select the right buttons.
+        $("#mobidetails_dialog").dialog({buttons: $.extend({}, oButtonFormConfirm, oButtonCancel)});
+        ');
+    } else {
+        // Ask the user to contact the LOVD team.
+        print('
+        $("#mobidetails_dialog").html("' . $sFormConfirmationNoKey . '<BR>");
+
+        // Select the right buttons.
+        $("#mobidetails_dialog").dialog({buttons: $.extend({}, oButtonClose)});
+        ');
+    }
     exit;
 }
 

--- a/src/ajax/mobidetails.php
+++ b/src/ajax/mobidetails.php
@@ -78,8 +78,8 @@ if (!$("#mobidetails_dialog").hasClass("ui-dialog-content") || !$("#mobidetails_
 
 ');
 
-$sFormConfirmation = '<FORM id=\'mobidetails_confirm_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'>MobiDetails has not seen this variant before and still needs to generate the annotation. This may take a while. Confirm you want this variant annotated by MobiDetails by clicking the button below.<BR><BR></FORM>';
-$sFormConfirmationNoKey = 'MobiDetails has not seen this variant before and still needs to generate the annotation. However, this LOVD instance doesn\'t have an MobiDetails API key configured yet, so it can not send the variant to MobiDetails. Please contact the Curator and ask to have an MobiDetails API key registered in the LOVD System Settings.<BR><BR>';
+$sFormConfirmation = '<FORM id=\'mobidetails_confirm_form\'><INPUT type=\'hidden\' name=\'csrf_token\' value=\'{{CSRF_TOKEN}}\'><A href=\'https://mobidetails.iurc.montp.inserm.fr/MD\' target=\'_blank\'>MobiDetails</A> is an annotation platform dedicated to the interpretation of DNA variants. MobiDetails has not seen this variant before and still needs to generate the annotation. This may take a while. Confirm you want this variant annotated by MobiDetails by clicking the button below.<BR><BR></FORM>';
+$sFormConfirmationNoKey = '<A href=\'https://mobidetails.iurc.montp.inserm.fr/MD\' target=\'_blank\'>MobiDetails</A> is an annotation platform dedicated to the interpretation of DNA variants. MobiDetails has not seen this variant before and still needs to generate the annotation. However, this LOVD instance doesn\'t have an MobiDetails API key configured yet, so it can not send the variant to MobiDetails. Please contact the Curator and ask to have an MobiDetails API key registered in the LOVD System Settings.<BR><BR>';
 
 // Set JS variables and objects.
 print('

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-27
- * Modified    : 2020-09-17
+ * Modified    : 2020-10-07
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -281,6 +281,7 @@ class LOVD_Template
 
         $this->bBotIncluded = true;
         switch (FORMAT) {
+            case 'application/json':
             case 'text/plain':
                 return false;
             case 'text/html':
@@ -473,6 +474,8 @@ function lovd_mapVariants ()
         $this->bFull = ($bFull && !isset($_GET['in_window']));
         $this->bTopIncluded = true;
         switch (FORMAT) {
+            case 'application/json':
+                return false;
             case 'text/plain':
                 if (!defined('FORMAT_ALLOW_TEXTPLAIN')) {
                     die('text/plain not allowed here');
@@ -902,6 +905,7 @@ foreach ($zAnnouncements as $zAnnouncement) {
         }
 
         switch (FORMAT) {
+            case 'application/json':
             case 'text/plain':
                 return false;
             case 'text/html':

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-09-30
+ * Modified    : 2020-10-07
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -87,8 +87,17 @@ $_SERVER['SCRIPT_NAME'] = lovd_cleanDirName(str_replace('\\', '/', $_SERVER['SCR
 // Our output formats: text/html by default.
 $aFormats = array('text/html', 'text/plain'); // Key [0] is default. Other values may not always be allowed. It is checked in the Template class' printHeader() and in Objects::viewList().
 if (lovd_getProjectFile() == '/api.php') {
-    $aFormats[] = 'application/json';
-    $aFormats[] = 'text/bed';
+    // The REST API has JSON as an *optional* format,
+    //  for the new API it's the *default*.
+    if (strpos($_SERVER['REQUEST_URI'], '/rest') !== false) {
+        // REST API.
+        $aFormats[] = 'application/json';
+        $aFormats[] = 'text/bed';
+    } else {
+        // New API.
+        array_unshift($aFormats, 'application/json');
+    }
+
 } elseif (lovd_getProjectFile() == '/import.php' && substr($_SERVER['QUERY_STRING'], 0, 25) == 'autoupload_scheduled_file') {
     // Set format to text/plain only when none is requested.
     if (empty($_GET['format']) || !in_array($_GET['format'], $aFormats)) {

--- a/src/inc-js-openwindow.php
+++ b/src/inc-js-openwindow.php
@@ -4,11 +4,11 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-20
- * Modified    : 2013-01-23
- * For LOVD    : 3.0-02
+ * Modified    : 2020-10-06
+ * For LOVD    : 3.0-25
  *
- * Copyright   : 2004-2013 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -34,7 +34,9 @@ header('Expires: ' . date('r', time()+(180*60)));
 function lovd_openWindow (var_dest, var_name, var_width, var_height, varPosX, varPosY)
 {
     // Load function to open up new windows.
-    var_name = 'LOVD_<?php echo time(); ?>_' + var_name;
+    if (var_name != '_blank') {
+        var_name = 'LOVD_<?php echo time(); ?>_' + var_name;
+    }
     if (!var_width) {
         var var_width = screen.width / 2;
     }
@@ -47,5 +49,9 @@ function lovd_openWindow (var_dest, var_name, var_width, var_height, varPosX, va
     if (!varPosY) {
         var varPosY = 50;
     }
-    return window.open(var_dest, var_name, 'width=' + var_width + ',height=' + var_height + ',left=' + varPosX + ',top=' + varPosY + ',scrollbars=1');
+    if (var_name == '_blank') {
+        return window.open(var_dest, var_name);
+    } else {
+        return window.open(var_dest, var_name, 'width=' + var_width + ',height=' + var_height + ',left=' + varPosX + ',top=' + varPosY + ',scrollbars=1');
+    }
 }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-10-01
+ * Modified    : 2020-10-07
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -355,7 +355,9 @@ function lovd_displayError ($sError, $sMessage, $sLogFile = 'Error')
     if ($_T->bBotIncluded) {
         print('<BR>' . "\n\n");
     }
-    $sMessage = htmlspecialchars($sMessage);
+    if (FORMAT == 'text/html') {
+        $sMessage = htmlspecialchars($sMessage);
+    }
 
     // A LOVD-Lib or Query error is always an LOVD bug! (unless MySQL went down)
     if ($sError == 'LOVD-Lib' || ($sError == 'Query' && strpos($sMessage, 'You have an error in your SQL syntax'))) {
@@ -364,12 +366,33 @@ function lovd_displayError ($sError, $sMessage, $sLogFile = 'Error')
     }
 
     // Display error.
-    print("\n" . '
+    switch (FORMAT) {
+        case 'application/json':
+            print(
+                json_encode(
+                    array(
+                        'version' => '',
+                        'messages' => array(),
+                        'warnings' => array(),
+                        'errors' => array(
+                            'Error: ' . $sError . ($bLog? ' (Logged)' : '') . "\n" . $sMessage,
+                        ),
+                        'data' => array(),
+                    )));
+            break;
+        case 'text/plain':
+            print('Error: ' . $sError . ($bLog? ' (Logged)' : '') . "\n" . $sMessage . "\n");
+            break;
+        case 'text/html':
+        default:
+            print("\n" . '
       <TABLE border="0" cellpadding="0" cellspacing="0" align="center" width="900" class="error">
         <TR>
           <TH>Error: ' . $sError . ($bLog? ' (Logged)' : '') . '</TH></TR>
         <TR>
           <TD>' . str_replace(array("\n", "\t"), array('<BR>', '&nbsp;&nbsp;&nbsp;&nbsp;'), $sMessage) . '</TD></TR></TABLE>' . "\n\n");
+            break;
+    }
 
     // If fatal, get bottom and exit.
     if ($_T->bBotIncluded) {

--- a/src/inc-lib-viewlist.php
+++ b/src/inc-lib-viewlist.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-22
- * Modified    : 2020-03-24
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-06
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -80,6 +80,10 @@ function lovd_formatSearchExpression ($sExpression, $sColumnType)
                         $sFormattedExpression .= 'Does not contain ' . trim($sORExpression, '!=');
                     } elseif ($sORExpression{0} == '=') {
                         $sFormattedExpression .= 'Exactly matches ' . trim($sORExpression, '="');
+                    } elseif ($sORExpression{0} == '^') {
+                        $sFormattedExpression .= 'Starts with ' . ltrim($sORExpression, '^');
+                    } elseif (substr($sORExpression, -1) == '$') {
+                        $sFormattedExpression .= 'Ends with ' . rtrim($sORExpression, '$');
                     } else {
                         $sFormattedExpression .= 'Contains ' . $sORExpression;
                     }

--- a/src/inc-lib-viewlist.php
+++ b/src/inc-lib-viewlist.php
@@ -74,7 +74,11 @@ function lovd_formatSearchExpression ($sExpression, $sColumnType)
         foreach ($aORExpressions as $nORIndex => $sORExpression) {
             switch ($sColumnType) {
                 case 'TEXT':
-                    if (substr($sORExpression, 0, 2) == '!=') {
+                    if ($sORExpression == '!=""') {
+                        $sFormattedExpression .= 'Is not empty';
+                    } elseif ($sORExpression == '=""') {
+                        $sFormattedExpression .= 'Is empty';
+                    } elseif (substr($sORExpression, 0, 2) == '!=') {
                         $sFormattedExpression .= 'Does not exactly match ' . trim($sORExpression, '!="');
                     } elseif ($sORExpression{0} == '!') {
                         $sFormattedExpression .= 'Does not contain ' . trim($sORExpression, '!=');

--- a/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
+++ b/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-02-17
- * Modified    : 2020-07-23
+ * Modified    : 2020-10-06
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -443,6 +443,30 @@ abstract class LOVDSeleniumWebdriverBaseTestCase extends PHPUnit_Framework_TestC
 
 
 
+    protected function waitForURLContains ($sValue, $nTimeOut = WEBDRIVER_MAX_WAIT_DEFAULT)
+    {
+        // Convenience function to let the webdriver wait for a standard amount
+        //  of time for the URL to contain a certain value.
+        return $this->waitUntil(
+            WebDriverExpectedCondition::urlContains($sValue), $nTimeOut);
+    }
+
+
+
+
+
+    protected function waitForURLEndsWith ($sValue, $nTimeOut = WEBDRIVER_MAX_WAIT_DEFAULT)
+    {
+        // Convenience function to let the webdriver wait for a standard amount
+        //  of time for the URL to end with a certain value.
+        return $this->waitUntil(
+            WebDriverExpectedCondition::urlMatches('/' . preg_quote($sValue, '/') . '$/'), $nTimeOut);
+    }
+
+
+
+
+
     protected function waitForValueContains ($oElement, $sValue, $nTimeOut = WEBDRIVER_MAX_WAIT_DEFAULT)
     {
         // Convenience function to let the webdriver wait for a standard amount
@@ -467,3 +491,4 @@ abstract class LOVDSeleniumWebdriverBaseTestCase extends PHPUnit_Framework_TestC
                             ->until($condition);
     }
 }
+?>

--- a/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
+++ b/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-02-17
- * Modified    : 2020-10-07
+ * Modified    : 2020-10-09
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -461,6 +461,18 @@ abstract class LOVDSeleniumWebdriverBaseTestCase extends PHPUnit_Framework_TestC
         //  of time for the URL to end with a certain value.
         return $this->waitUntil(
             WebDriverExpectedCondition::urlMatches('/' . preg_quote($sValue, '/') . '$/'), $nTimeOut);
+    }
+
+
+
+
+
+    protected function waitForURLEquals ($sValue, $nTimeOut = WEBDRIVER_MAX_WAIT_DEFAULT)
+    {
+        // Convenience function to let the webdriver wait for a standard amount
+        //  of time for the URL to have a certain value.
+        return $this->waitUntil(
+            WebDriverExpectedCondition::urlIs($sValue), $nTimeOut);
     }
 
 

--- a/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
+++ b/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-02-17
- * Modified    : 2020-10-06
+ * Modified    : 2020-10-07
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -461,6 +461,18 @@ abstract class LOVDSeleniumWebdriverBaseTestCase extends PHPUnit_Framework_TestC
         //  of time for the URL to end with a certain value.
         return $this->waitUntil(
             WebDriverExpectedCondition::urlMatches('/' . preg_quote($sValue, '/') . '$/'), $nTimeOut);
+    }
+
+
+
+
+
+    protected function waitForURLRegExp ($sPattern, $nTimeOut = WEBDRIVER_MAX_WAIT_DEFAULT)
+    {
+        // Convenience function to let the webdriver wait for a standard amount
+        //  of time for the URL to match a certain pattern.
+        return $this->waitUntil(
+            WebDriverExpectedCondition::urlMatches($sPattern), $nTimeOut);
     }
 
 

--- a/tests/selenium_tests/manager_tests/block_submitter_registration.php
+++ b/tests/selenium_tests/manager_tests/block_submitter_registration.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-08-31
- * Modified    : 2020-06-04
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-08
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -62,7 +62,7 @@ class BlockSubmitterRegistrationTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->chooseOkOnNextConfirmation();
         $this->assertEquals('Successfully edited the system settings!',
             $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/setup'));
+        $this->waitForURLEndsWith('/src/setup');
     }
 
 
@@ -122,7 +122,7 @@ class BlockSubmitterRegistrationTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->chooseOkOnNextConfirmation();
         $this->assertEquals('Successfully edited the system settings!',
             $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/setup'));
+        $this->waitForURLEndsWith('/src/setup');
     }
 
 

--- a/tests/selenium_tests/manager_tests/create_announcement_making_LOVD_readonly.php
+++ b/tests/selenium_tests/manager_tests/create_announcement_making_LOVD_readonly.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-08-30
- * Modified    : 2020-06-04
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-08
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -72,7 +72,7 @@ class CreateAnnouncementMakingLOVDReadOnlyTest extends LOVDSeleniumWebdriverBase
             $this->driver->findElement(WebDriverBy::xpath('//table[@class="info" and contains(., "Success")]'))->getText());
         $this->assertEquals($sAnnouncement, $this->driver->findElement(
             WebDriverBy::cssSelector('table[class=info]'))->getText());
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/announcements/0000'));
+        $this->waitForURLContains('/src/announcements/0000');
     }
 
 

--- a/tests/selenium_tests/manager_tests/delete_announcement.php
+++ b/tests/selenium_tests/manager_tests/delete_announcement.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-06-04
- * Modified    : 2020-06-04
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-08
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -59,11 +59,12 @@ class DeleteAnnouncementTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->driver->get(ROOT_URL . '/src/announcements');
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="data"]/tbody/tr[last()]/td[1]'))->click();
-        $this->assertContains('/src/announcements/0000', $this->driver->getCurrentURL());
+
+        $this->waitForURLContains('/src/announcements/0000');
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Announcements'))->click();
         $this->driver->findElement(WebDriverBy::linkText('Delete announcement'))->click();
 
-        $this->assertRegExp('/\/src\/announcements\/[0-9]+\?delete$/', $this->driver->getCurrentURL());
+        $this->waitForURLRegExp('/\/src\/announcements\/[0-9]+\?delete$/');
         $this->enterValue('password', 'test1234');
         $this->submitForm('Delete announcement');
 

--- a/tests/selenium_tests/shared_tests/access_submission_from_colleague.php
+++ b/tests/selenium_tests/shared_tests/access_submission_from_colleague.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-06-17
- * Modified    : 2020-06-17
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-09
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -60,19 +60,20 @@ class AccessSubmissionFromColleagueTest extends LOVDSeleniumWebdriverBaseTestCas
         // In our tests, user "Owner" has set a colleague.
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"]//tr[td[contains(., "Test Owner")]]/td[1]'))->click();
 
+        // Individual.
+        $this->waitForURLContains('/src/individuals/0000');
+
         // Menus should not exist (except for variants, they always have a menu),
         //  but I should be able to see non-public fields.
         // To return here.
         $sSubmissionURL = $this->driver->getCurrentURL();
 
-        // Individual.
-        $this->assertContains('/src/individuals/0000', $this->driver->getCurrentURL());
         $this->assertFalse($this->isElementPresent(WebDriverBy::id('viewentryOptionsButton_Individuals')));
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="Pending"]'));
         $this->driver->findElement(WebDriverBy::xpath('//div[contains(@id, "viewlistDiv_Phenotypes_for_I_VE_0000")]//td[text()="Pending"]'))->click();
 
         // Phenotype.
-        $this->assertContains('/src/phenotypes/0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/phenotypes/0000');
         $this->assertFalse($this->isElementPresent(WebDriverBy::id('viewentryOptionsButton_Phenotypes')));
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="Pending"]'));
 
@@ -80,13 +81,13 @@ class AccessSubmissionFromColleagueTest extends LOVDSeleniumWebdriverBaseTestCas
         $this->driver->findElement(WebDriverBy::xpath('//div[@id="viewlistDiv_Screenings_for_I_VE"]//td'))->click();
 
         // Screening.
-        $this->assertContains('/src/screenings/0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/screenings/0000');
         $this->assertFalse($this->isElementPresent(WebDriverBy::id('viewentryOptionsButton_Screenings')));
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="(Pending)"]'));
         $this->driver->findElement(WebDriverBy::xpath('//div[@id="viewlistDiv_CustomVL_VOT_for_S_VE"]//td[text()="Pending"]'))->click();
 
         // Variant, through Screening.
-        $this->assertContains('/src/variants/0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/variants/0000');
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="(Pending)"]'));
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="Pending"]'));
 
@@ -94,7 +95,7 @@ class AccessSubmissionFromColleagueTest extends LOVDSeleniumWebdriverBaseTestCas
         $this->driver->findElement(WebDriverBy::xpath('//div[@id="viewlistDiv_CustomVL_VOT_for_I_VE"]//td[text()="Pending"]'))->click();
 
         // Variant, through Individual.
-        $this->assertContains('/src/variants/0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/variants/0000');
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="(Pending)"]'));
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="Pending"]'));
     }

--- a/tests/selenium_tests/shared_tests/add_more_data_to_existing_submission.php
+++ b/tests/selenium_tests/shared_tests/add_more_data_to_existing_submission.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-20
- * Modified    : 2020-06-08
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-08
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -74,11 +74,11 @@ class AddMoreDataToExistingSubmissionTest extends LOVDSeleniumWebdriverBaseTestC
      */
     public function testAddPhenotypeRecord ()
     {
-        $this->assertContains('/src/individuals/0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/individuals/0000');
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Individuals'))->click();
         $this->driver->findElement(WebDriverBy::linkText('Add phenotype information to individual'))->click();
 
-        $this->assertContains('/src/phenotypes?create&target=0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/phenotypes?create&target=0000');
         $this->enterValue('Phenotype/Additional', 'More additional information.');
         $this->selectValue('Phenotype/Inheritance', 'Familial');
         $this->enterValue('Phenotype/Age/Diagnosis', '30y');
@@ -86,7 +86,7 @@ class AddMoreDataToExistingSubmissionTest extends LOVDSeleniumWebdriverBaseTestC
 
         $this->assertStringStartsWith('Successfully processed your submission',
             $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/phenotypes/0000'));
+        $this->waitForURLContains('/src/phenotypes/0000');
         $this->driver->findElement(WebDriverBy::xpath('//a[contains(@href, "individuals/0000")]'))->click();
     }
 
@@ -99,11 +99,11 @@ class AddMoreDataToExistingSubmissionTest extends LOVDSeleniumWebdriverBaseTestC
      */
     public function testAddScreening ()
     {
-        $this->assertContains('/src/individuals/0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/individuals/0000');
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Individuals'))->click();
         $this->driver->findElement(WebDriverBy::linkText('Add screening to individual'))->click();
 
-        $this->assertContains('/src/screenings?create&target=0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/screenings?create&target=0000');
         $this->selectValue('Screening/Template[]', 'Protein');
         $this->selectValue('Screening/Technique[]', 'Western');
         $this->selectValue('genes[]', 'IVD');
@@ -128,11 +128,11 @@ class AddMoreDataToExistingSubmissionTest extends LOVDSeleniumWebdriverBaseTestC
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "I want to add a variant to")]'))->click();
 
-        $this->assertContains('/src/variants?create&target=0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/variants?create&target=0000');
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "Yes, I want to confirm variants found")]'))->click();
 
-        $this->assertRegExp('/\/src\/screenings\/[0-9]+\?confirmVariants$/', $this->driver->getCurrentURL());
+        $this->waitForURLRegExp('/\/src\/screenings\/[0-9]+\?confirmVariants$/');
         $this->driver->findElement(WebDriverBy::xpath('//td[contains(text(), "?/")]'))->click();
         $this->submitForm('Save variant list');
 
@@ -157,7 +157,7 @@ class AddMoreDataToExistingSubmissionTest extends LOVDSeleniumWebdriverBaseTestC
 
         $this->assertStringStartsWith('Successfully processed your submission',
             $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/screenings/0000'));
+        $this->waitForURLContains('/src/screenings/0000');
     }
 
 
@@ -175,7 +175,7 @@ class AddMoreDataToExistingSubmissionTest extends LOVDSeleniumWebdriverBaseTestC
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Screenings'))->click();
         $this->driver->findElement(WebDriverBy::linkText('Add variant to screening'))->click();
 
-        $this->assertContains('/src/variants?create&target=0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/variants?create&target=0000');
     }
 }
 ?>

--- a/tests/selenium_tests/shared_tests/assign_colleague_to_owner.php
+++ b/tests/selenium_tests/shared_tests/assign_colleague_to_owner.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-25
- * Modified    : 2020-05-26
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-07
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -61,7 +61,7 @@ class AssignColleagueToOwnerTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Users'))->click();
         $this->driver->findElement(WebDriverBy::partialLinkText('Share access'))->click();
 
-        $this->assertStringEndsWith('/src/users/00005?share_access', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/users/00005?share_access');
         $this->driver->findElement(WebDriverBy::xpath('//tr[@id="00006"]/td[.="Test Submitter"]'))->click();
         $this->unCheck(WebDriverBy::xpath('//td[contains(text(), "Test Submitter")]/..//input[@name="allow_edit[]"]'));
         $this->enterValue('password', 'test1234');

--- a/tests/selenium_tests/shared_tests/assign_curator_to_IVD_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/assign_curator_to_IVD_not_authorized.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-06-17
- * Modified    : 2020-06-17
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-09
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -55,7 +55,7 @@ class AssignCuratorToIVDNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestC
     {
         $this->driver->get(ROOT_URL . '/src/genes/IVD?authorize');
         // Not being authorized should get you forwarded.
-        $this->assertStringEndsWith('/src/genes/IVD?sortCurators', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/genes/IVD?sortCurators');
         $this->assertEquals('To access this area, you need at least Curator clearance.',
             $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
     }

--- a/tests/selenium_tests/shared_tests/create_custom_column_phenotype.php
+++ b/tests/selenium_tests/shared_tests/create_custom_column_phenotype.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-19
- * Modified    : 2020-06-03
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-07
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -62,7 +62,7 @@ class CreateCustomColumnPhenotypeTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "Information on the phenotype")]'))->click();
 
-        $this->assertStringEndsWith('/src/columns?create', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/columns?create');
         $this->enterValue('colid', 'Age/Diagnosis');
         $this->enterValue('head_column', 'Age of diagnosis');
         $this->enterValue('description_legend_short', 'The age at which the individual\'s diagnosis was confirmed, if known. 04y08m = 4 years and 8 months.');
@@ -113,7 +113,7 @@ class CreateCustomColumnPhenotypeTest extends LOVDSeleniumWebdriverBaseTestCase
             $this->driver->findElement(WebDriverBy::cssSelector("table[class=info]"))->getText());
 
         // Wait for page redirect.
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/columns/Phenotype/Age/Diagnosis'));
+        $this->waitForURLEndsWith('/src/columns/Phenotype/Age/Diagnosis');
     }
 }
 ?>

--- a/tests/selenium_tests/shared_tests/create_submission_individual_with_IVA.php
+++ b/tests/selenium_tests/shared_tests/create_submission_individual_with_IVA.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-15
- * Modified    : 2020-07-23
+ * Modified    : 2020-10-06
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -92,7 +92,7 @@ class CreateSubmissionIndividualWithIVATest extends LOVDSeleniumWebdriverBaseTes
                 '//table[@class="option"]//td[contains(., "Yes, I want to submit")]'))->click();
         }
 
-        $this->assertStringEndsWith('/src/individuals?create', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/individuals?create');
         $this->enterValue('Individual/Lab_ID', '1234IVA');
         $this->enterValue('Individual/Reference', '{PMID:Fokkema et al (2011):21520333}');
         $this->selectValue('active_diseases[]', 'IVA (isovaleric acidemia)');
@@ -127,7 +127,7 @@ class CreateSubmissionIndividualWithIVATest extends LOVDSeleniumWebdriverBaseTes
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "I want to add phenotype information")]'))->click();
 
-        $this->assertContains('/src/phenotypes?create&target=0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/phenotypes?create&target=0000');
         $this->enterValue('Phenotype/Additional', 'Additional information.');
         $this->selectValue('Phenotype/Inheritance', 'Familial');
         $this->enterValue('Phenotype/Age/Diagnosis', '30y');
@@ -162,7 +162,7 @@ class CreateSubmissionIndividualWithIVATest extends LOVDSeleniumWebdriverBaseTes
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "I want to add a variant screening")]'))->click();
 
-        $this->assertContains('/src/screenings?create&target=0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/screenings?create&target=0000');
         // selectValue() allows for multiple selection.
         $this->selectValue('Screening/Template[]', 'DNA');
         $this->selectValue('Screening/Template[]', 'RNA (cDNA)');
@@ -200,7 +200,7 @@ class CreateSubmissionIndividualWithIVATest extends LOVDSeleniumWebdriverBaseTes
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "I want to add a variant to")]'))->click();
 
-        $this->assertContains('/src/variants?create&target=0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/variants?create&target=0000');
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "A variant that is located within a gene")]'))->click();
         // We probably don't need to search for IVD, but we might as well.
@@ -210,7 +210,7 @@ class CreateSubmissionIndividualWithIVATest extends LOVDSeleniumWebdriverBaseTes
         } catch (StaleElementReferenceException $e) {}
         $this->driver->findElement(WebDriverBy::xpath('//tr[@id="IVD"]/td[1]'))->click();
 
-        $this->assertContains('/src/variants?create&reference=Transcript&geneid=IVD&target=0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/variants?create&reference=Transcript&geneid=IVD&target=0000');
         $this->enterValue('00000001_VariantOnTranscript/Exon', '1');
         $this->enterValue('00000001_VariantOnTranscript/DNA', 'c.123A>T');
         $this->driver->findElement(WebDriverBy::cssSelector('button.mapVariant'))->click();
@@ -259,11 +259,11 @@ class CreateSubmissionIndividualWithIVATest extends LOVDSeleniumWebdriverBaseTes
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "I want to add a variant to")]'))->click();
 
-        $this->assertContains('/src/variants?create&target=0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/variants?create&target=0000');
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "A variant that was only described on genomic level")]'))->click();
 
-        $this->assertContains('/src/variants?create&reference=Genome&target=0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/variants?create&reference=Genome&target=0000');
         $this->assertFalse($this->isElementPresent(WebDriverBy::xpath('//input[contains(@name, "VariantOnTranscript/")]')));
         $this->selectValue('allele', 'Paternal (confirmed)');
         $this->selectValue('chromosome', '15');
@@ -301,9 +301,10 @@ class CreateSubmissionIndividualWithIVATest extends LOVDSeleniumWebdriverBaseTes
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "I want to finish this submission")]'))->click();
 
+        $this->waitForURLContains('/src/submit/finish/individual/0000');
         $this->assertStringStartsWith('Successfully processed your submission',
             $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/individuals/0000'));
+        $this->waitForURLContains('/src/individuals/0000');
     }
 }
 ?>

--- a/tests/selenium_tests/shared_tests/create_summary_data_upload_seattleseq.php
+++ b/tests/selenium_tests/shared_tests/create_summary_data_upload_seattleseq.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-02-17
- * Modified    : 2020-05-26
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-08
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -64,12 +64,12 @@ class CreateSummaryDataUploadSeattleseqTest extends LOVDSeleniumWebdriverBaseTes
         $this->assertStringStartsWith('Please reconsider to submit individual data as well, as it makes the data you submit much more valuable!',
             $this->getConfirmation());
         $this->chooseOkOnNextConfirmation();
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/variants?create'));
+        $this->waitForURLEndsWith('/src/variants?create');
 
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "I want to upload a file")]'))->click();
 
-        $this->assertStringEndsWith('/src/variants/upload?create', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/variants/upload?create');
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "I want to upload a SeattleSeq Annotation file")]'))->click();
     }
@@ -83,7 +83,7 @@ class CreateSummaryDataUploadSeattleseqTest extends LOVDSeleniumWebdriverBaseTes
      */
     public function testUploadFile ()
     {
-        $this->assertStringEndsWith('/src/variants/upload?create&type=SeattleSeq', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/variants/upload?create&type=SeattleSeq');
         $this->enterValue('variant_file', ROOT_PATH . '../tests/test_data_files/ShortSeattleSeqAnnotation138v1.txt');
         $this->selectValue('hg_build', 'hg19');
         $this->selectValue('dbSNP_column', 'VariantOnGenome/Reference');
@@ -97,7 +97,7 @@ class CreateSummaryDataUploadSeattleseqTest extends LOVDSeleniumWebdriverBaseTes
             $this->driver->findElement(WebDriverBy::id('lovd__progress_message'))->getText());
         $this->submitForm('Continue');
 
-        $this->assertContains('/src/submit/finish/upload/', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/submit/finish/upload/');
         $this->assertStringStartsWith('Successfully processed your submission',
             $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
     }

--- a/tests/selenium_tests/shared_tests/create_summary_data_upload_vcf.php
+++ b/tests/selenium_tests/shared_tests/create_summary_data_upload_vcf.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-02-17
- * Modified    : 2020-06-12
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-08
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -64,12 +64,12 @@ class CreateSummaryDataUploadVCFTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertStringStartsWith('Please reconsider to submit individual data as well, as it makes the data you submit much more valuable!',
             $this->getConfirmation());
         $this->chooseOkOnNextConfirmation();
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/variants?create'));
+        $this->waitForURLEndsWith('/src/variants?create');
 
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "I want to upload a file")]'))->click();
 
-        $this->assertStringEndsWith('/src/variants/upload?create', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/variants/upload?create');
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "I want to upload a Variant Call Format (VCF) file")]'))->click();
     }
@@ -83,7 +83,7 @@ class CreateSummaryDataUploadVCFTest extends LOVDSeleniumWebdriverBaseTestCase
      */
     public function testUploadFile ()
     {
-        $this->assertStringEndsWith('/src/variants/upload?create&type=VCF', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/variants/upload?create&type=VCF');
         $this->enterValue('variant_file', ROOT_PATH . '../tests/test_data_files/ShortVCFfilev1.vcf');
         $this->selectValue('hg_build', 'hg19');
         $this->selectValue('dbSNP_column', 'VariantOnGenome/Reference');
@@ -99,7 +99,7 @@ class CreateSummaryDataUploadVCFTest extends LOVDSeleniumWebdriverBaseTestCase
             $this->driver->findElement(WebDriverBy::id('lovd__progress_message'))->getText());
         $this->submitForm('Continue');
 
-        $this->assertContains('/src/submit/finish/upload/', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/submit/finish/upload/');
         $this->assertStringStartsWith('Successfully processed your submission',
             $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
 

--- a/tests/selenium_tests/shared_tests/create_summary_variant_located_within_gene_with_multiple_transcripts.php
+++ b/tests/selenium_tests/shared_tests/create_summary_variant_located_within_gene_with_multiple_transcripts.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-02-17
- * Modified    : 2020-07-23
+ * Modified    : 2020-10-08
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -69,7 +69,7 @@ class CreateSummaryVariantLocatedWithinGeneWithMultipleTranscriptsTest extends L
         $this->assertStringStartsWith('Please reconsider to submit individual data as well, as it makes the data you submit much more valuable!',
             $this->getConfirmation());
         $this->chooseOkOnNextConfirmation();
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/variants?create'));
+        $this->waitForURLEndsWith('/src/variants?create');
 
         $this->driver->findElement(WebDriverBy::xpath(
             '//table[@class="option"]//td[contains(., "A variant that is located within a gene")]'))->click();
@@ -90,7 +90,7 @@ class CreateSummaryVariantLocatedWithinGeneWithMultipleTranscriptsTest extends L
      */
     public function testCreateVariantWithinARSD ()
     {
-        $this->assertStringEndsWith('/src/variants?create&reference=Transcript&geneid=ARSD', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/variants?create&reference=Transcript&geneid=ARSD');
         // We'll be using transcript IDs 2 and 3, while 4 and 5 will be ignored.
         $this->check('ignore_00000004');
         $this->check('ignore_00000005');
@@ -132,7 +132,7 @@ class CreateSummaryVariantLocatedWithinGeneWithMultipleTranscriptsTest extends L
 
         $this->assertStringStartsWith('Successfully processed your submission',
             $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/variants/0000'));
+        $this->waitForURLContains('/src/variants/0000');
     }
 
 

--- a/tests/selenium_tests/shared_tests/curate_submission_step_by_step.php
+++ b/tests/selenium_tests/shared_tests/curate_submission_step_by_step.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-06-17
- * Modified    : 2020-06-17
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-09
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -60,10 +60,10 @@ class CurateSubmissionStepByStepTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->driver->get(ROOT_URL . '/src/configuration');
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="setup"]//a[text()="Pending"]'))->click();
 
-        $this->assertStringEndsWith('/src/view/IVD?search_var_status=%3D%22Pending%22', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/view/IVD?search_var_status=%3D%22Pending%22');
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"]//td[text()="Pending"][2]'))->click();
 
-        $this->assertContains('/src/variants/0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/variants/0000');
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"]//td[span[text()="(Pending)"]]/a'))->click();
     }
 
@@ -76,14 +76,14 @@ class CurateSubmissionStepByStepTest extends LOVDSeleniumWebdriverBaseTestCase
      */
     public function testCurateIndividual ()
     {
-        $this->assertContains('/src/individuals/0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/individuals/0000');
         $sSubmissionURL = $this->driver->getCurrentURL();
 
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="Pending"]'));
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Individuals'))->click();
         $this->driver->findElement(WebDriverBy::linkText('Publish (curate) individual entry'))->click();
 
-        $this->assertEquals($sSubmissionURL, $this->driver->getCurrentURL());
+        $this->waitForURLEquals($sSubmissionURL);
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="Public"]'));
         return $sSubmissionURL;
     }
@@ -101,12 +101,12 @@ class CurateSubmissionStepByStepTest extends LOVDSeleniumWebdriverBaseTestCase
         while ($this->isElementPresent(WebDriverBy::xpath($sLocator))) {
             $this->driver->findElement(WebDriverBy::xpath($sLocator))->click();
 
-            $this->assertContains('/src/phenotypes/0000', $this->driver->getCurrentURL());
+            $this->waitForURLContains('/src/phenotypes/0000');
             $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="Pending"]'));
             $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Phenotypes'))->click();
             $this->driver->findElement(WebDriverBy::linkText('Publish (curate) phenotype entry'))->click();
 
-            $this->assertContains('/src/phenotypes/0000', $this->driver->getCurrentURL());
+            $this->waitForURLContains('/src/phenotypes/0000');
             $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="Public"]'));
 
             $this->driver->get($sSubmissionURL);
@@ -127,13 +127,13 @@ class CurateSubmissionStepByStepTest extends LOVDSeleniumWebdriverBaseTestCase
         while ($this->isElementPresent(WebDriverBy::xpath($sLocator))) {
             $this->driver->findElement(WebDriverBy::xpath($sLocator))->click();
 
-            $this->assertContains('/src/variants/0000', $this->driver->getCurrentURL());
+            $this->waitForURLContains('/src/variants/0000');
             $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"]//td/span[text()="(Public)"]'));
             $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="Pending"]'));
             $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Variants'))->click();
             $this->driver->findElement(WebDriverBy::linkText('Publish (curate) variant entry'))->click();
 
-            $this->assertContains('/src/variants/0000', $this->driver->getCurrentURL());
+            $this->waitForURLContains('/src/variants/0000');
             $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"][1]//td/span[text()="Public"]'));
 
             $this->driver->get($sSubmissionURL);

--- a/tests/selenium_tests/shared_tests/delete_disease_IVA.php
+++ b/tests/selenium_tests/shared_tests/delete_disease_IVA.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-27
- * Modified    : 2020-06-08
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-08
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -60,7 +60,7 @@ class DeleteDiseaseIVATest extends LOVDSeleniumWebdriverBaseTestCase
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Diseases'))->click();
         $this->driver->findElement(WebDriverBy::linkText('Delete disease entry'))->click();
 
-        $this->assertRegExp('/\/src\/diseases\/[0-9]+\?delete$/', $this->driver->getCurrentURL());
+        $this->waitForURLRegExp('/\/src\/diseases\/[0-9]+\?delete$/');
         $this->enterValue('password', 'test1234');
         $this->submitForm('Delete disease information entry');
 

--- a/tests/selenium_tests/shared_tests/delete_disease_IVA_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/delete_disease_IVA_not_authorized.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-06-15
- * Modified    : 2020-06-15
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-09
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -54,10 +54,10 @@ class DeleteDiseaseIVANotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCas
     public function test ()
     {
         $this->driver->get(ROOT_URL . '/src/diseases/IVA');
+        $this->waitForURLContains('/src/diseases/0000');
         $this->assertFalse($this->isElementPresent(WebDriverBy::id('viewentryOptionsButton_Diseases')));
 
         $this->driver->get($this->driver->getCurrentURL() . '?delete');
-        $this->assertRegExp('/\/src\/diseases\/[0-9]+\?delete$/', $this->driver->getCurrentURL());
         $this->assertEquals('To access this area, you need at least Manager clearance.',
             $this->driver->findElement(WebDriverBy::cssSelector('table[class=info]'))->getText());
     }

--- a/tests/selenium_tests/shared_tests/delete_gene_IVD.php
+++ b/tests/selenium_tests/shared_tests/delete_gene_IVD.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-02-17
- * Modified    : 2020-05-26
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-08
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -61,7 +61,7 @@ class DeleteGeneIVDTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Genes'))->click();
         $this->driver->findElement(WebDriverBy::linkText('Delete gene entry'))->click();
 
-        $this->assertStringEndsWith('/src/genes/IVD?delete', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/genes/IVD?delete');
         $this->enterValue('password', 'test1234');
         $this->submitForm('Delete gene information entry');
 

--- a/tests/selenium_tests/shared_tests/enable_custom_column_for_IVA.php
+++ b/tests/selenium_tests/shared_tests/enable_custom_column_for_IVA.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-19
- * Modified    : 2020-06-05
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-07
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -65,7 +65,7 @@ class EnableCustomColumnForIVATest extends LOVDSeleniumWebdriverBaseTestCase
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Columns'))->click();
         $this->driver->findElement(WebDriverBy::linkText('Enable column'))->click();
 
-        $this->assertStringEndsWith('/src/columns/Phenotype/Age/Diagnosis?add', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/columns/Phenotype/Age/Diagnosis?add');
         $this->selectValue('target[]', 'IVA (isovaleric acidemia)');
         $this->enterValue('password', 'test1234');
         $this->submitForm('Add/enable custom data column');
@@ -73,7 +73,7 @@ class EnableCustomColumnForIVATest extends LOVDSeleniumWebdriverBaseTestCase
             $this->driver->findElement(WebDriverBy::id('lovd__progress_message_done'))->getText());
 
         // Wait for page redirect.
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/columns/Phenotype'));
+        $this->waitForURLEndsWith('/src/columns/Phenotype');
     }
 }
 ?>

--- a/tests/selenium_tests/shared_tests/enable_custom_column_for_individuals.php
+++ b/tests/selenium_tests/shared_tests/enable_custom_column_for_individuals.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-06-05
- * Modified    : 2020-05-28
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-08
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -62,14 +62,14 @@ class EnableCustomColumnForIndividualsTest extends LOVDSeleniumWebdriverBaseTest
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Columns'))->click();
         $this->driver->findElement(WebDriverBy::linkText('Enable column'))->click();
 
-        $this->assertStringEndsWith('/src/columns/Individual/Gender?add', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/columns/Individual/Gender?add');
         $this->enterValue('password', 'test1234');
         $this->submitForm('Add/enable custom data column');
         $this->assertEquals('Successfully added column "Gender"!',
             $this->driver->findElement(WebDriverBy::id('lovd__progress_message_done'))->getText());
 
         // Wait for page redirect.
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/columns/Individual'));
+        $this->waitForURLEndsWith('/src/columns/Individual');
     }
 }
 ?>

--- a/tests/selenium_tests/shared_tests/install_LOVD.php
+++ b/tests/selenium_tests/shared_tests/install_LOVD.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-03-04
- * Modified    : 2020-06-08
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-07
+ * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
@@ -87,7 +87,7 @@ class InstallLOVDTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->submitForm('Start');
 
         // Fill out Administrator form.
-        $this->assertStringEndsWith('/src/install/?step=1', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/install/?step=1');
         $this->enterValue('name', 'LOVD3 Admin');
         $this->enterValue('institute', 'Leiden University Medical Center');
         $this->enterValue('department', 'Human Genetics');
@@ -102,13 +102,13 @@ class InstallLOVDTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->submitForm('Continue');
 
         // Confirmation of account information, installing...
-        $this->assertStringEndsWith('/src/install/?step=1&sent=true', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/install/?step=1&sent=true');
         // We'll need to clean the cookies, so we'll be able to get the LOVD's ID from there.
         $aInitialSessionIDs = $this->getAllSessionIDs();
         $this->submitForm('Next');
 
         // Installation complete.
-        $this->assertStringEndsWith('/src/install/?step=2', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/install/?step=2');
         $aSessionIDsInCommon = array_intersect($this->getAllSessionIDs(), $aInitialSessionIDs);
         foreach ($aSessionIDsInCommon as $sSessionID) {
             $this->driver->manage()->deleteCookieNamed('PHPSESSID_' . $sSessionID);
@@ -126,7 +126,7 @@ class InstallLOVDTest extends LOVDSeleniumWebdriverBaseTestCase
     public function testSetSettings ()
     {
         // Fill out System Settings form.
-        $this->assertStringEndsWith('/src/install/?step=3', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/install/?step=3');
         $this->enterValue('institute', 'Leiden University Medical Center');
         $this->enterValue('email_address', 'noreply@LOVD.nl');
         $this->selectValue('refseq_build', 'hg19');
@@ -136,16 +136,15 @@ class InstallLOVDTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->submitForm('Continue');
 
         // Settings stored.
-        $this->assertStringEndsWith('/src/install/?step=3&sent=true', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/install/?step=3&sent=true');
         $this->submitForm('Next');
 
         // Done!
-        $this->assertStringEndsWith('/src/install/?step=4', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/install/?step=4');
         $this->clickButton('Continue to Setup area');
 
         // LOVD Setup Area.
-        $this->waitUntil(WebDriverExpectedCondition::titleContains("LOVD Setup"));
-        $this->assertStringEndsWith('/src/setup?newly_installed', $this->driver->getCurrentURL());
+        $this->waitForURLEndsWith('/src/setup?newly_installed');
     }
 }
 ?>

--- a/tests/selenium_tests/shared_tests/login_as_submitter.php
+++ b/tests/selenium_tests/shared_tests/login_as_submitter.php
@@ -1,4 +1,33 @@
 <?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2015-02-17
+ * Modified    : 2020-10-09
+ * For LOVD    : 3.0-25
+ *
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
 require_once 'LOVDSeleniumBaseTestCase.php';
 
 use \Facebook\WebDriver\WebDriverBy;
@@ -6,9 +35,29 @@ use \Facebook\WebDriver\WebDriverExpectedCondition;
 
 class LoginAsSubmitterTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    public function testLoginAsSubmitter()
+    protected function setUp ()
+    {
+        // Test if we have what we need for this test. If not, skip this test.
+        parent::setUp();
+        // Submitter is user ID 6.
+        $this->driver->get(ROOT_URL . '/src/users/00006');
+        $sBody = $this->driver->findElement(WebDriverBy::tagName('body'))->getText();
+        if (preg_match('/LOVD was not installed yet/', $sBody)) {
+            $this->markTestSkipped('LOVD was not installed yet.');
+        }
+        if (preg_match('/No such ID!/', $sBody)) {
+            $this->markTestSkipped('User does not exist yet.');
+        }
+    }
+
+
+
+
+
+    public function test ()
     {
         $this->logout();
         $this->login('submitter', 'test1234');
     }
 }
+?>

--- a/tests/selenium_tests/shared_tests/manage_transcripts_for_variant.php
+++ b/tests/selenium_tests/shared_tests/manage_transcripts_for_variant.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-19
- * Modified    : 2020-07-23
+ * Modified    : 2020-10-07
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -68,7 +68,7 @@ class ManageTranscriptsForVariantTest extends LOVDSeleniumWebdriverBaseTestCase
         $this->driver->get(ROOT_URL . '/src/variants/chr15');
         $this->driver->findElement(WebDriverBy::xpath('//table[@class="data"]//td[.="g.40702876G>T"]'))->click();
 
-        $this->assertContains('/src/variants/0000', $this->driver->getCurrentURL());
+        $this->waitForURLContains('/src/variants/0000');
         $this->assertEquals('No variants on transcripts found!',
             $this->driver->findElement(WebDriverBy::id('viewlistDiv_VOT_for_VOG_VE'))->getText());
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Variants'))->click();
@@ -84,7 +84,7 @@ class ManageTranscriptsForVariantTest extends LOVDSeleniumWebdriverBaseTestCase
      */
     public function testAddTranscript()
     {
-        $this->assertRegExp('/\/src\/variants\/[0-9]+\?map$/', $this->driver->getCurrentURL());
+        $this->waitForURLRegExp('/\/src\/variants\/[0-9]+\?map$/');
         $this->driver->findElement(WebDriverBy::xpath('//td[contains(text(), "NM_002225.3")]'))->click();
         $this->enterValue('password', 'test1234');
         $this->submitForm('Save transcript list');
@@ -102,7 +102,7 @@ class ManageTranscriptsForVariantTest extends LOVDSeleniumWebdriverBaseTestCase
      */
     public function testAddVOTAnnotation()
     {
-        $this->waitUntil(WebDriverExpectedCondition::urlMatches('/\/src\/variants\/[0-9]+\?edit\#[0-9]+$/'));
+        $this->waitForURLRegExp('/\/src\/variants\/[0-9]+\?edit\#[0-9]+$/');
         $this->driver->findElement(WebDriverBy::cssSelector('button.proteinChange'))->click();
         $this->waitForValueContains(WebDriverBy::xpath('//input[contains(@name, "_VariantOnTranscript/RNA")]'), 'r.');
         $this->enterValue('password', 'test1234');
@@ -121,7 +121,7 @@ class ManageTranscriptsForVariantTest extends LOVDSeleniumWebdriverBaseTestCase
      */
     public function testVerifyAddedTranscript()
     {
-        $this->waitUntil(WebDriverExpectedCondition::urlContains('/src/variants/0000'));
+        $this->waitForURLContains('/src/variants/0000');
         $this->driver->findElement(WebDriverBy::xpath('//td[text()="NM_002225.3"]'));
         $this->driver->findElement(WebDriverBy::xpath('//td[contains(text(), "p.(")]'));
         $this->driver->findElement(WebDriverBy::id('viewentryOptionsButton_Variants'))->click();
@@ -137,7 +137,7 @@ class ManageTranscriptsForVariantTest extends LOVDSeleniumWebdriverBaseTestCase
      */
     public function testRemoveTranscript()
     {
-        $this->assertRegExp('/\/src\/variants\/[0-9]+\?map$/', $this->driver->getCurrentURL());
+        $this->waitForURLRegExp('/\/src\/variants\/[0-9]+\?map$/');
         $this->driver->findElement(WebDriverBy::xpath('//tr[td[contains(text(), "NM_002225.3")]]/td/a'))->click();
         $this->assertStringStartsWith('You are about to remove the variant description of transcript NM_002225.3 from this variant.',
             $this->getConfirmation());
@@ -158,7 +158,7 @@ class ManageTranscriptsForVariantTest extends LOVDSeleniumWebdriverBaseTestCase
      */
     public function testVerifyRemovedTranscript()
     {
-        $this->waitUntil(WebDriverExpectedCondition::urlMatches('/\/src\/variants\/[0-9]+$/'));
+        $this->waitForURLRegExp('/\/src\/variants\/[0-9]+$/');
         $this->assertEquals('No variants on transcripts found!',
             $this->driver->findElement(WebDriverBy::id('viewlistDiv_VOT_for_VOG_VE'))->getText());
     }


### PR DESCRIPTION
### Fixed many small issues.

#### Changes related to MobiDetails implementation:
Small improvements to how LOVD handles the link to MobiDetails.
- Don't offer to submit a variant to MD when there is no API key configured.
- Updated `lovd_openWindow()` - it now accepts "_blank" as a window name, in which case it'll open up a new window (browser tab).
- Updated MD ajax script - open MD in a new browser tab instead of a popup.
- Added a bit more info on MobiDetails to its dialog window.

#### Changes related to testing:
Tests are regularly randomly failing because the test instance is too slow. Assertions that check for URLs then fail because that URL hasn't been reached yet. Replaced all assertions for an URL that depend on time, with a wait function that waits for the URL to match.
- Added `waitForURLContains()` for partial matching.
- Added `waitForURLEndsWith()` for suffix matching.
- Added `waitForURLRegExp()` for regular expressions.
- Added `waitForURLEquals()` for precise matching.
- Implemented these new functions in all related tests.

#### Changes related to the API:
A fatal error in the API would cause the API to return HTML. Also, improved the submission API to also allow using HGNC IDs rather than gene symbols to prevent problems with gene symbols changing.
- For the new API, make sure `FORMAT` is set to `application/json` by default.
- Don't print the HTML header, title, and footer when outputting JSON.
- Updated `lovd_displayError()` to return plain text or JSON depending on `FORMAT`.
- Updated the submission API - HGNC IDs can now also be used in place of gene symbols.
  - Also updated the error message when a given gene doesn't match the gene in the database, reminding users they can use numeric IDs. This change is only visible for API version 2 and up.
- Closes #466.

#### Other changes:
- Added new search syntax to `lovd_formatSearchExpression()`, so that the VL explains the current search value well:
  - Added `=""` and `!=""` search syntax.
  - Added `^` and `$` search syntax.