### PR TITLE
Fix 507: Resetting password doesn't always work

### DIFF
--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -99,7 +99,7 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
             }
 
             // Update database.
-            $_DB->query('UPDATE ' . TABLE_USERS . ' SET password_autogen = MD5(?) WHERE username = ?', array($sPasswd, $_POST['username']));
+            $_DB->query('UPDATE ' . TABLE_USERS . ' SET password_autogen = MD5(?) WHERE username = ?', array($sPasswd, $zData['username']));
 
             lovd_writeLog('Auth', LOG_EVENT, $_SERVER['REMOTE_ADDR'] . ' (' . lovd_php_gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') successfully reset password for account ' .
                 $_POST['username'] . ($_POST['username'] == $zData['username']? '' : ' (' . $zData['username'] . ')'));

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -68,9 +68,9 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
             $_T->printHeader();
             $_T->printTitle();
             lovd_writeLog('Auth', LOG_EVENT, $_SERVER['REMOTE_ADDR'] . ' (' . lovd_php_gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') tried to reset password for non-existent account ' . $_POST['username']);
-            print('      If you entered the username correctly, we have successfully reset your password.<BR>' . "\n" .
-                  '      We\'ve sent you an email containing your new password. With this new password, you can <A href="' . ROOT_PATH . 'login">unlock your account</A> and choose a new password.<BR><BR>' . "\n" .
-                  '      If you don\'t receive this email, it is possible that the username you entered is not correct. Please double-check it. Another possibility is that you registered at a different LOVD installation. Accounts are not shared between different LOVD installations, so please double-check where you are registered.<BR><BR>' . "\n\n");
+            print('      If you entered the username or email address correctly, we have successfully reset your password and we have sent you an email.' . "\n" .
+                  '      With this new password, you can <A href="' . ROOT_PATH . 'login">unlock your account</A> and choose a new password.<BR><BR>' . "\n" .
+                  '      If you don\'t receive this email, it is possible that the username or email address that you entered is not correct. Please double-check it. Another possibility is that you registered at a different LOVD installation. Accounts are not shared between different LOVD installations, so please double-check where you are registered.<BR><BR>' . "\n\n");
             $_T->printFooter();
             exit;
 

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-20
- * Modified    : 2020-07-27
- * For LOVD    : 3.0-25
+ * Modified    : 2021-04-14
+ * For LOVD    : 3.0-27
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -60,7 +60,7 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
                 array($_POST['username']))->fetchAllAssoc();
             if (!$zData) {
                 $zData = $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE email REGEXP ?',
-                    array('(^|\r\n)' . $_POST['username'] . '(\r\n|$)'))->fetchAllAssoc();
+                    array("(^|\r\n)" . $_POST['username'] . "(\r\n|$)"))->fetchAllAssoc();
             }
         }
         if (!$zData || $zData == array(false)) {


### PR DESCRIPTION
Fixed bugs in the password reset feature:
- The password reset code couldn't match accounts with multiple email addresses when the email address was used to reset the password.
- Improved reset password notification for accounts that don't exist.
- Fixed bug; unlocking an account using an email address didn't work.

Closes #507.