### PR TITLE
Improved the imported frequencies.

### DIFF
--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2020-11-02
+ * Modified    : 2020-11-05
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -554,7 +554,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
             } elseif ($zData['average_frequency'] === '0') {
                 $zData['average_frequency_'] = 'Variant not found in online data sets';
             } else {
-                $zData['average_frequency_'] = round($zData['average_frequency'], 5) . ' <SPAN style="float: right"><A href="http://databases.lovd.nl/whole_genome/variants/chr' . $zData['chromosome'] . '?search_VariantOnGenome/DNA=' . $zData['VariantOnGenome/DNA'] . '" title="" target="_blank">View details</A></SPAN>';
+                $zData['average_frequency_'] = round($zData['average_frequency'], 5) . ' <SPAN style="float: right"><A href="https://gnomad.broadinstitute.org/region/' . $zData['chromosome'] . '-' . $zData['position_g_start'] . '-' . $zData['position_g_end'] . '?dataset=gnomad_r2_1" target="_blank">View details</A></SPAN>';
             }
             if (LOVD_plus && !empty($zData['curation_status_'])) {
                 // Add a link to the curation status to show the curation status history for this variant.

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-11-02
+ * Modified    : 2020-11-05
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -174,7 +174,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-25',
+                            'version' => '3.0-25b',
                           ),
                 'user_levels' =>
                      array(

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2020-09-30
- * For LOVD    : 3.0-25
+ * Modified    : 2020-11-05
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -793,6 +793,9 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                  ),
                  '3.0-24c' => array(
                      'ALTER TABLE ' . TABLE_CONFIG . ' ADD COLUMN md_apikey VARCHAR(50) NOT NULL DEFAULT "" AFTER mutalyzer_soap_url',
+                 ),
+                 '3.0-25b' => array(
+                     'UPDATE ' . TABLE_VARIANTS . ' SET average_frequency = NULL',
                  ),
              );
 

--- a/src/scripts/fetch_frequencies.php
+++ b/src/scripts/fetch_frequencies.php
@@ -4,11 +4,11 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2013-08-11
- * Modified    : 2013-10-29
- * For LOVD    : 3.0-09
+ * Modified    : 2020-11-05
+ * For LOVD    : 3.0-26
  *
- * Copyright   : 2004-2013 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -35,8 +35,8 @@ require ROOT_PATH . 'inc-init.php';
 session_write_close();
 
 $_T->printHeader(false); // We'll use the "clean" template.
-$nLimit = 25; // For how many variants at the same time are we requesting the frequencies? 25 is the max allowed by the WGS API.
-$sURL = 'http://databases.lovd.nl/whole_genome/api/rest/get_frequencies?format=text/json'; // URL to request data from (GET (variant=chr;pos_start;pos_end;DNA) or POST (JSON)).
+$nLimit = 25; // For how many variants at the same time are we requesting the frequencies? 25 is the max allowed by the remote API.
+$sURL = 'https://gnomad.lovd.nl/api/rest/get_frequencies?format=application/json'; // URL to request data from (GET (variant=chr;pos_start;pos_end;DNA) or POST (JSON)).
 
 
 


### PR DESCRIPTION
Improved the imported frequencies.
- The variant field "Average frequency (large NGS studies)" used to be imported from a copy we obtained of the Exome Variant Server (EVS). Switching to GnomAD frequencies now, which we imported into [a separate LOVD instance](https://gnomad.lovd.nl/).
- Empty the `average_frequency` field, so we can update it with new data.
- Updated the URL from which the frequencies will be collected.
- Link directly to GnomAD to see the results, instead of our GnomAD LOVD instance.