### PR TITLE
Fixed query error.

### DIFF
--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-12
- * Modified    : 2020-10-26
+ * Modified    : 2020-12-28
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -544,7 +544,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
             $aSQL = array();
             foreach ($aGeneFields[$sGene] as $key => $sField) {
                 $sSQL .= (!$key? '' : ', ') . '`' . $sField . '` = ?';
-                if (substr(lovd_getColumnType(constant($this->sTable), $sField), 0, 3) == 'INT' && $aData[$sField] === '') {
+                if ($aData[$sField] === '' && in_array(substr(lovd_getColumnType(constant($this->sTable), $sField), 0, 3), array('INT', 'DAT', 'DEC', 'FLO'))) {
                     $aData[$sField] = NULL;
                 }
                 $aSQL[] = $aData[$sField];

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-11-05
+ * Modified    : 2020-12-29
  * For LOVD    : 3.0-26
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
@@ -305,7 +305,7 @@ $_SETT = array(
                             8 => '<SPAN style="color:red;">Important</SPAN>',
                             9 => '<SPAN style="color:red;"><B>Critical</B></SPAN>',
                           ),
-                'upstream_URL' => 'http://www.LOVD.nl/',
+                'upstream_URL' => 'https://www.LOVD.nl/',
                 'upstream_BTS_URL' => 'https://github.com/LOVDnl/LOVD3/issues/',
                 'upstream_BTS_URL_new_ticket' => 'https://github.com/LOVDnl/LOVD3/issues/new',
                 'list_sizes' =>


### PR DESCRIPTION
Fixed bug; VOT's `updateAll()` didn't handle numeric column like `updateEntry()` does, resulting in query errors for empty fields.
- These fields should have been caught and transformed into `NULL` values.

Also:
- Updated the upstream URL to prevent redirect issues.
  - We require HTTPS now on the live site.

Closes #489.