### PR TITLE
Fixed missing proper checks on select field values.

### DIFF
--- a/src/class/object_shared_columns.php
+++ b/src/class/object_shared_columns.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-05-02
- * Modified    : 2020-10-23
+ * Modified    : 2020-11-24
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -173,6 +173,16 @@ class LOVD_SharedColumn extends LOVD_Object
                       );
 
         parent::checkFields($aData, $zData, $aOptions);
+
+        // Select_options.
+        if (!empty($aData['select_options'])) {
+            $aOptions = explode("\r\n", $aData['select_options']);
+            foreach ($aOptions as $n => $sOption) {
+                if (!preg_match('/^([^=;]+|[A-Z0-9 \/\()?._+-]+ *= *[^=;]+)$/i', $sOption)) {
+                    lovd_errorAdd('select_options', 'Select option #' . ($n + 1) . ' &quot;' . htmlspecialchars($sOption) . '&quot; not understood.');
+                }
+            }
+        }
 
         // Width can not be less than 20 or more than 500.
         // These numbers are also defined in object_columns.php and inc-js-columns.php.

--- a/src/columns.php
+++ b/src/columns.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-03-04
- * Modified    : 2020-11-04
+ * Modified    : 2020-11-24
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -393,7 +393,7 @@ if (PATH_COUNT == 1 && ACTION == 'data_type_wizard') {
         if (!empty($_POST['select_options'])) {
             $aOptions = explode("\r\n", $_POST['select_options']);
             foreach ($aOptions as $n => $sOption) {
-                if (!preg_match('/^([^=]+|[A-Z0-9 \/\()?._+-]+ *= *[^=]+)$/i', $sOption)) {
+                if (!preg_match('/^([^=;]+|[A-Z0-9 \/\()?._+-]+ *= *[^=;]+)$/i', $sOption)) {
                     lovd_errorAdd('select_options', 'Select option #' . ($n + 1) . ' &quot;' . htmlspecialchars($sOption) . '&quot; not understood.');
                 }
             }

--- a/src/import.php
+++ b/src/import.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2020-09-23
- * For LOVD    : 3.0-25
+ * Modified    : 2020-11-24
+ * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1622,7 +1622,7 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
                     if (!empty($aLine['select_options'])) {
                         $aOptions = explode("\r\n", $aLine['select_options']);
                         foreach ($aOptions as $n => $sOption) {
-                            if (!preg_match('/^([^=]+|[A-Z0-9 \/\()?._+-]+ *= *[^=]+)$/i', $sOption)) {
+                            if (!preg_match('/^([^=;]+|[A-Z0-9 \/\()?._+-]+ *= *[^=;]+)$/i', $sOption)) {
                                 lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): Select option #' . ($n + 1) . ' &quot;' . htmlspecialchars($sOption) . '&quot; not understood.');
                             }
                         }


### PR DESCRIPTION
Fixed missing proper checks on select field values.
- Disallow semicolons to be used as selection options for fields created, edited, or imported.
- Disallow semicolons to be used as selection options for shared fields that are edited.

Closes #480.