### PR TITLE
Fixed the variant ID field configuration

### DIFF
--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -110,26 +110,27 @@ class LOVD_GenomeVariant extends LOVD_Custom
 
         // List of columns and (default?) order for viewing an entry.
         $this->aColumnsViewEntry = array_merge(
-                 array(
-                        'individualid_' => 'Individual ID',
-                        'chromosome' => 'Chromosome',
-                        'allele_' => 'Allele',
-                        'effect_reported' => 'Affects function (as reported)',
-                        'effect_concluded' => 'Affects function (by curator)',
-                        'curation_status_' => 'Curation status',
-                        'confirmation_status_' => 'Confirmation status',
-                      ),
-                 $this->buildViewEntry(),
-                 array(
-                        'mapping_flags_' => array('Automatic mapping', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'average_frequency_' => 'Average frequency (large NGS studies)',
-                        'owned_by_' => 'Owner',
-                        'status' => array('Variant data status', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'created_by_' => array('Created by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'created_date_' => array('Date created', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'edited_by_' => array('Last edited by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'edited_date_' => array('Date last edited', $_SETT['user_level_settings']['see_nonpublic_data']),
-                      ));
+            array(
+                'individualid_' => 'Individual ID',
+                'chromosome' => 'Chromosome',
+                'allele_' => 'Allele',
+                'effect_reported' => 'Affects function (as reported)',
+                'effect_concluded' => 'Affects function (by curator)',
+                'curation_status_' => 'Curation status',
+                'confirmation_status_' => 'Confirmation status',
+            ),
+            $this->buildViewEntry(),
+            array(
+                'mapping_flags_' => array('Automatic mapping', $_SETT['user_level_settings']['see_nonpublic_data']),
+                'average_frequency_' => 'Average frequency (large NGS studies)',
+                'owned_by_' => 'Owner',
+                'status' => array('Variant data status', $_SETT['user_level_settings']['see_nonpublic_data']),
+                'created_by_' => array('Created by', $_SETT['user_level_settings']['see_nonpublic_data']),
+                'created_date_' => array('Date created', $_SETT['user_level_settings']['see_nonpublic_data']),
+                'edited_by_' => array('Last edited by', $_SETT['user_level_settings']['see_nonpublic_data']),
+                'edited_date_' => array('Date last edited', $_SETT['user_level_settings']['see_nonpublic_data']),
+            )
+        );
         if (!LOVD_plus) {
             unset($this->aColumnsViewEntry['curation_status_']);
             unset($this->aColumnsViewEntry['confirmation_status_']);
@@ -137,56 +138,59 @@ class LOVD_GenomeVariant extends LOVD_Custom
 
         // List of columns and (default?) order for viewing a list of entries.
         $this->aColumnsViewList = array_merge(
-                 array(
-                     'id' => array(
-                         'view' => false,
-                         'db'   => array('vog.id', 'ASC', true)),
-                        'screeningids' => array(
-                                    'view' => false,
-                                    'db'   => array('screeningids', 'ASC', 'TEXT')),
-                        'id_' => array(
-                                    'auth' => LEVEL_CURATOR,
-                                    'view' => array('Variant ID', 75, 'style="text-align : right;"'),
-                                    'db'   => array('vog.id', 'ASC', true)),
-                        'effect' => array(
-                                    'view' => array('Effect', 70),
-                                    'db'   => array('e.name', 'ASC', true),
-                                    'legend' => array('The variant\'s effect on the function of the gene/protein, displayed in the format \'R/C\'. R is the value ' . (LOVD_plus? 'initially reported and C is the value finally concluded;' : 'reported by the source (publication, submitter) and C is the value concluded by the curator;') . ' values ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
-                                                      'The variant\'s effect on the function of the gene/protein, displayed in the format \'R/C\'. R is the value ' . (LOVD_plus? 'initially reported and C is the value finally concluded.' : 'reported by the source (publication, submitter) and this classification may vary between records. C is the value concluded by the curator. Note that in some database the curator uses Summary records to give details on the classification of the variant.') . 'Values used: \'+\' indicating the variant affects function, \'+?\' probably affects function, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect was not classified.')),
-                        'allele_' => array(
-                                    'view' => array('Allele', 120),
-                                    'db'   => array('a.name', 'ASC', true),
-                                    'legend' => array('On which allele is the variant located? Does not necessarily imply inheritance!',
-                                                      'On which allele is the variant located? Does not necessarily imply inheritance! \'Paternal\' (confirmed or inferred), \'Maternal\' (confirmed or inferred), \'Parent #1\' or #2 for compound heterozygosity without having screened the parents, \'Unknown\' for heterozygosity without having screened the parents, \'Both\' for homozygozity.')),
-                        'chromosome' => array(
-                                    'view' => array('Chr', 50),
-                                    'db'   => array('vog.chromosome', 'ASC', true)),
-                        'position_g_start' => array(
-                                    'view' => false,
-                                    'db'   => array('vog.position_g_start', 'ASC', true)),
-                        'position_g_end' => array(
-                                     'view' => false,
-                                    'db'   => array('vog.position_g_end', 'ASC', true)),
-                      ),
-                 $this->buildViewList(),
-                 array(
-                        'owned_by_' => array(
-                                    'view' => array('Owner', 160),
-                                    'db'   => array('uo.name', 'ASC', true)),
-                        'owner_countryid' => array(
-                                    'view' => false,
-                                    'db'   => array('uo.countryid', 'ASC', true)),
-                        'status' => array(
-                                    'view' => array('Status', 70),
-                                    'db'   => array('ds.name', false, true),
-                                    'auth' => $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'created_by' => array(
-                                    'view' => false,
-                                    'db'   => array('vog.created_by', false, true)),
-                        'created_date' => array(
-                                    'view' => false,
-                                    'db'   => array('vog.created_date', 'ASC', true)),
-                      ));
+            array(
+                'id' => array(
+                    'view' => false,
+                    'db'   => array('vog.id', 'ASC', true)),
+                'screeningids' => array(
+                    'view' => false,
+                    'db'   => array('screeningids', 'ASC', 'TEXT')),
+                'id_' => array(
+                    'auth' => LEVEL_CURATOR,
+                    'view' => array('Variant ID', 75, 'style="text-align : right;"'),
+                    'db'   => array('vog.id', 'ASC', true)),
+                'effect' => array(
+                    'view' => array('Effect', 70),
+                    'db'   => array('e.name', 'ASC', true),
+                    'legend' => array(
+                        'The variant\'s effect on the function of the gene/protein, displayed in the format \'R/C\'. R is the value ' . (LOVD_plus? 'initially reported and C is the value finally concluded;' : 'reported by the source (publication, submitter) and C is the value concluded by the curator;') . ' values ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
+                        'The variant\'s effect on the function of the gene/protein, displayed in the format \'R/C\'. R is the value ' . (LOVD_plus? 'initially reported and C is the value finally concluded.' : 'reported by the source (publication, submitter) and this classification may vary between records. C is the value concluded by the curator. Note that in some database the curator uses Summary records to give details on the classification of the variant.') . 'Values used: \'+\' indicating the variant affects function, \'+?\' probably affects function, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect was not classified.')),
+                'allele_' => array(
+                    'view' => array('Allele', 120),
+                    'db'   => array('a.name', 'ASC', true),
+                    'legend' => array(
+                        'On which allele is the variant located? Does not necessarily imply inheritance!',
+                        'On which allele is the variant located? Does not necessarily imply inheritance! \'Paternal\' (confirmed or inferred), \'Maternal\' (confirmed or inferred), \'Parent #1\' or #2 for compound heterozygosity without having screened the parents, \'Unknown\' for heterozygosity without having screened the parents, \'Both\' for homozygozity.')),
+                'chromosome' => array(
+                    'view' => array('Chr', 50),
+                    'db'   => array('vog.chromosome', 'ASC', true)),
+                'position_g_start' => array(
+                    'view' => false,
+                    'db'   => array('vog.position_g_start', 'ASC', true)),
+                'position_g_end' => array(
+                    'view' => false,
+                    'db'   => array('vog.position_g_end', 'ASC', true)),
+            ),
+            $this->buildViewList(),
+            array(
+                'owned_by_' => array(
+                    'view' => array('Owner', 160),
+                    'db'   => array('uo.name', 'ASC', true)),
+                'owner_countryid' => array(
+                    'view' => false,
+                    'db'   => array('uo.countryid', 'ASC', true)),
+                'status' => array(
+                    'view' => array('Status', 70),
+                    'db'   => array('ds.name', false, true),
+                    'auth' => $_SETT['user_level_settings']['see_nonpublic_data']),
+                'created_by' => array(
+                    'view' => false,
+                    'db'   => array('vog.created_by', false, true)),
+                'created_date' => array(
+                    'view' => false,
+                    'db'   => array('vog.created_date', 'ASC', true)),
+            )
+        );
 
         $this->sSortDefault = 'VariantOnGenome/DNA';
 

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2020-10-26
+ * Modified    : 2020-10-27
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -138,6 +138,9 @@ class LOVD_GenomeVariant extends LOVD_Custom
         // List of columns and (default?) order for viewing a list of entries.
         $this->aColumnsViewList = array_merge(
                  array(
+                     'id' => array(
+                         'view' => false,
+                         'db'   => array('vog.id', 'ASC', true)),
                         'screeningids' => array(
                                     'view' => false,
                                     'db'   => array('screeningids', 'ASC', 'TEXT')),

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -103,19 +103,21 @@ class LOVD_TranscriptVariant extends LOVD_Custom
 
         // List of columns and (default?) order for viewing an entry.
         $this->aColumnsViewEntry = array_merge(
-                 array(
-                        'geneid_' => 'Gene',
-                        'id_ncbi_' => 'Transcript ID',
-                        'effect_reported' => 'Affects function (as reported)',
-                        'effect_concluded' => 'Affects function (by curator)',
-                      ),
-                 (!LOVD_plus || !lovd_verifyInstance('mgha', false)? array() :
-                     // MGHA entry for the Genomizer link in the VOT ViewEntry.
-                     array(
-                         'genomizer_url_' => 'Genomizer',
-                         'clinvar_' => "ClinVar Description (dbNSFP)"
-                     )),
-                 $this->buildViewEntry());
+            array(
+                'geneid_' => 'Gene',
+                'id_ncbi_' => 'Transcript ID',
+                'effect_reported' => 'Affects function (as reported)',
+                'effect_concluded' => 'Affects function (by curator)',
+            ),
+            (!LOVD_plus || !lovd_verifyInstance('mgha', false)? array() :
+                // MGHA entry for the Genomizer link in the VOT ViewEntry.
+                array(
+                    'genomizer_url_' => 'Genomizer',
+                    'clinvar_' => "ClinVar Description (dbNSFP)"
+                )
+            ),
+            $this->buildViewEntry()
+        );
         if (LOVD_plus) {
             unset($this->aColumnsViewEntry['effect_reported']);
             unset($this->aColumnsViewEntry['effect_concluded']);
@@ -126,36 +128,38 @@ class LOVD_TranscriptVariant extends LOVD_Custom
 
         // List of columns and (default?) order for viewing a list of entries.
         $this->aColumnsViewList = array_merge(
-                 array(
-                     'id' => array(
-                         'view' => false,
-                         'db'   => array('vot.id', 'ASC', true)),
-                        'geneid' => array(
-                                    'view' => array('Gene', 70),
-                                    'db'   => array('t.geneid', 'ASC', true)),
-                        'transcriptid' => array(
-                                    'view' => array('Transcript ID', 50),
-                                    'db'   => array('vot.transcriptid', 'ASC', true)),
-                        'id_ncbi' => array(
-                                    'view' => array('Transcript', 120),
-                                    'db'   => array('t.id_ncbi', 'ASC', true)),
-                        'id_' => array(
-                                    'auth' => LEVEL_CURATOR,
-                                    'view' => array('Variant ID', 75),
-                                    'db'   => array('vot.id', 'ASC', true)),
-                        'effect' => array(
-                                    'view' => array('Affects function', 70),
-                                    'db'   => array('e.name', 'ASC', true),
-                                    'legend' => array('The variant\'s effect on the function of the gene/protein, displayed in the format \'R/C\'. R is the value ' . (LOVD_plus? 'initially reported and C is the value finally concluded;' : 'reported by the source (publication, submitter) and C is the value concluded by the curator;') . ' values ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
-                                        'The variant\'s effect on the function of the gene/protein, displayed in the format \'R/C\'. R is the value ' . (LOVD_plus? 'initially reported and C is the value finally concluded.' : 'reported by the source (publication, submitter) and this classification may vary between records. C is the value concluded by the curator. Note that in some database the curator uses Summary records to give details on the classification of the variant.') . 'Values used: \'+\' indicating the variant affects function, \'+?\' probably affects function, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect was not classified.')),
-                      ),
-                 $this->buildViewList(),
-                 array(
-                        'status' => array(
-                                    'view' => array('Status', 70),
-                                    'db'   => array('ds.name', false, true),
-                                    'auth' => $_SETT['user_level_settings']['see_nonpublic_data']),
-                      ));
+            array(
+                'id' => array(
+                    'view' => false,
+                    'db'   => array('vot.id', 'ASC', true)),
+                'geneid' => array(
+                    'view' => array('Gene', 70),
+                    'db'   => array('t.geneid', 'ASC', true)),
+                'transcriptid' => array(
+                    'view' => array('Transcript ID', 50),
+                    'db'   => array('vot.transcriptid', 'ASC', true)),
+                'id_ncbi' => array(
+                    'view' => array('Transcript', 120),
+                    'db'   => array('t.id_ncbi', 'ASC', true)),
+                'id_' => array(
+                    'auth' => LEVEL_CURATOR,
+                    'view' => array('Variant ID', 75),
+                    'db'   => array('vot.id', 'ASC', true)),
+                'effect' => array(
+                    'view' => array('Affects function', 70),
+                    'db'   => array('e.name', 'ASC', true),
+                    'legend' => array(
+                        'The variant\'s effect on the function of the gene/protein, displayed in the format \'R/C\'. R is the value ' . (LOVD_plus? 'initially reported and C is the value finally concluded;' : 'reported by the source (publication, submitter) and C is the value concluded by the curator;') . ' values ranging from \'+\' (variant affects function) to \'-\' (does not affect function).',
+                        'The variant\'s effect on the function of the gene/protein, displayed in the format \'R/C\'. R is the value ' . (LOVD_plus? 'initially reported and C is the value finally concluded.' : 'reported by the source (publication, submitter) and this classification may vary between records. C is the value concluded by the curator. Note that in some database the curator uses Summary records to give details on the classification of the variant.') . 'Values used: \'+\' indicating the variant affects function, \'+?\' probably affects function, \'-\' does not affect function, \'-?\' probably does not affect function, \'?\' effect unknown, \'.\' effect was not classified.')),
+            ),
+            $this->buildViewList(),
+            array(
+                'status' => array(
+                    'view' => array('Status', 70),
+                    'db'   => array('ds.name', false, true),
+                    'auth' => $_SETT['user_level_settings']['see_nonpublic_data']),
+            )
+        );
         if (LOVD_plus) {
             unset($this->aColumnsViewList['effect']);
         }

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -127,6 +127,9 @@ class LOVD_TranscriptVariant extends LOVD_Custom
         // List of columns and (default?) order for viewing a list of entries.
         $this->aColumnsViewList = array_merge(
                  array(
+                     'id' => array(
+                         'view' => false,
+                         'db'   => array('vot.id', 'ASC', true)),
                         'geneid' => array(
                                     'view' => array('Gene', 70),
                                     'db'   => array('t.geneid', 'ASC', true)),

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2020-10-12
- * For LOVD    : 3.0-25
+ * Modified    : 2020-10-27
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -678,7 +678,11 @@ class LOVD_Object
         }
 
         // Handle simple setting arrays differently.
-        if (!$nNesting && current(array_unique(array_values($aData))) == 1) {
+        // Added SORT_REGULAR to prevent array_unique() to transform nested
+        //  arrays to string to make the comparison (as it does by default).
+        //  Adding SORT_REGULAR makes it actually compare the arrays instead of
+        //  comparing "Array" and then taking the first only.
+        if (!$nNesting && current(array_unique(array_values($aData), SORT_REGULAR)) == 1) {
             // This is a simple array with just settings that are turned on.
             return implode('<BR>', array_map(function ($sKey) {
                 return ucfirst(str_replace('_', ' ', $sKey)) . ' <IMG src="gfx/mark_1.png" alt="" width="11" height="11">';

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2020-08-27
- * For LOVD    : 3.0-25
+ * Modified    : 2020-10-27
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -639,7 +639,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
     $_DATA = new LOVD_GenomeVariant();
     $_DATA->setRowLink('Screenings_' . $nID . '_confirmVariants', 'javascript:$(\'#check_{{ID}}\').trigger(\'click\'); return false;');
     $aVLOptions = array(
-        'cols_to_skip' => array('id_', 'chromosome'),
         'track_history' => false,
         'show_options' => true,
     );
@@ -794,11 +793,10 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'removeVariants') {
 
     $_GET['page_size'] = 10;
     $_GET['search_screeningids'] = $nID;
-    $_GET['search_id_'] = (count($aInvalidVariants)? '!' . implode(' !', $aInvalidVariants) : '');
+    $_GET['search_id'] = (count($aInvalidVariants)? '!' . implode(' !', $aInvalidVariants) : '');
     require ROOT_PATH . 'class/object_genome_variants.php';
     $_DATA = new LOVD_GenomeVariant();
     $aVLOptions = array(
-        'cols_to_skip' => array('id_', 'screeningids', 'chromosome'),
         'track_history' => false,
         'show_options' => true,
     );

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2020-10-01
- * For LOVD    : 3.0-25
+ * Modified    : 2020-10-26
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -477,7 +477,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
           '      <DIV id="viewentryDiv">' . "\n" .
           '      </DIV>' . "\n\n");
 
-    $_GET['search_id_'] = $nID;
+    $_GET['search_id'] = $nID;
     print('      <BR><BR>' . "\n\n");
     $_T->printTitle('Variant on transcripts', 'H4');
     require ROOT_PATH . 'class/object_transcript_variants.php';
@@ -500,7 +500,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         });
     }
     $_DATA->viewList($sViewListID, $aVLOptions);
-    unset($_GET['search_id_']);
+    unset($_GET['search_id']);
 ?>
 
       <SCRIPT type="text/javascript">


### PR DESCRIPTION
Fixed the variant ID field configuration.
- Fixed bug; The recent change unsetting the VOT `id_` field broke filtering on VOT ID for the VOG VE, breaking large databases.
  - Standardizing the use of the `id` vs `id_` field. The `id` field will now always be present, and always be hidden, but usable for filtering.
- Added the definition of an `id` field for the VOG object that is always hidden and used for filtering.
  - Removed the no longer necessary `cols_to_remove` setting for the VOG VLs in `screenings.php`.
- Standardized indentation for the VOG and VOT objects.
- Fixed bug; `formatArrayToTable()` was running `array_unique()` on an array with possibly nested arrays.
  - This doesn't work as `array_unique()` by default converts everything to strings, after which a notice is thrown and it compares "Array" with "Array", dropping all nested arrays except the first one.