### PR TITLE
Add the GA4GH Data Discovery API to LOVD3.

### DIFF
--- a/src/__function_list.txt
+++ b/src/__function_list.txt
@@ -196,7 +196,8 @@
 5.3.3 PDO::inTransaction() (already in use, but we check for it)
 5.4.0 JSON_PRETTY_PRINT is available (now I'm using it if available)
 5.4.0 Short array notation is available; array() => [].
-5.4.0 Array dereferencing; $sWord = explode(' ', $sSentence)[5];
+5.4.0 Array dereferencing; $sWord = explode(' ', $sSentence)[5]; now solved using list().
+5.6.0 Argument unpacking; array_merge(...$a) == array_merge($a[0], $a[1], $a[2]); now solved using call_user_func_array().
 =====-========
 5.3.0 REQUIRED (2021-06-22: we still have a few PHP/5.3 users, although they haven't updated their LOVDs for years, mostly 3.0-21 and lower)
 

--- a/src/__function_list.txt
+++ b/src/__function_list.txt
@@ -196,8 +196,9 @@
 5.3.3 PDO::inTransaction() (already in use, but we check for it)
 5.4.0 JSON_PRETTY_PRINT is available (now I'm using it if available)
 5.4.0 Short array notation is available; array() => [].
+5.4.0 Array dereferencing; $sWord = explode(' ', $sSentence)[5];
 =====-========
-5.3.0 REQUIRED (2021-02-17: we still have a lot of PHP/5.3 users, although they haven't updated their LOVDs for years)
+5.3.0 REQUIRED (2021-06-22: we still have a few PHP/5.3 users, although they haven't updated their LOVDs for years, mostly 3.0-21 and lower)
 
 
 

--- a/src/ajax/licenses.php
+++ b/src/ajax/licenses.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-02-25
- * Modified    : 2021-05-10
+ * Modified    : 2021-07-07
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -55,7 +55,7 @@ $nID = lovd_getCurrentID();
 $sObject = $_PE[2];
 if ($sObject == 'individual') {
     $rObject = $_DB->query('
-        SELECT CONCAT("individual #", i.id), IFNULL(i.license, uc.default_license), uc.name
+        SELECT CONCAT("individual #", i.id), IFNULL(NULLIF(i.license, ""), uc.default_license), uc.name
         FROM ' . TABLE_INDIVIDUALS . ' AS i
           INNER JOIN ' . TABLE_USERS . ' AS uc ON (i.created_by = uc.id)
         WHERE i.id = ?', array($nID))->fetchRow();

--- a/src/api.php
+++ b/src/api.php
@@ -31,6 +31,7 @@
  *  3.0-beta-10  /api/rest.php/genes?search_position=chrX:3200000_4000000&position_match=exact|exclusive|partial
  *  3.0-22       /api/rest.php/*****?format=application/json   (JSON output for whole LOVD2-style API)
  *  3.0-27 (v2)  /api/v#/ga4gh (GET) (redirects)
+ *  3.0-27 (v2)  /api/v#/ga4gh/service-info
  *  3.0-27 (v2)  /api/v#/ga4gh/tables (GET)
  *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/info (GET)
  *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data (GET)

--- a/src/api.php
+++ b/src/api.php
@@ -33,6 +33,8 @@
  *  3.0-27 (v2)  /api/v#/ga4gh (GET) (redirects)
  *  3.0-27 (v2)  /api/v#/ga4gh/tables (GET)
  *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/info (GET)
+ *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data (GET)
+ *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data:hg19:chr1:123456 (GET)
  *  3.0-18 (v1)  /api/v#/submissions (POST) (/v# is optional)
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/

--- a/src/api.php
+++ b/src/api.php
@@ -35,6 +35,7 @@
  *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/info (GET)
  *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data (GET)
  *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data:hg19:chr1:123456 (GET)
+ *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data:hg19:chr1:123456-234567 (GET)
  *  3.0-18 (v1)  /api/v#/submissions (POST) (/v# is optional)
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/

--- a/src/api.php
+++ b/src/api.php
@@ -30,13 +30,13 @@
  *  3.0-beta-10  /api/rest.php/genes?search_position=chrX:3200000
  *  3.0-beta-10  /api/rest.php/genes?search_position=chrX:3200000_4000000&position_match=exact|exclusive|partial
  *  3.0-22       /api/rest.php/*****?format=application/json   (JSON output for whole LOVD2-style API)
- *  3.0-27 (v2)  /api/v#/ga4gh (GET) (redirects)
- *  3.0-27 (v2)  /api/v#/ga4gh/service-info
- *  3.0-27 (v2)  /api/v#/ga4gh/tables (GET)
- *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/info (GET)
- *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data (GET)
- *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data:hg19:chr1:123456 (GET)
- *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data:hg19:chr1:123456-234567 (GET)
+ *  3.0-27 (v2)  /api/v#/ga4gh (GET/HEAD) (redirects)
+ *  3.0-27 (v2)  /api/v#/ga4gh/service-info (GET/HEAD)
+ *  3.0-27 (v2)  /api/v#/ga4gh/tables (GET/HEAD)
+ *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/info (GET/HEAD)
+ *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data (GET/HEAD)
+ *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data:hg19:chr1:123456 (GET/HEAD)
+ *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data:hg19:chr1:123456-234567 (GET/HEAD)
  *  3.0-18 (v1)  /api/v#/submissions (POST) (/v# is optional)
  *
  * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1344,6 +1344,9 @@ class LOVD_API_GA4GH
                             $aPhenotype['accession'] = $nOMIMID;
                         }
                         if ($sInheritance) {
+                            // Inheritance can contain multiple values, but
+                            //  VarioML allows for only one. Combined values
+                            //  will therefore just be stored as a term.
                             if (isset($this->aValueMappings['inheritance'][$sInheritance])) {
                                 $aPhenotype['inheritance_pattern'] = $this->aValueMappings['inheritance'][$sInheritance];
                             } else {

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -277,7 +277,9 @@ class LOVD_API_GA4GH
                     // Values like "pathogenic (!)" require a comment.
                     if (substr($sClassification, -3) == '(!)') {
                         $aReturn[$nID]['comments']= $this->addComment(array(),
-                            '[IEXCEPTION]: This classification is marked as an exceptional case, see the full entry.');
+                            'This classification is marked as an exceptional case, see the full entry.',
+                            'IEXCEPTION'
+                        );
                     }
                 }
             }
@@ -378,7 +380,7 @@ class LOVD_API_GA4GH
                 // We need to indicate to varcache that they have access,
                 // but only when varcache is calling us.
                 $aReturn['sharing_policy']['comments'] = $this->addComment(array(),
-                    '[ILICENSE4LOVD]: Additional permissions for LOVD project.');
+                    'Additional permissions for LOVD project.', 'ILICENSE4LOVD');
             }
             return $aReturn;
         }
@@ -1367,9 +1369,11 @@ class LOVD_API_GA4GH
                                 //  doesn't match given genetic_origin value.
                                 $aVariant['genetic_origin']['genetic_source']['comments'] = $this->addComment(
                                     array(),
-                                    '[WCONFLICT]: Conflict in value for genetic_source: ' .
+                                    'Conflict in value for genetic_source: ' .
                                         $aVariant['genetic_origin']['genetic_source']['term'] .
-                                        ' != ' . $sAllele . '.');
+                                        ' != ' . $sAllele . '.',
+                                    'WCONFLICT'
+                                );
                             }
                         }
                     }

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1006,7 +1006,7 @@ class LOVD_API_GA4GH
                     'id' => $aSubmission['id'],
                 );
                 if ($aSubmission['panel_size'] > 1) {
-                    $aIndividual['size'] = $aSubmission['panel_size'];
+                    $aIndividual['size'] = (int) $aSubmission['panel_size'];
                 }
                 if (isset($aSubmission['gender'])) {
                     $nCode = (!isset($this->aValueMappings['gender'][$aSubmission['gender']])?

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -894,10 +894,8 @@ class LOVD_API_GA4GH
                 unset($aReturn['aliases']);
             }
 
-            $aReturn['pathogenicities'] = array_merge(
-                call_user_func_array('array_merge', $this->convertEffectsToVML($zData['effectids'])),
-                array_values($this->convertClassificationToVML($zData['classifications']))
-            );
+            $aReturn['effectids'] = $this->convertEffectsToVML($zData['effectids']);
+            $aReturn['classifications'] = $this->convertClassificationToVML($zData['classifications']);
 
             // Further annotate the entries.
             $aSubmissions = array();
@@ -1383,6 +1381,19 @@ class LOVD_API_GA4GH
                         'pathogenicities' => array(),
                     );
 
+                    // Copy the phenotypes to this variant's aggregate pathogenicities.
+                    if (!empty($aIndividual['phenotypes'])) {
+                        if (isset($aReturn['effectids'][$nID][0])) {
+                            $aReturn['effectids'][$nID][0]['phenotypes'] = $aIndividual['phenotypes'];
+                        }
+                        if (isset($aReturn['effectids'][$nID][1])) {
+                            $aReturn['effectids'][$nID][0]['phenotypes'] = $aIndividual['phenotypes'];
+                        }
+                        if (isset($aReturn['classifications'][$nID])) {
+                            $aReturn['classifications'][$nID]['phenotypes'] = $aIndividual['phenotypes'];
+                        }
+                    }
+
                     if (!$aVariant['aliases']) {
                         unset($aVariant['aliases']);
                     }
@@ -1626,6 +1637,13 @@ class LOVD_API_GA4GH
                     $aReturn['panel']['individuals'][] = $aIndividual;
                 }
             }
+
+            // The aggregate pathogenicities aren't stored well yet.
+            $aReturn['pathogenicities'] = array_merge(
+                call_user_func_array('array_merge', $aReturn['effectids']),
+                array_values($aReturn['classifications'])
+            );
+            unset($aReturn['effectids'], $aReturn['classifications']);
 
             return $aReturn;
         }, $zData);

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -274,7 +274,7 @@ class LOVD_API_GA4GH
                     // Values like "pathogenic (!)" require a comment.
                     if (substr($sClassification, -3) == '(!)') {
                         $aReturn[$nID]['comments']= $this->addComment(array(),
-                            '[IEXCL]: This classification is marked as an exceptional case, see the full entry.');
+                            '[IEXCEPTION]: This classification is marked as an exceptional case, see the full entry.');
                     }
                 }
             }
@@ -375,7 +375,7 @@ class LOVD_API_GA4GH
                 // We need to indicate to varcache that they have access,
                 // but only when varcache is calling us.
                 $aReturn['sharing_policy']['comments'] = $this->addComment(array(),
-                    '[IPERMLOVD]: Additional permissions for LOVD project.');
+                    '[ILICENSE4LOVD]: Additional permissions for LOVD project.');
             }
             return $aReturn;
         }

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -331,6 +331,7 @@ class LOVD_API_GA4GH
                 if ($nEffectID{0}) {
                     $aReturn[$nID] = array(
                         'scope' => 'individual', // Always the same for us.
+                        'source' => 'LOVD',
                         'term' => $this->aValueMappings['effect'][(int) $nEffectID{0}],
                         'data_source' => array(
                             'name' => 'submitter',
@@ -340,6 +341,7 @@ class LOVD_API_GA4GH
                 if ($nEffectID{1}) {
                     $aReturn[$nID] = array(
                         'scope' => 'individual', // Always the same for us.
+                        'source' => 'LOVD',
                         'term' => $this->aValueMappings['effect'][(int) $nEffectID{1}],
                         'data_source' => array(
                             'name' => 'curator',

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -520,6 +520,7 @@ class LOVD_API_GA4GH
 
         // Check URL structure.
         if (count($this->aURLElements) > 3
+            || ($this->aURLElements[0] == 'service-info' && $aURLElements[1])
             || ($this->aURLElements[0] == 'tables' && $aURLElements[1])) {
             $this->API->nHTTPStatus = 400; // Send 400 Bad Request.
             $this->API->aResponse = array('errors' => array('title' => 'Could not parse requested URL.'));
@@ -549,7 +550,9 @@ class LOVD_API_GA4GH
         }
 
         // Now actually handle the request.
-        if ($aURLElements[0] == 'tables') {
+        if ($aURLElements[0] == 'service-info') {
+            return $this->showServiceInfo();
+        } elseif ($aURLElements[0] == 'tables') {
             return $this->showTables();
         } elseif ($aURLElements[0] == 'table' && $aURLElements[2] == 'info') {
             return $this->showTableInfo($aURLElements[1]);
@@ -561,6 +564,35 @@ class LOVD_API_GA4GH
 
         // If we end up here, we didn't handle the request well.
         return false;
+    }
+
+
+
+
+
+    private function showServiceInfo ()
+    {
+        // Shows service info.
+        global $_STAT;
+
+        $aOutput = array(
+            'id' => 'nl.lovd.ga4gh.' . md5(md5($_STAT['signature'])), // Note, a double md5(), to not leak the LSDB ID nor the signature.
+            'name' => 'GA4GH Data Connect API for LOVD instance ' . md5(md5($_STAT['signature'])),
+            'type' => array(
+                'group' => 'org.ga4gh',
+                'artifact' => 'service-registry',
+                'version' => '1.0.0'
+            ),
+            'description' => 'Implementation of the GA4GH Data Connect API on top of this LOVD instance. Supports export of aggregated variant records (table: "variants"). See /tables for more information.',
+            'organization' => array(
+                'name' => 'Leiden Open Variation Database (LOVD)',
+                'url' => 'https://lovd.nl/',
+            ),
+            'version' => '1.0.0',
+        );
+
+        $this->API->aResponse = $aOutput;
+        return true;
     }
 
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -328,8 +328,9 @@ class LOVD_API_GA4GH
         foreach (explode(';', $sEffects) as $sIDEffect) {
             if ($sIDEffect) {
                 list($nID, $nEffectID) = explode(':', $sIDEffect);
+                $aReturn[$nID] = array();
                 if ($nEffectID{0}) {
-                    $aReturn[$nID] = array(
+                    $aReturn[$nID][] = array(
                         'scope' => 'individual', // Always the same for us.
                         'source' => 'LOVD',
                         'term' => $this->aValueMappings['effect'][(int) $nEffectID{0}],
@@ -339,7 +340,7 @@ class LOVD_API_GA4GH
                     );
                 }
                 if ($nEffectID{1}) {
-                    $aReturn[$nID] = array(
+                    $aReturn[$nID][] = array(
                         'scope' => 'individual', // Always the same for us.
                         'source' => 'LOVD',
                         'term' => $this->aValueMappings['effect'][(int) $nEffectID{1}],
@@ -884,7 +885,7 @@ class LOVD_API_GA4GH
             }
 
             $aReturn['pathogenicities'] = array_merge(
-                array_values($this->convertEffectsToVML($zData['effectids'])),
+                call_user_func_array('array_merge', $this->convertEffectsToVML($zData['effectids'])),
                 array_values($this->convertClassificationToVML($zData['classifications']))
             );
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -265,10 +265,16 @@ class LOVD_API_GA4GH
                             if (!isset($this->aValueMappings['classifications'][$sMethod][$aReturn[$nID]['term']])) {
                                 // Unset the whole thing.
                                 unset($aReturn[$nID]);
+                                continue;
                             } else {
                                 $aReturn[$nID]['term'] = $this->aValueMappings['classifications'][$sMethod][$aReturn[$nID]['term']];
                             }
                         }
+                    }
+                    // Values like "pathogenic (!)" require a comment.
+                    if (substr($sClassification, -3) == '(!)') {
+                        $aReturn[$nID]['comments']= $this->addComment(array(),
+                            '[IEXCL]: This classification is marked as an exceptional case, see the full entry.');
                     }
                 }
             }

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -583,7 +583,9 @@ class LOVD_API_GA4GH
             (!$bdbSNP? '' : ',
                        IFNULL(vog.`VariantOnGenome/dbSNP`, "")') . ', "||"' .
             (!$bVOGReference? '' : ',
-                       IFNULL(vog.`VariantOnGenome/Reference`, "")') . ', "||",
+                       IFNULL(vog.`VariantOnGenome/Reference`, "")') . ', "||"' .
+            (!$bVOGRemarks? '' : ',
+                       IFNULL(vog.`VariantOnGenome/Remarks`, "")') . ', "||",
                        IFNULL(
                          (SELECT
                             GROUP_CONCAT(
@@ -723,7 +725,7 @@ class LOVD_API_GA4GH
                     $aSubmissions[] = $sVariant;
                 } else {
                     // Full variant data, which means there was no Individual.
-                    list($nID, $sLicense, $sDNA38, $sRSID, $sRefs, $sVOTs, $sCreator, $sOwner) = explode('||', $sVariant);
+                    list($nID, $sLicense, $sDNA38, $sRSID, $sRefs, $sRemarks, $sVOTs, $sCreator, $sOwner) = explode('||', $sVariant);
                     $aVariant = array(
                         'id' => $nID,
                         'type' => 'DNA',
@@ -747,6 +749,18 @@ class LOVD_API_GA4GH
                         )),
                         'pathogenicities' => array(),
                     );
+
+                    if ($sRemarks) {
+                        $aVariant['comments'] = array(
+                            array(
+                                'texts' => array(
+                                    array(
+                                        'value' => $sRemarks,
+                                    ),
+                                ),
+                            ),
+                        );
+                    }
 
                     if ($sRSID) {
                         $aVariant['db_xrefs'] = array(

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -791,6 +791,8 @@ class LOVD_API_GA4GH
                        IFNULL(vog.`VariantOnGenome/ClinicalClassification`, "")') . ', "||"' .
             (!$bClassificationMethod? '' : ',
                        IFNULL(vog.`VariantOnGenome/ClinicalClassification/Method`, "")') . ', "||"' .
+            (!$bGeneticOrigin? '' : ',
+                       IFNULL(LOWER(vog.`VariantOnGenome/Genetic_origin`), "")') . ', "||"' .
             (!$bdbSNP? '' : ',
                        IFNULL(vog.`VariantOnGenome/dbSNP`, "")') . ', "||"' .
             (!$bVOGReference? '' : ',
@@ -951,6 +953,7 @@ class LOVD_API_GA4GH
                         $sEffects,
                         $sClassification,
                         $sClassificationMethod,
+                        $sOrigin,
                         $sRSID,
                         $sRefs,
                         $sRemarks,
@@ -1001,6 +1004,18 @@ class LOVD_API_GA4GH
                         current($this->convertEffectsToVML($nID . ':' . $sEffects)),
                         array_values($this->convertClassificationToVML($nID . ':' . $sClassification . ':' . $sClassificationMethod))
                     );
+
+                    // For GV shared type "SUMMARY records", overwrite the data_source.
+                    if ($sOrigin && $sOrigin == 'summary record') {
+                        // These entries are made by curators.
+                        $aVariant['pathogenicities'] = array_map(
+                            function ($aPathogenicity) {
+                                if (isset($aPathogenicity['data_source'])) {
+                                    $aPathogenicity['data_source']['name'] = 'curator';
+                                }
+                                return $aPathogenicity;
+                            }, $aVariant['pathogenicities']);
+                    }
 
                     if ($sRemarks) {
                         $aVariant['comments'] = $this->addComment(array(), $sRemarks);

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -527,6 +527,7 @@ class LOVD_API_GA4GH
         $aColsToCheck = array_merge($aRequiredCols, array(
             'Individual/Gender',
             'Individual/Reference',
+            'Individual/Remarks',
             'Phenotype/Additional',
             'Phenotype/Inheritance',
             'VariantOnGenome/DNA/hg38',
@@ -549,6 +550,7 @@ class LOVD_API_GA4GH
         }
         $bIndGender = in_array('Individual/Gender', $aCols);
         $bIndReference = in_array('Individual/Reference', $aCols);
+        $bIndRemarks = in_array('Individual/Remarks', $aCols);
         $bPhenotypeAdditional = in_array('Phenotype/Additional', $aCols);
         $bPhenotypeInheritance = in_array('Phenotype/Inheritance', $aCols);
         $bDNA38 = in_array('VariantOnGenome/DNA/hg38', $aCols);
@@ -629,7 +631,7 @@ class LOVD_API_GA4GH
         use (
             $sBuild, $sChr,
             $bdbSNP, $bDNA38, $bGeneticOrigin,
-            $bIndGender, $bIndReference,
+            $bIndGender, $bIndReference, $bIndRemarks,
             $bPhenotypeAdditional, $bPhenotypeInheritance,
             $bVOGReference)
         {
@@ -856,6 +858,8 @@ class LOVD_API_GA4GH
                       GROUP_CONCAT(DISTINCT IFNULL(d.id_omim, ""), "||", IFNULL(d.inheritance, ""), "||", IF(CASE d.symbol WHEN "-" THEN "" ELSE d.symbol END = "", d.name, CONCAT(d.name, " (", d.symbol, ")")) ORDER BY d.id_omim, d.name SEPARATOR ";;") AS diseases' .
                     (!$bIndReference? '' : ',
                       i.`Individual/Reference` AS reference') .
+                    (!$bIndRemarks? '' : ',
+                      i.`Individual/Remarks` AS remarks') .
                     (!$bPhenotypeAdditional? '' : ',
                       GROUP_CONCAT(DISTINCT ' .
                         (!$bPhenotypeInheritance? '' : 'REPLACE(p.`Phenotype/Inheritance`, ",", ""), ') . '"||",
@@ -1031,6 +1035,18 @@ class LOVD_API_GA4GH
                         $aIndividual['phenotypes'],
                         SORT_REGULAR)
                 );
+
+                if ($aSubmission['remarks']) {
+                    $aIndividual['comments'] = array(
+                        array(
+                            'texts' => array(
+                                array(
+                                    'value' => $aSubmission['remarks'],
+                                ),
+                            ),
+                        ),
+                    );
+                }
 
                 if ($aSubmission['reference']) {
                     $aRefs = $this->convertReferenceToVML($aSubmission['reference'], array('doi', 'pubmed'));

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-07-02
+ * Modified    : 2021-07-07
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -757,6 +757,9 @@ class LOVD_API_GA4GH
         );
         // Now what licenses will only allow us to return summary data?
         $aLicensesSummaryData = array_keys(array_diff($aLicenses, array(1)));
+
+        // We'll need lots of space for GROUP_CONCAT().
+        $_DB->query('SET group_concat_max_len = 200000');
 
         // Fetch data. We do this in two steps; first the basic variant
         //  information and after that the full submission data.

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1738,7 +1738,7 @@ class LOVD_API_GA4GH
 
 
         // Set next seek window.
-        $nNextPosition = $zData[$n-1]['position_g_start'] + 1;
+        $nNextPosition = (!$zData? 0 : $zData[$n-1]['position_g_start'] + 1);
         if ($n < $nLimit) {
             // We didn't receive everything. This must be because we're at the
             //  end of the chromosome. Let's look at the next.

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-07-01
+ * Modified    : 2021-07-02
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -44,7 +44,7 @@ class LOVD_API_GA4GH
     private $aTables = array(
         'variants' => array(
             'description' => 'Aggregated variant data, when available also containing information on individuals, their phenotypes, and their other variants.',
-            'data_model' => 'https://github.com/VarioML/VarioML/blob/master/json/schemas/v.2.0/variants.json',
+            'data_model' => 'https://raw.githubusercontent.com/VarioML/VarioML/master/json/schemas/v.2.0/variant.json',
             'first_page' => 'data:{{refseq_build}}:chr1',
         ),
     );

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -41,6 +41,7 @@ class LOVD_API_GA4GH
 
     private $API;                     // The API object.
     private $aURLElements = array();  // The current URL broken in parts.
+    private $aFilters = array();      // Filters active on the data.
     private $aTables = array(
         'variants' => array(
             'description' => 'Aggregated variant data, when available also containing information on individuals, their phenotypes, and their other variants.',
@@ -554,6 +555,15 @@ class LOVD_API_GA4GH
             $this->API->nHTTPStatus = 400; // Send 400 Bad Request.
             $this->API->aResponse = array('errors' => array('title' => 'Could not parse requested URL.'));
             return false;
+        }
+
+        // Process filters.
+        // Supported: "If-Modified-Since" for selecting only data recently edited.
+        // HTTP has a very strict definition of how this field should look,
+        //  but we're happy with whatever strtotime() recognizes.
+        if (isset($aHeaders['If-Modified-Since']) && $tIfModifiedSince = strtotime($aHeaders['If-Modified-Since'])) {
+            // strtotime() took care of timezone differences.
+            $this->aFilters['modified_since'] = date('Y-m-d H:i:s', $tIfModifiedSince);
         }
 
         // Now actually handle the request.

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1211,7 +1211,9 @@ class LOVD_API_GA4GH
                         if ($nAllele >= 10) {
                             $aVariant['genetic_origin']['genetic_source'] = array(
                                 'term' => ($nAllele < 20? 'paternal' : 'maternal'),
-                                'evidence_code' => (($nAllele % 10)? 'confirmed' : 'inferred')
+                                'evidence_code' => array(
+                                    'term' => (($nAllele % 10)? 'confirmed' : 'inferred'),
+                                ),
                             );
                         }
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-06-24
+ * Modified    : 2021-06-25
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -898,12 +898,12 @@ class LOVD_API_GA4GH
                         if ($sContact) {
                             $aContact = $this->convertContactToVML($sRole, $sContact);
 
-                            if (!isset($aVariant['source'])) {
-                                $aVariant['source'] = array(
+                            if (!isset($aVariant['data_source'])) {
+                                $aVariant['data_source'] = array(
                                     'contacts' => array(),
                                 );
                             }
-                            $aVariant['source']['contacts'][] = $aContact;
+                            $aVariant['data_source']['contacts'][] = $aContact;
                         }
                     }
 
@@ -1151,12 +1151,12 @@ class LOVD_API_GA4GH
                     if ($sContact) {
                         $aContact = $this->convertContactToVML($sRole, $sContact);
 
-                        if (!isset($aIndividual['source'])) {
-                            $aIndividual['source'] = array(
+                        if (!isset($aIndividual['data_source'])) {
+                            $aIndividual['data_source'] = array(
                                 'contacts' => array(),
                             );
                         }
-                        $aIndividual['source']['contacts'][] = $aContact;
+                        $aIndividual['data_source']['contacts'][] = $aContact;
                     }
                 }
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -364,6 +364,34 @@ class LOVD_API_GA4GH
 
 
 
+    private function convertGeneToVML ($sSymbol)
+    {
+        // Converts gene symbol into VarioML.
+        global $_DB;
+        static $aGenes = array();
+
+        if (!isset($aGenes[$sSymbol])) {
+            $aGenes[$sSymbol] = $_DB->query('
+                SELECT id_hgnc, id_omim FROM ' . TABLE_GENES . ' WHERE id = ?',
+                array($sSymbol))->fetchAssoc();
+        }
+
+        return array(
+            'source' => 'HGNC',
+            'accession' => $aGenes[$sSymbol]['id_hgnc'],
+            'db_xrefs' => array(
+                array(
+                    'source' => 'HGNC.symbol',
+                    'accession' => $sSymbol,
+                ),
+            )
+        );
+    }
+
+
+
+
+
     private function convertLicenseToVML ($sLicense)
     {
         // Converts license string into VarioML license data.
@@ -873,12 +901,7 @@ class LOVD_API_GA4GH
 
             if (!empty($zData['genes'])) {
                 $aReturn['genes'] = array_map(
-                    function ($sSymbol) {
-                        return array(
-                            'source' => 'HGNC',
-                            'accession' => $sSymbol,
-                        );
-                    }, explode(';', $zData['genes']));
+                    array($this, 'convertGeneToVML'), explode(';', $zData['genes']));
             }
 
             if (!empty($zData['DNA38'])) {

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1164,7 +1164,7 @@ class LOVD_API_GA4GH
                             (SELECT
                                GROUP_CONCAT(
                                  CONCAT(
-                                   t.geneid, "##", t.id_ncbi, "##", vot.`VariantOnTranscript/DNA`, "##", vot.`VariantOnTranscript/RNA`, "##", vot.`VariantOnTranscript/Protein`)
+                                   t.geneid, "##", t.id_ncbi, "##", vot.`VariantOnTranscript/DNA`, "##", vot.`VariantOnTranscript/RNA`, "##", t.id_protein_ncbi, "##", vot.`VariantOnTranscript/Protein`)
                                  SEPARATOR "$$")
                              FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot
                                INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id)
@@ -1626,7 +1626,7 @@ class LOVD_API_GA4GH
                     if ($sVOTs) {
                         $aVariant['seq_changes']['variants'] = array();
                         foreach (explode('$$', $sVOTs) as $sVOT) {
-                            list($sGene, $sRefSeq, $sDNA, $sRNA, $sProtein) = explode('##', $sVOT);
+                            list($sGene, $sRefSeq, $sDNA, $sRNA, $sProtRefSeq, $sProtein) = explode('##', $sVOT);
                             $aVariant['seq_changes']['variants'][] = array(
                                 'type' => 'cDNA',
                                 'gene' => array(
@@ -1653,6 +1653,10 @@ class LOVD_API_GA4GH
                                                 'variants' => array(
                                                     array(
                                                         'type' => 'AA',
+                                                        'ref_seq' => array(
+                                                            'source' => 'genbank',
+                                                            'accession' => $sProtRefSeq,
+                                                        ),
                                                         'name' => array(
                                                             'scheme' => 'HGVS',
                                                             'value' => $sProtein,
@@ -1664,6 +1668,11 @@ class LOVD_API_GA4GH
                                     )
                                 )
                             );
+
+                            // Remove protein NCBI ID when not available.
+                            if (!$sProtRefSeq) {
+                                unset($aVariant['seq_changes']['variants'][count($aVariant['seq_changes']['variants'])-1]['seq_changes']['variants'][0]['seq_changes']['variants'][0]['ref_seq']);
+                            }
                         }
                     }
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-06-28
+ * Modified    : 2021-06-30
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -368,15 +368,8 @@ class LOVD_API_GA4GH
             if ($bLOVDPermission && $this->bVarCache) {
                 // We need to indicate to varcache that they have access,
                 // but only when varcache is calling us.
-                $aReturn['sharing_policy']['comments'] = array(
-                    array(
-                        'texts' => array(
-                            array(
-                                'value' => 'Additional permissions for LOVD project.',
-                            ),
-                        ),
-                    )
-                );
+                $aReturn['sharing_policy']['comments'] = $this->addComment(array(),
+                    'Additional permissions for LOVD project.');
             }
             return $aReturn;
         }

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -661,7 +661,8 @@ class LOVD_API_GA4GH
                  GROUP_CONCAT(vog.id SEPARATOR ";") AS ids,
                  vog.`VariantOnGenome/DNA` AS DNA' .
             (!$bDNA38? '' : ',
-                 GROUP_CONCAT(DISTINCT NULLIF(vog.`VariantOnGenome/DNA/hg38`, "") ORDER BY vog.`VariantOnGenome/DNA/hg38` SEPARATOR ";") AS DNA38') .
+                 GROUP_CONCAT(DISTINCT NULLIF(vog.`VariantOnGenome/DNA/hg38`, "") ORDER BY vog.`VariantOnGenome/DNA/hg38` SEPARATOR ";") AS DNA38') . ',
+                 GROUP_CONCAT(DISTINCT CONCAT(vog.id, ":", vog.effectid) ORDER BY vog.id SEPARATOR ";") AS effectids' .
             (!$bdbSNP? '' : ',
                  GROUP_CONCAT(DISTINCT NULLIF(vog.`VariantOnGenome/dbSNP`, "") ORDER BY vog.`VariantOnGenome/dbSNP` SEPARATOR ";") AS dbSNP') .
             (!$bVOGReference? '' : ',
@@ -809,6 +810,8 @@ class LOVD_API_GA4GH
             } else {
                 unset($aReturn['aliases']);
             }
+
+            $aReturn['pathogenicities'] = array_values($this->convertEffectsToVML($zData['effectids']));
 
             // Further annotate the entries.
             $aSubmissions = array();

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -874,7 +874,7 @@ class LOVD_API_GA4GH
                      )
                    ) SEPARATOR ";;") AS variants,
                  MIN(vog.created_date) AS created_date,
-                 MAX(vog.edited_date) AS edited_date
+                 MAX(IFNULL(vog.edited_date, vog.created_date)) AS edited_date
                FROM ' . TABLE_VARIANTS . ' AS vog
                  LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING (id)
                  LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id)

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -780,7 +780,9 @@ class LOVD_API_GA4GH
                            IFNULL(uo.orcid_id, ""), "##", uo.name, "##", uo.email
                          ), "")
                      )
-                   ) SEPARATOR ";;") AS variants
+                   ) SEPARATOR ";;") AS variants,
+                 MIN(vog.created_date) AS created_date,
+                 MAX(vog.edited_date) AS edited_date
                FROM ' . TABLE_VARIANTS . ' AS vog
                  LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING (id)
                  LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id)
@@ -831,6 +833,8 @@ class LOVD_API_GA4GH
                 ),
                 'aliases' => array(),
                 'pathogenicities' => array(),
+                'creation_date' => date('c', strtotime($zData['created_date'])),
+                'modification_date' => date('c', strtotime($zData['edited_date'])),
                 'panel' => array(
                     'individuals' => array(),
                     'panels' => array(),

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1746,7 +1746,10 @@ class LOVD_API_GA4GH
 
         // Set next seek window.
         $nNextPosition = (!$zData? 0 : $zData[$n-1]['position_g_start'] + 1);
-        if ($n < $nLimit) {
+        if ($nPositionEnd) {
+            // We were looking in a closed range. Continue with the next window.
+            $nNextPosition = $nPositionEnd + 1;
+        } elseif ($n < $nLimit) {
             // We didn't receive everything. This must be because we're at the
             //  end of the chromosome. Let's look at the next.
             // The easiest way to find the "next" chromosome is by our list.

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -798,13 +798,15 @@ class LOVD_API_GA4GH
                             'value' => $zData['DNA'],
                         ),
                         'aliases' => (!$sDNA38? array() : array(
-                            'ref_seq' => array(
-                                'source' => 'genbank',
-                                'accession' => $_SETT['human_builds']['hg38']['ncbi_sequences'][$sChr],
-                            ),
-                            'name' => array(
-                                'scheme' => 'HGVS',
-                                'value' => $sDNA38,
+                            array(
+                                'ref_seq' => array(
+                                    'source' => 'genbank',
+                                    'accession' => $_SETT['human_builds']['hg38']['ncbi_sequences'][$sChr],
+                                ),
+                                'name' => array(
+                                    'scheme' => 'HGVS',
+                                    'value' => $sDNA38,
+                                ),
                             ),
                         )),
                         'pathogenicities' => array(),
@@ -1188,13 +1190,15 @@ class LOVD_API_GA4GH
                             'value' => $sDNA,
                         ),
                         'aliases' => (!$sDNA38? array() : array(
-                            'ref_seq' => array(
-                                'source' => 'genbank',
-                                'accession' => $_SETT['human_builds']['hg38']['ncbi_sequences'][$sChr],
-                            ),
-                            'name' => array(
-                                'scheme' => 'HGVS',
-                                'value' => $sDNA38,
+                            array(
+                                'ref_seq' => array(
+                                    'source' => 'genbank',
+                                    'accession' => $_SETT['human_builds']['hg38']['ncbi_sequences'][$sChr],
+                                ),
+                                'name' => array(
+                                    'scheme' => 'HGVS',
+                                    'value' => $sDNA38,
+                                ),
                             ),
                         )),
                         'pathogenicities' => array(),

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -765,6 +765,8 @@ class LOVD_API_GA4GH
                         ),
                     );
                 }
+            } else {
+                unset($aReturn['aliases']);
             }
 
             // Further annotate the entries.
@@ -811,6 +813,10 @@ class LOVD_API_GA4GH
                         )),
                         'pathogenicities' => array(),
                     );
+
+                    if (!$aVariant['aliases']) {
+                        unset($aVariant['aliases']);
+                    }
 
                     if ($sRemarks) {
                         $aVariant['comments'] = $this->addComment(array(), $sRemarks);
@@ -1207,6 +1213,10 @@ class LOVD_API_GA4GH
                         )),
                         'pathogenicities' => array(),
                     );
+
+                    if (!$aVariant['aliases']) {
+                        unset($aVariant['aliases']);
+                    }
 
                     if ($sOrigin && isset($this->aValueMappings['genetic_origin'][$sOrigin])) {
                         $aVariant['genetic_origin'] = array(

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -535,6 +535,7 @@ class LOVD_API_GA4GH
             'VariantOnGenome/dbSNP',
             'VariantOnGenome/Genetic_origin',
             'VariantOnGenome/Reference',
+            'VariantOnGenome/Remarks',
         ));
         $aCols = $_DB->query('SELECT colid FROM ' . TABLE_ACTIVE_COLS . ' WHERE colid IN (?' . str_repeat(', ?', count($aColsToCheck) - 1) . ')',
             $aColsToCheck)->fetchAllColumn();
@@ -557,6 +558,7 @@ class LOVD_API_GA4GH
         $bdbSNP = in_array('VariantOnGenome/dbSNP', $aCols);
         $bGeneticOrigin = in_array('VariantOnGenome/Genetic_origin', $aCols);
         $bVOGReference = in_array('VariantOnGenome/Reference', $aCols);
+        $bVOGRemarks = in_array('VariantOnGenome/Remarks', $aCols);
 
         // Fetch data. We do this in two steps; first the basic variant
         //  information and after that the full submission data.
@@ -633,7 +635,7 @@ class LOVD_API_GA4GH
             $bdbSNP, $bDNA38, $bGeneticOrigin,
             $bIndGender, $bIndReference, $bIndRemarks,
             $bPhenotypeAdditional, $bPhenotypeInheritance,
-            $bVOGReference)
+            $bVOGReference, $bVOGRemarks)
         {
             global $_DB, $_SETT;
 
@@ -884,7 +886,9 @@ class LOVD_API_GA4GH
                     (!$bdbSNP? '' : ',
                           IFNULL(vog.`VariantOnGenome/dbSNP`, "")') . ', "||"' .
                     (!$bVOGReference? '' : ',
-                          IFNULL(vog.`VariantOnGenome/Reference`, "")') . ', "||",
+                          IFNULL(vog.`VariantOnGenome/Reference`, "")') . ', "||"' .
+                    (!$bVOGRemarks? '' : ',
+                          IFNULL(vog.`VariantOnGenome/Remarks`, "")') . ', "||",
                           IFNULL(s.`Screening/Template`, ""), "||",
                           IFNULL(s.`Screening/Technique`, ""), "||",
                           IFNULL(
@@ -1106,7 +1110,7 @@ class LOVD_API_GA4GH
                 //  more than one screening has been created and linked to the
                 //  same variant.
                 foreach (explode(';;', $aSubmission['variants']) as $sVariant) {
-                    list($nID, $nAllele, $sChr, $sDNA, $sDNA38, $sOrigin, $sRSID, $sRefs, $sTemplate, $sTechnique, $sVOTs) = explode('||', $sVariant);
+                    list($nID, $nAllele, $sChr, $sDNA, $sDNA38, $sOrigin, $sRSID, $sRefs, $sRemarks, $sTemplate, $sTechnique, $sVOTs) = explode('||', $sVariant);
                     $aVariant = array(
                         'id' => $nID,
                         'copy_count' => ($nAllele == '3'? 2 : 1),
@@ -1175,6 +1179,18 @@ class LOVD_API_GA4GH
                                 );
                             }
                         }
+                    }
+
+                    if ($sRemarks) {
+                        $aVariant['comments'] = array(
+                            array(
+                                'texts' => array(
+                                    array(
+                                        'value' => $sRemarks,
+                                    ),
+                                ),
+                            ),
+                        );
                     }
 
                     if ($sRSID) {

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-07-08
+ * Modified    : 2021-07-09
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -184,6 +184,7 @@ class LOVD_API_GA4GH
         ),
     );
     private $bAuthorized = false;
+    private $bReturnBody = true;
     private $bVarCache = false;
 
 
@@ -481,10 +482,16 @@ class LOVD_API_GA4GH
 
 
 
-    public function processGET ($aURLElements)
+    public function processGET ($aURLElements, $bReturnBody)
     {
-        // Handle GET requests for GA4GH Data Connect.
+        // Handle GET and HEAD requests for GA4GH Data Connect.
+        // For HEAD requests, we won't print any output.
+        // We could just check for the HEAD constant but this way the code will
+        //  be more independent on the rest of the infrastructure.
+        // Note that LOVD API's sendHeaders() function does check for HEAD and
+        //  automatically won't print any contents if HEAD is used.
         global $_SETT, $_STAT;
+        $this->bReturnBody = $bReturnBody;
 
         // We currently require authorization. This needs to be sent over an
         //  Authorization HTTP request header.
@@ -654,6 +661,9 @@ class LOVD_API_GA4GH
                 return false;
             }
 
+            if (!$this->bReturnBody) {
+                return true;
+            }
             return $this->showVariantDataPage($sBuild, $sChr, $sPosition);
         }
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -249,7 +249,7 @@ class LOVD_API_GA4GH
         foreach (explode(';', $sClassifications) as $sIDClassificationMethod) {
             if ($sIDClassificationMethod) {
                 list($nID, $sClassification, $sMethod) = explode(':', $sIDClassificationMethod);
-                if ($sClassification && $sClassification != 'unclassified') {
+                if ($sClassification && !in_array($sClassification, array('NA', 'unclassified'))) {
                     $aReturn[$nID] = array(
                         'scope' => 'individual', // Always the same for us.
                         'term' => trim(preg_replace('/\s\([a-z!]+\)$/i', '', $sClassification)),

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1174,7 +1174,7 @@ class LOVD_API_GA4GH
                       CONCAT(
                         IFNULL(uo.orcid_id, ""), "##", uo.name, "##", uo.email
                       ) AS owner,
-                      IFNULL(i.license, uc.default_license) AS license,
+                      IFNULL(NULLIF(i.license, ""), uc.default_license) AS license,
                       GROUP_CONCAT(DISTINCT
                         CONCAT(
                           vog.id, "||",
@@ -1220,7 +1220,7 @@ class LOVD_API_GA4GH
                       LEFT OUTER JOIN ' . TABLE_USERS . ' AS uo ON (i.owned_by = uo.id)
                     WHERE i.id IN (?' . str_repeat(', ?', count($aSubmissions) - 1) . ')
                       AND i.statusid >= ?
-                      AND IFNULL(i.license, IFNULL(uc.default_license, "")) NOT IN (?' . str_repeat(', ?', count($aLicensesSummaryData) - 1) . ')
+                      AND IFNULL(NULLIF(i.license, ""), IFNULL(uc.default_license, "")) NOT IN (?' . str_repeat(', ?', count($aLicensesSummaryData) - 1) . ')
                     GROUP BY i.id',
                     array_merge(
                         array(STATUS_MARKED, STATUS_MARKED),

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -745,7 +745,12 @@ class LOVD_API_GA4GH
                    IFNULL(i.id,
                      CONCAT(vog.id, "||", IFNULL(uc.default_license, ""), "||"' .
             (!$bDNA38? '' : ',
-                       IFNULL(vog.`VariantOnGenome/DNA/hg38`, "")') . ', "||"' .
+                       IFNULL(vog.`VariantOnGenome/DNA/hg38`, "")') . ', "||",
+                       vog.effectid, "||"' .
+            (!$bClassification? '' : ',
+                       IFNULL(vog.`VariantOnGenome/ClinicalClassification`, "")') . ', "||"' .
+            (!$bClassificationMethod? '' : ',
+                       IFNULL(vog.`VariantOnGenome/ClinicalClassification/Method`, "")') . ', "||"' .
             (!$bdbSNP? '' : ',
                        IFNULL(vog.`VariantOnGenome/dbSNP`, "")') . ', "||"' .
             (!$bVOGReference? '' : ',
@@ -898,7 +903,20 @@ class LOVD_API_GA4GH
                     $aSubmissions[] = $sVariant;
                 } else {
                     // Full variant data, which means there was no Individual.
-                    list($nID, $sLicense, $sDNA38, $sRSID, $sRefs, $sRemarks, $sVOTs, $sCreator, $sOwner) = explode('||', $sVariant);
+                    list(
+                        $nID,
+                        $sLicense,
+                        $sDNA38,
+                        $sEffects,
+                        $sClassification,
+                        $sClassificationMethod,
+                        $sRSID,
+                        $sRefs,
+                        $sRemarks,
+                        $sVOTs,
+                        $sCreator,
+                        $sOwner
+                    ) = explode('||', $sVariant);
 
                     // Ignore the full variant entry when the license isn't
                     //  compatible; we're not allowed to show the details then.
@@ -937,6 +955,11 @@ class LOVD_API_GA4GH
                     if (!$aVariant['aliases']) {
                         unset($aVariant['aliases']);
                     }
+
+                    $aVariant['pathogenicities'] = array_merge(
+                        current($this->convertEffectsToVML($nID . ':' . $sEffects)),
+                        array_values($this->convertClassificationToVML($nID . ':' . $sClassification . ':' . $sClassificationMethod))
+                    );
 
                     if ($sRemarks) {
                         $aVariant['comments'] = $this->addComment(array(), $sRemarks);

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -560,8 +560,15 @@ class LOVD_API_GA4GH
             'VariantOnGenome/Reference',
             'VariantOnGenome/Remarks',
         ));
-        $aCols = $_DB->query('SELECT colid FROM ' . TABLE_ACTIVE_COLS . ' WHERE colid IN (?' . str_repeat(', ?', count($aColsToCheck) - 1) . ')',
-            $aColsToCheck)->fetchAllColumn();
+        // Select columns only if they're *globally* set to public.
+        // Note that this means, for VOT and Phenotype columns, the gene- and
+        //  disease-specific settings are ignored.
+        $aCols = $_DB->query('
+            SELECT colid
+            FROM ' . TABLE_ACTIVE_COLS . ' AS ac
+              INNER JOIN ' . TABLE_COLS . ' AS c ON (ac.colid = c.id)
+            WHERE c.id IN (?' . str_repeat(', ?', count($aColsToCheck) - 1) . ')
+              AND c.public_view = 1', $aColsToCheck)->fetchAllColumn();
 
         foreach ($aRequiredCols as $sCol) {
             if (!in_array($sCol, $aCols)) {

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -798,7 +798,7 @@ class LOVD_API_GA4GH
                          (SELECT
                             GROUP_CONCAT(
                               CONCAT(
-                                t.geneid, "##", t.id_ncbi, "##", vot.`VariantOnTranscript/DNA`, "##", vot.`VariantOnTranscript/RNA`, "##", vot.`VariantOnTranscript/Protein`)
+                                t.geneid, "##", t.id_ncbi, "##", vot.`VariantOnTranscript/DNA`, "##", vot.`VariantOnTranscript/RNA`, "##", t.id_protein_ncbi, "##", vot.`VariantOnTranscript/Protein`)
                               SEPARATOR "$$")
                          FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot
                            INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id)
@@ -1030,7 +1030,7 @@ class LOVD_API_GA4GH
                     if ($sVOTs) {
                         $aVariant['seq_changes']['variants'] = array();
                         foreach (explode('$$', $sVOTs) as $sVOT) {
-                            list($sGene, $sRefSeq, $sDNA, $sRNA, $sProtein) = explode('##', $sVOT);
+                            list($sGene, $sRefSeq, $sDNA, $sRNA, $sProtRefSeq, $sProtein) = explode('##', $sVOT);
                             $aVariant['seq_changes']['variants'][] = array(
                                 'type' => 'cDNA',
                                 'gene' => array(
@@ -1057,6 +1057,10 @@ class LOVD_API_GA4GH
                                                 'variants' => array(
                                                     array(
                                                         'type' => 'AA',
+                                                        'ref_seq' => array(
+                                                            'source' => 'genbank',
+                                                            'accession' => $sProtRefSeq,
+                                                        ),
                                                         'name' => array(
                                                             'scheme' => 'HGVS',
                                                             'value' => $sProtein,
@@ -1068,6 +1072,11 @@ class LOVD_API_GA4GH
                                     )
                                 )
                             );
+
+                            // Remove protein NCBI ID when not available.
+                            if (!$sProtRefSeq) {
+                                unset($aVariant['seq_changes']['variants'][count($aVariant['seq_changes']['variants'])-1]['seq_changes']['variants'][0]['seq_changes']['variants'][0]['ref_seq']);
+                            }
                         }
                     }
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -865,8 +865,12 @@ class LOVD_API_GA4GH
                 ),
                 'aliases' => array(),
                 'pathogenicities' => array(),
-                'creation_date' => date('c', strtotime($zData['created_date'])),
-                'modification_date' => date('c', strtotime($zData['edited_date'])),
+                'creation_date' => array(
+                    'value' => date('c', strtotime($zData['created_date'])),
+                ),
+                'modification_date' => array(
+                    'value' => date('c', strtotime($zData['edited_date'])),
+                ),
                 'panel' => array(
                     'individuals' => array(),
                     'panels' => array(),

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -215,7 +215,7 @@ class LOVD_API_GA4GH
 
 
 
-    private function addComment ($aComments, $Text)
+    private function addComment ($aComments, $Text, $sTerm = '')
     {
         // Adds a comment to an existing array of comments.
 
@@ -225,11 +225,14 @@ class LOVD_API_GA4GH
             );
         }
 
-        $aComments[] = array(
-            'texts' => array(
-                $Text,
-            ),
+        $aReturn = array();
+        if ($sTerm) {
+            $aReturn['term'] = $sTerm;
+        }
+        $aReturn['texts'] = array(
+            $Text,
         );
+        $aComments[] = $aReturn;
 
         return $aComments;
     }

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -895,9 +895,15 @@ class LOVD_API_GA4GH
             $aQ[] = (int) $nPositionEnd;
         }
         $aQ[] = STATUS_MARKED;
-        // FIXME: This is where searching will be implemented.
         $sQ .= '
-               GROUP BY vog.chromosome, vog.position_g_start, vog.position_g_end, vog.`VariantOnGenome/DNA`
+               GROUP BY vog.chromosome, vog.position_g_start, vog.position_g_end, vog.`VariantOnGenome/DNA`';
+        // If-Modified-Since filter must be on HAVING as it must be done *after* grouping.
+        if (isset($this->aFilters['modified_since'])) {
+            $sQ .= '
+               HAVING edited_date >= ?';
+            $aQ[] = $this->aFilters['modified_since'];
+        }
+        $sQ .= '
                ORDER BY vog.chromosome, vog.position_g_start, vog.position_g_end, vog.`VariantOnGenome/DNA`
                LIMIT ' . $nLimit;
         $zData = $_DB->query($sQ, $aQ)->fetchAllAssoc();

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -514,7 +514,7 @@ class LOVD_API_GA4GH
         // No further elements given, then forward to the table list.
         if (!implode('', $this->aURLElements)) {
             $this->API->nHTTPStatus = 302; // Send 302 Moved Temporarily (302 Found in HTTP 1.1).
-            $this->API->aResponse['messages'][] = 'Location: ' . lovd_getInstallURL() . 'api/v' . $this->API->nVersion . '/ga4gh/tables';
+            $this->API->aResponse['messages'][] = 'Location: ' . lovd_getInstallURL() . 'api/v' . $this->API->nVersion . '/ga4gh/service-info';
             return true;
         }
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1771,6 +1771,14 @@ class LOVD_API_GA4GH
             );
             unset($aReturn['effectids'], $aReturn['classifications']);
 
+            // Clean "individuals", "panels" and "variants" when empty.
+            // VarioML wants them gone when empty.
+            foreach (array('individuals', 'panels', 'variants') as $sIndex) {
+                if (!count($aReturn['panel'][$sIndex])) {
+                    unset($aReturn['panel'][$sIndex]);
+                }
+            }
+
             return $aReturn;
         }, $zData);
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -864,18 +864,22 @@ class LOVD_API_GA4GH
                                 ),
                                 'seq_changes' => array(
                                     'variants' => array(
-                                        'type' => 'RNA',
-                                        'name' => array(
-                                            'scheme' => 'HGVS',
-                                            'value' => $sRNA,
-                                        ),
-                                        'seq_changes' => array(
-                                            'variants' => array(
-                                                'type' => 'AA',
-                                                'name' => array(
-                                                    'scheme' => 'HGVS',
-                                                    'value' => $sProtein,
-                                                ),
+                                        array(
+                                            'type' => 'RNA',
+                                            'name' => array(
+                                                'scheme' => 'HGVS',
+                                                'value' => $sRNA,
+                                            ),
+                                            'seq_changes' => array(
+                                                'variants' => array(
+                                                    array(
+                                                        'type' => 'AA',
+                                                        'name' => array(
+                                                            'scheme' => 'HGVS',
+                                                            'value' => $sProtein,
+                                                        ),
+                                                    )
+                                                )
                                             )
                                         )
                                     )
@@ -1402,18 +1406,22 @@ class LOVD_API_GA4GH
                                 ),
                                 'seq_changes' => array(
                                     'variants' => array(
-                                        'type' => 'RNA',
-                                        'name' => array(
-                                            'scheme' => 'HGVS',
-                                            'value' => $sRNA,
-                                        ),
-                                        'seq_changes' => array(
-                                            'variants' => array(
-                                                'type' => 'AA',
-                                                'name' => array(
-                                                    'scheme' => 'HGVS',
-                                                    'value' => $sProtein,
-                                                ),
+                                        array(
+                                            'type' => 'RNA',
+                                            'name' => array(
+                                                'scheme' => 'HGVS',
+                                                'value' => $sRNA,
+                                            ),
+                                            'seq_changes' => array(
+                                                'variants' => array(
+                                                    array(
+                                                        'type' => 'AA',
+                                                        'name' => array(
+                                                            'scheme' => 'HGVS',
+                                                            'value' => $sProtein,
+                                                        ),
+                                                    )
+                                                )
                                             )
                                         )
                                     )

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -194,6 +194,29 @@ class LOVD_API_GA4GH
 
 
 
+    private function addComment ($aComments, $Text)
+    {
+        // Adds a comment to an existing array of comments.
+
+        if (!is_array($Text)) {
+            $Text = array(
+                'value' => $Text
+            );
+        }
+
+        $aComments[] = array(
+            'texts' => array(
+                $Text,
+            ),
+        );
+
+        return $aComments;
+    }
+
+
+
+
+
     private function convertContactToVML ($sRole, $sContact)
     {
         // Converts contact string into VarioML contact data.
@@ -751,15 +774,7 @@ class LOVD_API_GA4GH
                     );
 
                     if ($sRemarks) {
-                        $aVariant['comments'] = array(
-                            array(
-                                'texts' => array(
-                                    array(
-                                        'value' => $sRemarks,
-                                    ),
-                                ),
-                            ),
-                        );
+                        $aVariant['comments'] = $this->addComment(array(), $sRemarks);
                     }
 
                     if ($sRSID) {
@@ -1055,15 +1070,7 @@ class LOVD_API_GA4GH
                 );
 
                 if ($aSubmission['remarks']) {
-                    $aIndividual['comments'] = array(
-                        array(
-                            'texts' => array(
-                                array(
-                                    'value' => $aSubmission['remarks'],
-                                ),
-                            ),
-                        ),
-                    );
+                    $aIndividual['comments'] = $this->addComment(array(), $aSubmission['remarks']);
                 }
 
                 if ($aSubmission['reference']) {
@@ -1180,31 +1187,17 @@ class LOVD_API_GA4GH
                             } elseif ($aVariant['genetic_origin']['genetic_source']['term'] != $sAllele) {
                                 // Strange, a conflict. Given allele value
                                 //  doesn't match given genetic_origin value.
-                                $aVariant['genetic_origin']['genetic_source']['comments'] = array(
-                                    array(
-                                        'texts' => array(
-                                            array(
-                                                'value' => 'Conflict in value for genetic_source: ' .
-                                                    $aVariant['genetic_origin']['genetic_source']['term'] .
-                                                    ' != ' . $sAllele . '.',
-                                            ),
-                                        ),
-                                    )
-                                );
+                                $aVariant['genetic_origin']['genetic_source']['comments'] = $this->addComment(
+                                    array(),
+                                    'Conflict in value for genetic_source: ' .
+                                        $aVariant['genetic_origin']['genetic_source']['term'] .
+                                        ' != ' . $sAllele . '.');
                             }
                         }
                     }
 
                     if ($sRemarks) {
-                        $aVariant['comments'] = array(
-                            array(
-                                'texts' => array(
-                                    array(
-                                        'value' => $sRemarks,
-                                    ),
-                                ),
-                            ),
-                        );
+                        $aVariant['comments'] = $this->addComment(array(), $sRemarks);
                     }
 
                     if ($sRSID) {

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-07-07
+ * Modified    : 2021-07-08
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -542,7 +542,7 @@ class LOVD_API_GA4GH
         // Check URL structure some more.
         if ($this->aURLElements[0] == 'table'
             && !in_array($this->aURLElements[2], array('info', 'data'))
-            && !preg_match('/^data:hg[0-9]{2}(:chr([XYM]|[0-9]{1,2})(:[0-9]+)?)?$/', $this->aURLElements[2])) {
+            && !preg_match('/^data:hg[0-9]{2}(:chr([XYM]|[0-9]{1,2})(:[0-9]+(-[0-9]+)?)?)?$/', $this->aURLElements[2])) {
             $this->API->nHTTPStatus = 400; // Send 400 Bad Request.
             $this->API->aResponse = array('errors' => array('title' => 'Could not parse requested URL.'));
             return false;
@@ -555,7 +555,7 @@ class LOVD_API_GA4GH
             return $this->showTableInfo($aURLElements[1]);
         } elseif ($aURLElements[0] == 'table' && $aURLElements[2] == 'data') {
             return $this->showTableData($aURLElements[1]);
-        } elseif ($aURLElements[0] == 'table' && preg_match('/^data:(hg[0-9]{2})(?::chr([XYM]|[0-9]{1,2})(?::([0-9]+))?)?$/', $aURLElements[2], $aRegs)) {
+        } elseif ($aURLElements[0] == 'table' && preg_match('/^data:(hg[0-9]{2})(?::chr([XYM]|[0-9]{1,2})(?::([0-9]+(?:-[0-9]+)?))?)?$/', $aURLElements[2], $aRegs)) {
             return $this->showTableDataPage($aURLElements[1], $aRegs);
         }
 
@@ -599,7 +599,7 @@ class LOVD_API_GA4GH
         global $_CONF, $_SETT;
 
         if ($sTableName == 'variants') {
-            list(, $sBuild, $sChr, $nPosition) = array_pad($aPage, 4, '1');
+            list(, $sBuild, $sChr, $sPosition) = array_pad($aPage, 4, '1');
 
             if ($sBuild != $_CONF['refseq_build']) {
                 // We don't support this yet, because we can't use an index on a
@@ -622,7 +622,7 @@ class LOVD_API_GA4GH
                 return false;
             }
 
-            return $this->showVariantDataPage($sBuild, $sChr, $nPosition);
+            return $this->showVariantDataPage($sBuild, $sChr, $sPosition);
         }
 
         return false;
@@ -678,7 +678,7 @@ class LOVD_API_GA4GH
 
 
 
-    private function showVariantDataPage ($sBuild, $sChr, $nPosition)
+    private function showVariantDataPage ($sBuild, $sChr, $sPosition)
     {
         // Shows variant data page.
         global $_DB, $_CONF, $_SETT;
@@ -833,7 +833,7 @@ class LOVD_API_GA4GH
         $aQ = array(
             STATUS_MARKED,
             (string) $sChr,
-            (int) $nPosition,
+            (int) $sPosition,
             STATUS_MARKED
         );
         // FIXME: This is where searching will be implemented.

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-06-23
+ * Modified    : 2021-06-24
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -363,6 +363,7 @@ class LOVD_API_GA4GH
             }
         }
         $this->bAuthorized = true;
+        $this->bVarCache = ($this->bVarCache && $this->bAuthorized);
 
         $this->aURLElements = array_pad($aURLElements, 3, '');
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-06-21
+ * Modified    : 2021-06-22
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -239,9 +239,13 @@ class LOVD_API_GA4GH
                 // We need to indicate to varcache that they have access,
                 // but only when varcache is calling us.
                 $aReturn['sharing_policy']['comments'] = array(
-                    'texts' => array(
-                        'value' => 'Additional permissions for LOVD project.',
-                    ),
+                    array(
+                        'texts' => array(
+                            array(
+                                'value' => 'Additional permissions for LOVD project.',
+                            ),
+                        ),
+                    )
                 );
             }
             return $aReturn;
@@ -1213,6 +1217,9 @@ class LOVD_API_GA4GH
                                 // We've seen this variant before.
                                 // The simplest is simply to take both arrays,
                                 //  merge them, and make them unique.
+                                // This may mean that templates are repeated,
+                                //  but it indicates multiple screenings exist
+                                //  in LOVD and varcache can merge it if needed.
                                 $aIndividual['variants'][$nKey]['variant_detection'] =
                                     array_unique(
                                         array_merge(

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-06-30
+ * Modified    : 2021-07-01
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -276,9 +276,14 @@ class LOVD_API_GA4GH
                     }
                     // Values like "pathogenic (!)" require a comment.
                     if (substr($sClassification, -3) == '(!)') {
-                        $aReturn[$nID]['comments']= $this->addComment(array(),
+                        $aReturn[$nID]['comments'] = $this->addComment(array(),
                             'This classification is marked as an exceptional case, see the full entry.',
                             'IEXCEPTION'
+                        );
+                    } elseif (substr($sClassification, -8) == 'aternal)') {
+                        $aReturn[$nID]['comments'] = $this->addComment(array(),
+                            'This classification is marked as ' . substr($sClassification, -9, -1) . ' genomic imprinting.',
+                            'IIMPRINTING'
                         );
                     }
                 }

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -384,6 +384,10 @@ class LOVD_API_GA4GH
                     'source' => 'HGNC.symbol',
                     'accession' => $sSymbol,
                 ),
+                array(
+                    'source' => 'MIM',
+                    'accession' => $aGenes[$sSymbol]['id_omim'],
+                ),
             )
         );
     }
@@ -1209,7 +1213,7 @@ class LOVD_API_GA4GH
                             'term' => $sName,
                         );
                         if ($nOMIMID) {
-                            $aPhenotype['source'] = 'OMIM';
+                            $aPhenotype['source'] = 'MIM';
                             $aPhenotype['accession'] = $nOMIMID;
                         }
                         if ($sInheritance) {

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -375,7 +375,7 @@ class LOVD_API_GA4GH
                 // We need to indicate to varcache that they have access,
                 // but only when varcache is calling us.
                 $aReturn['sharing_policy']['comments'] = $this->addComment(array(),
-                    'Additional permissions for LOVD project.');
+                    '[IPERMLOVD]: Additional permissions for LOVD project.');
             }
             return $aReturn;
         }
@@ -1364,7 +1364,7 @@ class LOVD_API_GA4GH
                                 //  doesn't match given genetic_origin value.
                                 $aVariant['genetic_origin']['genetic_source']['comments'] = $this->addComment(
                                     array(),
-                                    'Conflict in value for genetic_source: ' .
+                                    '[WCONFLICT]: Conflict in value for genetic_source: ' .
                                         $aVariant['genetic_origin']['genetic_source']['term'] .
                                         ' != ' . $sAllele . '.');
                             }

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -656,6 +656,7 @@ class LOVD_API_GA4GH
             'Phenotype/Inheritance',
             'VariantOnGenome/DNA/hg38',
             'VariantOnGenome/ClinicalClassification',
+            'VariantOnGenome/ClinicalClassification/Method',
             'VariantOnGenome/dbSNP',
             'VariantOnGenome/Genetic_origin',
             'VariantOnGenome/Reference',
@@ -686,6 +687,8 @@ class LOVD_API_GA4GH
         $bPhenotypeAdditional = in_array('Phenotype/Additional', $aCols);
         $bPhenotypeInheritance = in_array('Phenotype/Inheritance', $aCols);
         $bDNA38 = in_array('VariantOnGenome/DNA/hg38', $aCols);
+        $bClassification = in_array('VariantOnGenome/ClinicalClassification', $aCols);
+        $bClassificationMethod = in_array('VariantOnGenome/ClinicalClassification/Method', $aCols);
         $bdbSNP = in_array('VariantOnGenome/dbSNP', $aCols);
         $bGeneticOrigin = in_array('VariantOnGenome/Genetic_origin', $aCols);
         $bVOGReference = in_array('VariantOnGenome/Reference', $aCols);
@@ -722,6 +725,10 @@ class LOVD_API_GA4GH
             (!$bDNA38? '' : ',
                  GROUP_CONCAT(DISTINCT NULLIF(vog.`VariantOnGenome/DNA/hg38`, "") ORDER BY vog.`VariantOnGenome/DNA/hg38` SEPARATOR ";") AS DNA38') . ',
                  GROUP_CONCAT(DISTINCT CONCAT(vog.id, ":", vog.effectid) ORDER BY vog.id SEPARATOR ";") AS effectids' .
+            (!$bClassification? '' : ',
+                 GROUP_CONCAT(DISTINCT CONCAT(vog.id, ":", NULLIF(vog.`VariantOnGenome/ClinicalClassification`, ""), ":"' .
+                (!$bClassificationMethod? '' : ', IFNULL(vog.`VariantOnGenome/ClinicalClassification/Method`, "")') .
+                ') ORDER BY vog.id SEPARATOR ";") AS classifications') .
             (!$bdbSNP? '' : ',
                  GROUP_CONCAT(DISTINCT NULLIF(vog.`VariantOnGenome/dbSNP`, "") ORDER BY vog.`VariantOnGenome/dbSNP` SEPARATOR ";") AS dbSNP') .
             (!$bVOGReference? '' : ',
@@ -870,7 +877,10 @@ class LOVD_API_GA4GH
                 unset($aReturn['aliases']);
             }
 
-            $aReturn['pathogenicities'] = array_values($this->convertEffectsToVML($zData['effectids']));
+            $aReturn['pathogenicities'] = array_merge(
+                array_values($this->convertEffectsToVML($zData['effectids'])),
+                array_values($this->convertClassificationToVML($zData['classifications']))
+            );
 
             // Further annotate the entries.
             $aSubmissions = array();

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -287,6 +287,15 @@ class LOVD_API_GA4GH
                             'This classification is marked as ' . substr($sClassification, -9, -1) . ' genomic imprinting.',
                             'IIMPRINTING'
                         );
+                    } elseif (in_array(substr($sClassification, -10), array('recessive)', '(dominant)'))) {
+                        // VarioML states we need to store inheritance within a phenotype.
+                        // But that's difficult to do in the code, and not all variants
+                        //  have phenotypes (summary records, classification records).
+                        $sInheritance = str_replace('(', '', substr($sClassification, -10, -1));
+                        $aReturn[$nID]['comments'] = $this->addComment(array(),
+                            'This classification is marked as ' . $sInheritance . ' inheritance.',
+                            'I' . strtoupper($sInheritance)
+                        );
                     }
                 }
             }

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1015,6 +1015,21 @@ class LOVD_API_GA4GH
                                 }
                                 return $aPathogenicity;
                             }, $aVariant['pathogenicities']);
+
+                        // Also overwrite the values collected for the
+                        //  aggregated variant entry.
+                        if (!empty($aReturn['effectids'][$nID])) {
+                            $aReturn['effectids'][$nID] = array_map(
+                                function ($aPathogenicity) {
+                                    if (isset($aPathogenicity['data_source'])) {
+                                        $aPathogenicity['data_source']['name'] = 'curator';
+                                    }
+                                    return $aPathogenicity;
+                                }, $aReturn['effectids'][$nID]);
+                        }
+                        if (!empty($aReturn['classifications'][$nID]['data_source'])) {
+                            $aReturn['classifications'][$nID]['data_source']['name'] = 'curator';
+                        }
                     }
 
                     if ($sRemarks) {

--- a/src/class/api.php
+++ b/src/class/api.php
@@ -56,6 +56,7 @@ class LOVD_API
         'data' => array(),
     );
     public $nHTTPStatus = 0;   // The HTTP status that should be send back to the user.
+    public $aHTTPHeaders = array(); // The HTTP response headers to send.
 
     // Currently supported resources (resource => array(methods)):
     private $aResourcesSupported = array(
@@ -418,6 +419,10 @@ class LOVD_API
         }
         // Content type...
         header('Content-type: ' . $this->sFormatOutput . '; charset=UTF-8');
+        // Other headers...
+        foreach ($this->aHTTPHeaders as $sHeader => $sContent) {
+            header($sHeader . ': ' . $sContent);
+        }
         if ($bHalt) {
             if (!HEAD) {
                 print($this->formatReponse() . "\n");

--- a/src/class/api.php
+++ b/src/class/api.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2021-04-29
+ * Modified    : 2021-07-08
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -324,7 +324,10 @@ class LOVD_API
             }
         } else {
             // Default: application/json.
-            $sResponse = json_encode($this->aResponse, (PHP_VERSION_ID >= 50400? JSON_PRETTY_PRINT : NULL));
+            $bPrettyPrint = (PHP_VERSION_ID >= 50400
+                && memory_get_usage() < 10000000
+                && (empty($this->aResponse['data']) || count($this->aResponse['data']) <= 10));
+            $sResponse = json_encode($this->aResponse, ($bPrettyPrint? JSON_PRETTY_PRINT : NULL));
         }
 
         return $sResponse;

--- a/src/class/api.php
+++ b/src/class/api.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2021-07-08
+ * Modified    : 2021-07-09
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -261,6 +261,8 @@ class LOVD_API
             $bReturn = null;
             if (GET) {
                 $bReturn = $this->processGET($aURLElements);
+            } elseif (HEAD) {
+                $bReturn = $this->processHEAD($aURLElements);
             } elseif (POST) {
                 $bReturn = $this->processPOST();
             }
@@ -337,7 +339,7 @@ class LOVD_API
 
 
 
-    private function processGET ($aURLElements)
+    private function processGET ($aURLElements, $bReturnBody = true)
     {
         // Processes the GET calls to the API.
 
@@ -347,8 +349,21 @@ class LOVD_API
             $o = new LOVD_API_GA4GH($this);
             // This should process the request, return false on failure,
             //  true on success, and void otherwise (bugs).
-            return $o->processGET($aURLElements);
+            return $o->processGET($aURLElements, $bReturnBody);
         }
+    }
+
+
+
+
+
+    private function processHEAD ($aURLElements)
+    {
+        // Processes the HEAD calls to the API.
+        // Even though HEAD is often not implemented, it should return the same
+        //  headers as GET does. So basically, it should do all checks.
+
+        return $this->processGET($aURLElements, false);
     }
 
 
@@ -377,7 +392,7 @@ class LOVD_API
     public function sendHeader ($nStatus, $bHalt = false)
     {
         // Sends the HTTP header as requested, and optionally halts. If it does,
-        //  it will send the response as well.
+        //  it will send the response as well if we're not using HEAD.
         global $_SETT;
 
         // Response header...
@@ -404,7 +419,9 @@ class LOVD_API
         // Content type...
         header('Content-type: ' . $this->sFormatOutput . '; charset=UTF-8');
         if ($bHalt) {
-            print($this->formatReponse() . "\n");
+            if (!HEAD) {
+                print($this->formatReponse() . "\n");
+            }
             exit;
         }
 

--- a/src/class/object_custom.php
+++ b/src/class/object_custom.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-17
- * Modified    : 2021-04-20
+ * Modified    : 2021-07-07
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -610,6 +610,7 @@ class LOVD_Custom extends LOVD_Object
                     $zData['license'] = strstr($zData['license'], ';', true);
                     $sLicenseName = substr($zData['license'], 3, -4);
                     $sLicenseVersion = substr($zData['license'], -3);
+                    $nIndividualID = false;
 
                     if ($this->sObject == 'Genome_Variant') {
                         if (count($zData['individuals']) > 1) {
@@ -621,15 +622,13 @@ class LOVD_Custom extends LOVD_Object
                                     }
                                 }
                             }
-                        } else {
+                        } elseif ($zData['individuals']) {
                             $nIndividualID = $zData['individuals'][0][0];
                         }
                     } elseif ($this->sObject == 'Individual') {
                         $nIndividualID = $zData['id'];
                     } elseif (in_array($this->sObject, array('Phenotype', 'Screening'))) {
                         $nIndividualID = $zData['individualid'];
-                    } else {
-                        $nIndividualID = false;
                     }
 
                     $zData['license_'] =

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2021-05-10
+ * Modified    : 2021-07-07
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -615,10 +615,10 @@ class LOVD_Gene extends LOVD_Object
                 // 2013-06-05; 3.0-06; There should be no link for users not logged in; they can't access these anyways.
                 if ($_AUTH) {
                     // Use links, hidden curators possibly in the list (depends on exact user level).
-                    $zData['curators_'] .= ($i == 1? '' : ($i == $nCurators? ' and ' : ', ')) . ($nOrder? '<B><A href="users/' . $nUserID . '">' . $sName . '</A></B>' : '<I><A href="users/' . $nUserID . '">' . $sName . '</A> (hidden)</I>');
+                    $zData['curators_'] .= ($i == 1? '' : ($i == $nCurators? ($i == 2? '' : ',') . ' and ' : ', ')) . ($nOrder? '<B><A href="users/' . $nUserID . '">' . $sName . '</A></B>' : '<I><A href="users/' . $nUserID . '">' . $sName . '</A> (hidden)</I>');
                 } else {
                     // Don't use links, and we never see hidden users anyways.
-                    $zData['curators_'] .= ($i == 1? '' : ($i == $nCurators? ' and ' : ', ')) . '<B>' . $sName . '</B>';
+                    $zData['curators_'] .= ($i == 1? '' : ($i == $nCurators? ($i == 2? '' : ',') . ' and ' : ', ')) . '<B>' . $sName . '</B>';
                 }
             }
             $this->aColumnsViewEntry['curators_'] .= ' (' . $nCurators . ')';
@@ -628,7 +628,7 @@ class LOVD_Gene extends LOVD_Object
                 $i = 0;
                 foreach ($aCollaborators as $nUserID => $sName) {
                     $i ++;
-                    $zData['collaborators_'] .= ($i == 1? '' : ($i == $nCollaborators? ' and ' : ', ')) . '<A href="users/' . $nUserID . '">' . $sName . '</A>';
+                    $zData['collaborators_'] .= ($i == 1? '' : ($i == $nCollaborators? ($i == 2? '' : ',') . ' and ' : ', ')) . '<A href="users/' . $nUserID . '">' . $sName . '</A>';
                 }
                 $this->aColumnsViewEntry['collaborators_'][0] .= ' (' . $nCollaborators . ')';
             }

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2021-04-22
+ * Modified    : 2021-07-07
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -70,7 +70,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
                                            'a.name AS allele_, ' .
                                            'GROUP_CONCAT(DISTINCT i.id, ";", i.statusid SEPARATOR ";;") AS __individuals, ' .
                                            'GROUP_CONCAT(s2v.screeningid SEPARATOR "|") AS screeningids, ' .
-                                           'GROUP_CONCAT(DISTINCT IFNULL(i.license, IFNULL(iuc.default_license, uc.default_license)) SEPARATOR ";;") AS license, ' .
+                                           'GROUP_CONCAT(DISTINCT IFNULL(NULLIF(i.license, ""), IFNULL(iuc.default_license, uc.default_license)) SEPARATOR ";;") AS license, ' .
                                            'uo.name AS owned_by_, CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) AS _owner, ' .
                                            'uc.name AS created_by_, ' .
                                            'ue.name AS edited_by_';

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2021-04-22
+ * Modified    : 2021-07-07
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -72,7 +72,7 @@ class LOVD_Individual extends LOVD_Custom
 
         // SQL code for viewing an entry.
         $this->aSQLViewEntry['SELECT']   = 'i.*, ' .
-                                           'IFNULL(i.license, uc.default_license) AS license, ' .
+                                           'IFNULL(NULLIF(i.license, ""), uc.default_license) AS license, ' .
                                            'GROUP_CONCAT(DISTINCT d.id SEPARATOR ";") AS _diseaseids, ' .
                                            'GROUP_CONCAT(DISTINCT d.id, ";", IF(CASE d.symbol WHEN "-" THEN "" ELSE d.symbol END = "", d.name, d.symbol), ";", d.name ORDER BY (d.symbol != "" AND d.symbol != "-") DESC, d.symbol, d.name SEPARATOR ";;") AS __diseases, ' .
                                            'GROUP_CONCAT(DISTINCT p.diseaseid SEPARATOR ";") AS _phenotypes, ' .

--- a/src/class/object_phenotypes.php
+++ b/src/class/object_phenotypes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2021-04-22
+ * Modified    : 2021-07-07
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -65,7 +65,7 @@ class LOVD_Phenotype extends LOVD_Custom
 
         // SQL code for viewing an entry.
         $this->aSQLViewEntry['SELECT']   = 'p.*, ' .
-                                           'IFNULL(i.license, iuc.default_license) AS license, ' .
+                                           'IFNULL(NULLIF(i.license, ""), iuc.default_license) AS license, ' .
                                            'i.statusid AS individual_statusid, ' .
                                            'd.symbol AS disease, ' .
                                            'uo.name AS owned_by_, CONCAT_WS(";", uo.id, uo.name, uo.email, uo.institute, uo.department, IFNULL(uo.countryid, "")) AS _owner, ' .

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2021-04-22
+ * Modified    : 2021-07-07
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -68,7 +68,7 @@ class LOVD_Screening extends LOVD_Custom
 
         // SQL code for viewing an entry.
         $this->aSQLViewEntry['SELECT']   = 's.*, ' .
-                                           'IFNULL(i.license, iuc.default_license) AS license, ' .
+                                           'IFNULL(NULLIF(i.license), iuc.default_license) AS license, ' .
                                            'i.statusid AS individual_statusid, ' .
                                            'GROUP_CONCAT(DISTINCT "=\"", s2g.geneid, "\"" SEPARATOR "|") AS search_geneid, ' .
                                            'IF(s.variants_found = 1 AND COUNT(s2v.variantid) = 0, -1, COUNT(DISTINCT ' . ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? 's2v.variantid' : 'vog.id') . ')) AS variants_found_, ' .

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-27
- * Modified    : 2021-04-21
+ * Modified    : 2021-07-07
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -729,7 +729,7 @@ foreach ($zAnnouncements as $zAnnouncement) {
             $nCurators = count($aCurators);
             foreach ($aCurators as $i => $z) {
                 $i ++;
-                $sCurators .= ($sCurators? ($i == $nCurators? ' and ' : ', ') : '') . '<A href="mailto:' . str_replace(array("\r\n", "\r", "\n"), ', ', trim($z['email'])) . '">' . $z['name'] . '</A>';
+                $sCurators .= ($sCurators? ($i == $nCurators? ($i == 2? '' : ',') . ' and ' : ', ') : '') . '<A href="mailto:' . str_replace(array("\r\n", "\r", "\n"), ', ', trim($z['email'])) . '">' . $z['name'] . '</A>';
             }
 
             if ($sCurators) {


### PR DESCRIPTION
Added the GA4GH Data Discovery API to LOVD3.
- This is a full LOVD3-specific implementation of the GA4GH Data Discovery standards without the use of other libraries.
- Supported URLs:
  - `/api/v#/ga4gh` (GET/HEAD) (redirects)
  - `/api/v#/ga4gh/service-info` (GET/HEAD)
  - `/api/v#/ga4gh/tables` (GET/HEAD)
  - `/api/v#/ga4gh/table/variants` (GET/HEAD) (redirects)
  - `/api/v#/ga4gh/table/variants/info` (GET/HEAD)
  - `/api/v#/ga4gh/table/variants/data` (GET/HEAD)
  - `/api/v#/ga4gh/table/variants/data:hg19:chr1:123456` (GET/HEAD)
  - `/api/v#/ga4gh/table/variants/data:hg19:chr1:123456-234567` (GET/HEAD)
- This endpoint is available from API version 2 (v2).
- This endpoint currently requires authorization.
- The data is shared using the VarioML [aggregated variant format](https://github.com/VarioML/VarioML/tree/master/json/schemas/v.2.0/variant.json), which was developed in parallel to the development of this API. No other format is available or supported. This format allows for the export of virtually all standard fields in LOVD.
- The data can be viewed in a paginated manner, as specified in the GA4GH standards.
- Filtering on the date an entry was last edited is possible using the `If-Modified-Since` HTTP request header.
- Data is only shown when the given licenses allow LOVD to do so. License information is shown in the output.

Closes #518.