### PR TITLE
Improved the link to MobiDetails.

### DIFF
--- a/src/ajax/mobidetails.php
+++ b/src/ajax/mobidetails.php
@@ -62,11 +62,12 @@ list($sVOG, $nHGNCID) =
         ORDER BY (vot.`VariantOnTranscript/DNA` REGEXP "[*+-]") ASC,
         LEAST(
           IF(vot.position_c_start < 0, -vot.position_c_start,
-            IF(vot.position_c_start > t.position_c_cds_end, vot.position_c_start - t.position_c_cds_end,
-              IFNULL(vot.position_c_start_intron, 0))),
+            IF(vot.position_c_start > t.position_c_cds_end, vot.position_c_start - t.position_c_cds_end, 0)),
           IF(vot.position_c_end < 0, -vot.position_c_end,
-            IF(vot.position_c_end > t.position_c_cds_end, vot.position_c_end - t.position_c_cds_end,
-              IFNULL(vot.position_c_end_intron, 0)))) ASC,
+            IF(vot.position_c_end > t.position_c_cds_end, vot.position_c_end - t.position_c_cds_end, 0))) ASC,
+        LEAST(
+          IFNULL(ABS(vot.position_c_start_intron), 0),
+          IFNULL(ABS(vot.position_c_end_intron), 0)) ASC,
         COUNT(vot_count.id) DESC, t.id ASC',
         array($nID, $bIsAuthorized, STATUS_MARKED))->fetchRow();
 if (!$sVOG) {

--- a/src/ajax/mobidetails.php
+++ b/src/ajax/mobidetails.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-10-01
- * Modified    : 2020-10-12
+ * Modified    : 2020-10-19
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -59,7 +59,7 @@ list($sVOG, $nHGNCID) =
           INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot_count ON (t.id = vot_count.transcriptid)
         WHERE vog.id = ? AND (? = 1 OR vog.statusid >= ?)
         GROUP BY vog.id, vot.transcriptid
-        ORDER BY COUNT(vot_count.id) DESC, t.id ASC',
+        ORDER BY (vot.`VariantOnTranscript/DNA` REGEXP "[*+-]") ASC, COUNT(vot_count.id) DESC, t.id ASC',
         array($nID, $bIsAuthorized, STATUS_MARKED))->fetchRow();
 if (!$sVOG) {
     // Variant doesn't exist, isn't public, or has no VOT.

--- a/src/ajax/mobidetails.php
+++ b/src/ajax/mobidetails.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-10-01
- * Modified    : 2020-10-19
+ * Modified    : 2020-10-20
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -59,7 +59,15 @@ list($sVOG, $nHGNCID) =
           INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot_count ON (t.id = vot_count.transcriptid)
         WHERE vog.id = ? AND (? = 1 OR vog.statusid >= ?)
         GROUP BY vog.id, vot.transcriptid
-        ORDER BY (vot.`VariantOnTranscript/DNA` REGEXP "[*+-]") ASC, COUNT(vot_count.id) DESC, t.id ASC',
+        ORDER BY (vot.`VariantOnTranscript/DNA` REGEXP "[*+-]") ASC,
+        LEAST(
+          IF(vot.position_c_start < 0, -vot.position_c_start,
+            IF(vot.position_c_start > t.position_c_cds_end, vot.position_c_start - t.position_c_cds_end,
+              IFNULL(vot.position_c_start_intron, 0))),
+          IF(vot.position_c_end < 0, -vot.position_c_end,
+            IF(vot.position_c_end > t.position_c_cds_end, vot.position_c_end - t.position_c_cds_end,
+              IFNULL(vot.position_c_end_intron, 0)))) ASC,
+        COUNT(vot_count.id) DESC, t.id ASC',
         array($nID, $bIsAuthorized, STATUS_MARKED))->fetchRow();
 if (!$sVOG) {
     // Variant doesn't exist, isn't public, or has no VOT.

--- a/src/ajax/mobidetails.php
+++ b/src/ajax/mobidetails.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-10-01
- * Modified    : 2020-10-06
+ * Modified    : 2020-10-12
  * For LOVD    : 3.0-25
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -161,9 +161,9 @@ if (ACTION == 'confirm' && POST) {
     // Send variant to MobiDetails. This can take a while.
     $aJSON = false;
     $aJSONResponse = lovd_php_file(
-        'https://mobidetails.iurc.montp.inserm.fr/MD/api/variant/create',
+        'https://mobidetails.iurc.montp.inserm.fr/MD/api/variant/create_g',
         false,
-        'caller=cli&variant_chgvs=' . rawurlencode($sVOT) . '&api_key=' . $_CONF['md_apikey'],
+        'caller=cli&variant_ghgvs=' . rawurlencode($sVOG) . '&gene_hgnc=' . strchr($sVOT, ':', true) . '&api_key=' . $_CONF['md_apikey'],
         array(
             'Accept: application/json',
         ));

--- a/src/ajax/mobidetails.php
+++ b/src/ajax/mobidetails.php
@@ -47,14 +47,15 @@ $nID = sprintf('%0' . $_SETT['objectid_length']['variants'] . 'd', $_PE[2]);
 //  information when people try random IDs!
 // lovd_isAuthorized() can produce false, 0 or 1. Accept 0 or 1.
 $bIsAuthorized = (lovd_isAuthorized('variant', $nID, false) !== false);
-list($sVOG, $sVOT) =
+list($sVOG, $nHGNCID) =
     $_DB->query('
         SELECT CONCAT(c.`' . $_CONF['refseq_build'] . '_id_ncbi`, ":", vog.`VariantOnGenome/DNA`) AS VOG_DNA,
-            CONCAT(t.id_ncbi, ":", vot.`VariantOnTranscript/DNA`) AS VOT_DNA
+            g.id_hgnc AS HGNC
         FROM ' . TABLE_VARIANTS . ' AS vog
           INNER JOIN ' . TABLE_CHROMOSOMES . ' AS c ON (vog.chromosome = c.name)
           INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vog.id = vot.id)
           INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id)
+          INNER JOIN ' . TABLE_GENES . ' AS g ON (t.geneid = g.id)
           INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot_count ON (t.id = vot_count.transcriptid)
         WHERE vog.id = ? AND (? = 1 OR vog.statusid >= ?)
         GROUP BY vog.id, vot.transcriptid
@@ -163,7 +164,7 @@ if (ACTION == 'confirm' && POST) {
     $aJSONResponse = lovd_php_file(
         'https://mobidetails.iurc.montp.inserm.fr/MD/api/variant/create_g',
         false,
-        'caller=cli&variant_ghgvs=' . rawurlencode($sVOG) . '&gene_hgnc=' . strchr($sVOT, ':', true) . '&api_key=' . $_CONF['md_apikey'],
+        'caller=cli&variant_ghgvs=' . rawurlencode($sVOG) . '&gene_hgnc=' . $nHGNCID . '&api_key=' . $_CONF['md_apikey'],
         array(
             'Accept: application/json',
         ));

--- a/src/variants.php
+++ b/src/variants.php
@@ -467,6 +467,8 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         $aNavigation['javascript:lovd_openWindow(\'http://genome.ucsc.edu/cgi-bin/hgTracks?clade=mammal&amp;org=Human&amp;db=' . $_CONF['refseq_build'] . '&amp;position=chr' . $zData['chromosome'] . ':' . ($zData['position_g_start'] - $lMargin) . '-' . ($zData['position_g_end'] + $lMargin) . '&amp;width=800&amp;ruler=full&amp;ccdsGene=full\', \'variant_UCSC\', 1000, 500);'] = array('menu_magnifying_glass.png', 'View location in UCSC genome browser', 1);
         $sURLEnsembl = 'http://' . ($_CONF['refseq_build'] == 'hg18'? 'may2009.archive' : ($_CONF['refseq_build'] == 'hg19'? 'grch37' : 'www')) . '.ensembl.org/Homo_sapiens/Location/View?r=' . $zData['chromosome'] . ':' . ($zData['position_g_start'] - $lMargin) . '-' . ($zData['position_g_end'] + $lMargin);
         $aNavigation['javascript:lovd_openWindow(\'' . $sURLEnsembl . '\', \'variant_Ensembl\', 1000, 500);'] = array('menu_magnifying_glass.png', 'View location in Ensembl genome browser', 1);
+        // Link to MobiDetails, but only if this variant has a gene. We'll know that only a few lines later when we load the VOT object.
+        // To prevent yet another query, handled this with JS further below.
         $aNavigation['javascript:$.post(\'ajax/mobidetails.php/' . $nID . '?check\').fail(function(){alert(\'Error while preparing to check MobiDetails.\');});'] = array('menu_mobidetails.png', 'View variant in MobiDetails', 1);
     }
     lovd_showJGNavigation($aNavigation, 'Variants');
@@ -510,6 +512,14 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
             // If there is only one row of VOT, then trigger click on the first row so that the details of that transcript is displayed.
             if ($('#viewlistTable_<?php echo $sViewListID; ?> tr').length === 2) { // Table heading + first row.
                 $('#viewlistTable_<?php echo $sViewListID; ?> tr')[1].click();
+            }
+
+            // Disable link to MD when there is no VOT.
+            if (<?php echo count($_DATA->aTranscripts); ?> < 1) {
+                // Add disabled class.
+                sLink = $('#viewentryMenu_Variants').children(':contains("MobiDetails")').children().html();
+                $('#viewentryMenu_Variants').children(':contains("MobiDetails")').addClass('disabled');
+                $('#viewentryMenu_Variants').children(':contains("MobiDetails")').html(sLink);
             }
         });
 


### PR DESCRIPTION
Improved the link to MobiDetails.
- Now that MobiDetails supports sending hg19 variants, better always send the genomic variant.
- Use the HCNC ID rather than the transcript ID, to prevent issues with certain transcripts and different versions.
- Disabled the link to MD for variants without any transcripts mapped to it.
- While determining which gene to send to MD, prioritize locations in the CDS rather than introns or UTRs, then measure the distance of the variant to any CDS and pick the lowest distance.

Closes #471.