### PR TITLE
Small changes to the Variant ID fields

### DIFF
--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-15
- * Modified    : 2020-09-10
- * For LOVD    : 3.0-25
+ * Modified    : 2020-10-26
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -617,6 +617,10 @@ class LOVD_CustomViewList extends LOVD_Object
                     // The fixed columns.
                     $this->aColumnsViewList = array_merge($this->aColumnsViewList,
                          array(
+                                'votid' => array(
+                                        'auth' => LEVEL_CURATOR,
+                                        'view' => (!isset($nKeyVOT) || $nKeyVOT !== 0? false : array('Variant ID', 70, 'style="text-align : right;"')),
+                                        'db'   => array('vot.id', 'ASC', true)),
                                 'transcriptid' => array(
                                         'view' => false,
                                         'db'   => array('vot.transcriptid', 'ASC', true)),
@@ -794,6 +798,9 @@ class LOVD_CustomViewList extends LOVD_Object
                     break;
             }
         }
+
+        // Unset columns with a configured 'auth' key for lower level users.
+        $this->unsetColsByAuthLevel();
 
 
 

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2020-06-08
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-26
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -142,7 +142,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
                                     'view' => false,
                                     'db'   => array('screeningids', 'ASC', 'TEXT')),
                         'id_' => array(
-                                    'view' => array('Variant ID', 90, 'style="text-align : right;"'),
+                                    'view' => array('Variant ID', 75, 'style="text-align : right;"'),
                                     'db'   => array('vog.id', 'ASC', true)),
                         'effect' => array(
                                     'view' => array('Effect', 70),

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -142,6 +142,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
                                     'view' => false,
                                     'db'   => array('screeningids', 'ASC', 'TEXT')),
                         'id_' => array(
+                                    'auth' => LEVEL_CURATOR,
                                     'view' => array('Variant ID', 75, 'style="text-align : right;"'),
                                     'db'   => array('vog.id', 'ASC', true)),
                         'effect' => array(

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-12
- * Modified    : 2020-06-08
- * For LOVD    : 3.0-24
+ * Modified    : 2020-10-26
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -137,7 +137,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
                                     'view' => array('Transcript', 120),
                                     'db'   => array('t.id_ncbi', 'ASC', true)),
                         'id_' => array(
-                                    'view' => array('Variant ID', 90),
+                                    'view' => array('Variant ID', 75),
                                     'db'   => array('vot.id', 'ASC', true)),
                         'effect' => array(
                                     'view' => array('Affects function', 70),

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -131,7 +131,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
                                     'view' => array('Gene', 70),
                                     'db'   => array('t.geneid', 'ASC', true)),
                         'transcriptid' => array(
-                                    'view' => array('Transcript ID', 90),
+                                    'view' => array('Transcript ID', 50),
                                     'db'   => array('vot.transcriptid', 'ASC', true)),
                         'id_ncbi' => array(
                                     'view' => array('Transcript', 120),

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -137,6 +137,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
                                     'view' => array('Transcript', 120),
                                     'db'   => array('t.id_ncbi', 'ASC', true)),
                         'id_' => array(
+                                    'auth' => LEVEL_CURATOR,
                                     'view' => array('Variant ID', 75),
                                     'db'   => array('vot.id', 'ASC', true)),
                         'effect' => array(

--- a/src/class/object_transcripts.php
+++ b/src/class/object_transcripts.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2019-10-01
- * For LOVD    : 3.0-22
+ * Modified    : 2020-10-26
+ * For LOVD    : 3.0-26
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -124,7 +124,7 @@ class LOVD_Transcript extends LOVD_Object
         $this->aColumnsViewList =
             array(
                 'id_' => array(
-                    'view' => array('ID', 70, 'style="text-align : right;"'),
+                    'view' => array('ID', 50, 'style="text-align : right;"'),
                     'db'   => array('t.id', 'ASC', true)),
                 'chromosome' => array(
                     'view' => array('Chr', 40),

--- a/src/transcripts.php
+++ b/src/transcripts.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2020-08-12
- * For LOVD    : 3.0-25
+ * Modified    : 2020-10-26
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -113,7 +113,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     $_DATA->sSortDefault = 'VariantOnTranscript/DNA';
     $_DATA->setRowLink('VOT_for_T_VE', 'javascript:window.location.href=\'' . lovd_getInstallURL() . 'variants/{{ID}}#{{transcriptid}}\'; return false');
     $aVLOptions = array(
-        'cols_to_skip' => array('geneid', 'transcriptid', 'id_ncbi', 'id_'),
+        'cols_to_skip' => array('geneid', 'transcriptid', 'id_ncbi'),
     );
     $_DATA->viewList('VOT_for_T_VE', $aVLOptions);
 


### PR DESCRIPTION
Small changes to the Variant ID fields:
- Resized the variant ID columns a bit, they could be made smaller.
- Resized the transcript ID columns a bit, they could be made smaller.
- All variant overviews now show the variant IDs, but only to Curators and up.
  - Simple downloads could then more easily be used for imports, although modifications are always required to alert users of the dangers of update-imports.