### PR TITLE
Fix problems with genes not supported by Mutalyzer by using VV as a backup.

### DIFF
--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2020-11-06
- * For LOVD    : 3.0-26
+ * Modified    : 2021-04-15
+ * For LOVD    : 3.0-27
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -274,10 +274,10 @@ class LOVD_VV
                             $aGenomicPositions[$sBuild] = array();
                         }
                         $aGenomicPositions[$sBuild][$sChromosome] = array(
-                            'start' => ($aTranscript['orientation'] == 1?
+                            'start' => ($aTranscript['genomic_spans'][$sRefSeq]['orientation'] == 1?
                                 $aTranscript['genomic_spans'][$sRefSeq]['start_position'] :
                                 $aTranscript['genomic_spans'][$sRefSeq]['end_position']),
-                            'end' => ($aTranscript['orientation'] == 1?
+                            'end' => ($aTranscript['genomic_spans'][$sRefSeq]['orientation'] == 1?
                                 $aTranscript['genomic_spans'][$sRefSeq]['end_position'] :
                                 $aTranscript['genomic_spans'][$sRefSeq]['start_position']),
                         );

--- a/src/inc-lib-genes.php
+++ b/src/inc-lib-genes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-01-25
- * Modified    : 2019-01-22
- * For LOVD    : 3.0-22
+ * Modified    : 2021-04-15
+ * For LOVD    : 3.0-27
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -419,7 +419,7 @@ function lovd_getUDForGene ($sBuild, $sGene)
     // Let's get the mapping information.
     $aResponse = lovd_callMutalyzer('getGeneLocation', array('build' => $sBuild, 'gene' => $sGene));
     // If this is false, Mutalyzer returned a HTTP 500. On screen you'd get a reason and error message perhaps, but lovd_callMutalyzer() just returns false.
-    if ($aResponse) {
+    if ($aResponse && array_keys($aResponse) != array('faultcode', 'faultstring')) {
         $sChromosome = $_SETT['human_builds'][$sBuild]['ncbi_sequences'][substr($aResponse['chromosome_name'], 3)];
         $nStart = $aResponse['start'] - ($aResponse['orientation'] == 'forward'? 5000 : 2000);
         $nEnd = $aResponse['stop'] + ($aResponse['orientation'] == 'forward'? 2000 : 5000);


### PR DESCRIPTION
Fix problems with genes not supported by Mutalyzer by using VV as a backup.
- Prevent notices when Mutalyzer doesn't recognize a gene.
- VV: Get orientation from elsewhere in the structure. VV changed where a transcript's orientation is located in the JSON structure. See [openvar/variantValidator#253](https://github.com/openvar/variantValidator/issues/253#issuecomment-743188434).
- Started the migration by using VV as a backup for Mutalyzer when creating genes and adding transcripts to existing genes. There are too many "unsupported" genes right now, that have changed their symbol and therefore are no longer supported by Mutalyzer. VV can handle them just fine. For now, call VV only when Mutalyzer fails to generate a UD or when Mutalyzer fails to find transcripts at all.

Closes #513.