### PR TITLE
Removed Conversion variant type.

### DIFF
--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-11-02
+ * Modified    : 2020-11-17
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1054,6 +1054,11 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
 
         if ($bCheckHGVS) {
             // This was quite a lossy check, sufficient to get positions and type, but we need a HGVS check now.
+            if ($sVariant == 'con') {
+                // Conversion has been removed in favor of delins.
+                // See: http://varnomen.hgvs.org/bg-material/consultation/svd-wg009/
+                return false;
+            }
             if (strpos($sVariant, '>') !== false && $sEndPosition) {
                 // Substitutions are not allowed to have a range.
                 return false;
@@ -1153,6 +1158,11 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
 
         if ($bCheckHGVS) {
             // This was quite a lossy check, sufficient to get positions and type, but we need a HGVS check now.
+            if ($sVariant == 'con') {
+                // Conversion has been removed in favor of delins.
+                // See: http://varnomen.hgvs.org/bg-material/consultation/svd-wg009/
+                return false;
+            }
             if ($sSuffix) {
                 // Suffix not allowed in some cases.
                 if (in_array($sVariant, array('del', 'dup', 'inv')) || substr($sVariant, 0, 1) == '|') {

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-11-17
+ * Modified    : 2020-11-18
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1069,15 +1069,15 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 if (strpos($sVariant, '>') !== false || $sVariant == 'inv' || substr($sVariant, 0, 1) == '|' || $sVariant == '=') {
                     // No suffix allowed for substitutions, inversions, methylation or WT calls.
                     return false;
-                } elseif ($sVariant == 'con' && !preg_match('/^([NX][CMR]_[0-9]{6}\.[0-9]+:)?([0-9]+|[0-9]+[+-][0-9]+)_([0-9]+|[0-9]+[+-][0-9]+)$/', $sSuffix)) {
-                    // Gene conversions require position fields.
-                    return false;
                 } elseif (in_array($sVariant, array('del', 'dup')) && !preg_match('/^[ACTG]+$/', $sSuffix)) {
                     // Only allow bases as suffix for deletions and duplications.
                     return false;
-                } elseif ($sVariant == 'delins' && !preg_match('/^([ACTG]+|\([0-9]+\))$/', $sSuffix)) {
-                    // Only allow bases or length as suffix for deletion-insertion events.
-                    // Position ranges for deletion-insertions are actually conversions.
+                } elseif ($sVariant == 'delins'
+                    && !preg_match('/^([ACTG]+|\([0-9]+\))$/', $sSuffix)
+                    && !preg_match('/^([0-9]+|[0-9]+[+-][0-9]+)_([0-9]+|[0-9]+[+-][0-9]+)$/', $sSuffix)
+                    && !preg_match('/^\[[NX][CMR]_[0-9]{6,9}\.[0-9]+:[cgmn]\.([0-9]+|[0-9]+[+-][0-9]+)_([0-9]+|[0-9]+[+-][0-9]+)\]$/', $sSuffix)) {
+                    // Only allow bases, length, or positions as suffix for deletion-insertion events.
+                    // Position ranges for deletion-insertions used to be conversions.
                     return false;
                 } elseif ($sVariant == 'ins' && !preg_match('/^([ACTG]+|\([0-9]+\)|[0-9]+_[0-9]+|\[NC_[0-9]{6}\.[0-9]+:[0-9]+_[0-9]+\])$/', $sSuffix)) {
                     // Supported are insertions with bases, length, or with position fields.
@@ -1168,12 +1168,12 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 if (in_array($sVariant, array('del', 'dup', 'inv')) || substr($sVariant, 0, 1) == '|') {
                     // No suffix allowed for uncertain deletions, duplications, or inversions.
                     return false;
-                } elseif ($sVariant == 'con' && !preg_match('/^([NX][CMR]_[0-9]{6}\.[0-9]+:)?[0-9]+_[0-9]+$/', $sSuffix)) {
-                    // Gene conversions require position fields.
-                    return false;
-                } elseif ($sVariant == 'delins' && !preg_match('/^(\([0-9]+\))$/', $sSuffix)) {
-                    // Only allow length as suffix for deletion-insertion events.
-                    // Position ranges for deletion-insertions are actually conversions.
+                } elseif ($sVariant == 'delins'
+                    && !preg_match('/^\([0-9]+\)$/', $sSuffix)
+                    && !preg_match('/^[0-9]+_[0-9]+$/', $sSuffix)
+                    && !preg_match('/^\[[NX][CMR]_[0-9]{6,9}\.[0-9]+:[cgmn]\.[0-9]+_[0-9]+\]$/', $sSuffix)) {
+                    // Only allow length or positions as suffix for deletion-insertion events.
+                    // Position ranges for deletion-insertions used to be conversions.
                     return false;
                 } elseif ($sVariant == 'ins' && !preg_match('/^(\([0-9]+\)|[0-9]+_[0-9]+|\[NC_[0-9]{6}\.[0-9]+:[0-9]+_[0-9]+\])$/', $sSuffix)) {
                     // Supported are insertions with length or with position fields.

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2020-11-12
+ * Modified    : 2020-11-17
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -70,6 +70,17 @@ function lovd_fixHGVS ($sVariant, $sType = 'g')
     // People sometimes leave spaces.
     if (strpos($sVariant, ' ') !== false) {
         return lovd_fixHGVS(preg_replace('/\s+/', '', $sVariant));
+    }
+
+    // Con variants that should be delins.
+    if (preg_match('/^' . $sType . '\.([0-9]+_[0-9]+)con([N0-9].+)/', $sVariant, $aRegs)) {
+        // Return as a delins.
+        // The annoying thing is that 'con' never needed a square bracket,
+        //  but a delins does, when NCs are involved.
+        if ($aRegs[2]{0} == 'N') {
+            $aRegs[2] = '[' . $aRegs[2] . ']';
+        }
+        return lovd_fixHGVS($sType . '.' . $aRegs[1] . 'delins' . $aRegs[2]);
     }
 
     // Parentheses where they shouldn't belong?

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2020-11-17
+ * Modified    : 2020-11-19
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -73,14 +73,20 @@ function lovd_fixHGVS ($sVariant, $sType = 'g')
     }
 
     // Con variants that should be delins.
-    if (preg_match('/^' . $sType . '\.([0-9]+_[0-9]+)con([N0-9].+)/', $sVariant, $aRegs)) {
+    if (preg_match('/^' . $sType . '\.([0-9]+_[0-9]+)con(.+)$/', $sVariant, $aRegs)) {
         // Return as a delins.
         // The annoying thing is that 'con' never needed a square bracket,
-        //  but a delins does, when NCs are involved.
-        if ($aRegs[2]{0} == 'N') {
+        //  but a delins does, when other reference sequences are involved.
+        if (in_array($aRegs[2]{0}, array('N', 'X'))) {
             $aRegs[2] = '[' . $aRegs[2] . ']';
         }
         return lovd_fixHGVS($sType . '.' . $aRegs[1] . 'delins' . $aRegs[2]);
+    }
+
+    // Delins variants that require square brackets.
+    if (preg_match('/^' . $sType . '\.([0-9]+_[0-9]+)delins([NX].+)$/', $sVariant, $aRegs)) {
+        // Include the inserted sequence into square brackets.
+        return lovd_fixHGVS($sType . '.' . $aRegs[1] . 'delins' . '[' . $aRegs[2] . ']');
     }
 
     // Parentheses where they shouldn't belong?

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2020-07-16
- * For LOVD    : 3.0-25
+ * Modified    : 2020-11-12
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -70,12 +70,6 @@ function lovd_fixHGVS ($sVariant, $sType = 'g')
     // People sometimes leave spaces.
     if (strpos($sVariant, ' ') !== false) {
         return lovd_fixHGVS(preg_replace('/\s+/', '', $sVariant));
-    }
-
-    // Delins variants that should be conversions.
-    if (preg_match('/^' . $sType . '\.([0-9]+_[0-9]+)delins([0-9+-]+_[0-9+-]+)$/', $sVariant, $aRegs)) {
-        // Return as a conversion.
-        return lovd_fixHGVS($sType . '.' . $aRegs[1] . 'con' . $aRegs[2]);
     }
 
     // Parentheses where they shouldn't belong?

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2020-05-07
- * For LOVD    : 3.0-24
+ * Modified    : 2020-11-17
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -55,8 +55,8 @@ class FixHGVSTest extends PHPUnit_Framework_TestCase
             array('g.123dup', 'g.123dup'),
             // Add prefix when missing.
             array('123del', 'g.123del'),
-            // Delins variants that should be conversions.
-            array('g.100_200delins400_500', 'g.100_200con400_500'),
+            // Conversions that should be delins variants.
+            array('g.100_200con400_500', 'g.100_200delins400_500'),
             // Unneeded parentheses.
             array('g.(100_200)del', 'g.100_200del'),
             // Swaps positions when needed.


### PR DESCRIPTION
Removed Conversion variant type.
- Updated `lovd_fixHGVS()`; No longer convert delins variants into con variants - con will be removed.
  - See: http://varnomen.hgvs.org/bg-material/consultation/svd-wg009/
- Updated `lovd_fixHGVS()`; it will convert conversions into deletion-insertions.
- Updated test for `lovd_fixHGVS()`; conversions should be changed into deletion-insertions.
- Drop support for conversions in `lovd_getVariantInfo()` when `$bCheckHGVS` is true.
- Fixed some issues with `lovd_getVariantInfo()`.
  - Extended matching of delins variants, allowing for positions.
  - These positions actually require c. or g. when a reference sequence is included.
  - Removed some verification of the "con" variant type, it's rejected for HGVS checks (but still supported for getting positions).
- Updated `lovd_fixHGVS()`; adding square brackets around all refseqs for delins variants.