### PR TITLE
Fix #495.

### DIFF
--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2020-11-18
+ * Modified    : 2021-02-16
  * For LOVD    : 3.0-26
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -587,16 +587,37 @@ function lovd_getColumnLength ($sTable, $sCol)
         } elseif (preg_match('/^DECIMAL\(([0-9]+),([0-9]+)\)/i', $sColType, $aRegs)) {
             return ($aRegs[1] - $aRegs[2]);
 
-        } elseif (preg_match('/^(TINY|MEDIUM|LONG)?(TEXT|BLOB)/i', $sColType, $aRegs)) {
+        } elseif (preg_match('/^(TINY|SMALL|MEDIUM|LONG)?(TEXT|BLOB|INT UNSIGNED)/i', $sColType, $aRegs)) {
+            // We're matching *INT UNSIGNED as well here. MySQL 8.0.22 leaves
+            //  out the length of the field when defining unsigned fields
+            //  *without* zerofill. Signed fields or fields with zerofill all
+            //  have their length in the column definition. It doesn't make much
+            //  sense, but we need this column to work.
+            if (substr($aRegs[0], 0, 3) == 'INT') {
+                $aRegs[1] = 'LONG';
+            }
             switch ($aRegs[1]) { // Key [1] must exist, because $aRegs[2] exists.
                 case 'TINY':
-                    return 255;
+                    $nBytes = 255;
+                    break;
+                case 'SMALL':
+                    // This is for INTs only.
+                    $nBytes = 65535;
+                    break;
                 case 'MEDIUM':
-                    return 16777215;
+                    $nBytes = 16777215;
+                    break;
                 case 'LONG':
-                    return 4294967295;
+                    $nBytes = 4294967295;
+                    break;
                 default:
-                    return 65535;
+                    // TEXT|BLOB only.
+                    $nBytes = 65535;
+            }
+            if (substr($aRegs[2], 0, 3) == 'INT') {
+                return strlen((string) $nBytes);
+            } else {
+                return $nBytes;
             }
         }
     }


### PR DESCRIPTION
- Fix `lovd_getColumnLength()` for MySQL 8.0.22.
MySQL 8.0.22 and probably others don't describe unsigned integer fields well when there is no `zerofill` set. Strangely enough, their given length is deleted from their column definition. This confused `lovd_getColumnLength()` completely, and the returned length of the field was `0`. This broke a lot of forms in LOVD. This fix makes sure LOVD will handle these kinds of column definitions from now on.
- Created the `lovd_getColumnMinMax()` function.
Numeric columns are currently only checked for their format and the length of the text value inside the field. The length is currently checked just from the definition of the field. However, a `TINYINT(3) UNSIGNED` doesn't allow for 999, even though the `(3)` suggests that it does. This new function, `lovd_getColumnMinMax()` will calculate the minimum and maximum values of a column and return these, so that values can properly be checked.
- Implemented `lovd_getColumnMinMax()`, having numeric values properly checked.

Closes #495.