### PR TITLE
Fix several query errors collected from the logs.

### DIFF
--- a/src/ajax/viewentry.php
+++ b/src/ajax/viewentry.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-11-09
- * Modified    : 2020-02-24
- * For LOVD    : 3.0-24
+ * Modified    : 2021-07-12
+ * For LOVD    : 3.0-27
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -60,6 +60,7 @@ if (isset($aNeededLevel[$sObject])) {
 // Call isAuthorized() on the object. NB: isAuthorized() modifies the global
 // $_AUTH for curators, owners and colleagues.
 if ($sObject == 'Transcript_Variant') {
+    // Note that these values have NOT been sanitized yet.
     list($nVariantID, $nTranscriptID) = explode(',', $nID);
     lovd_isAuthorized('variant', $nVariantID);
 } elseif ($sObject == 'User') {
@@ -97,8 +98,6 @@ if (!file_exists($sFile)) {
 if (in_array($sObject, array('Phenotype', 'Transcript_Variant', 'Custom_ViewList', 'ScreeningPLUS'))) {
     // Exception for VOT viewEntry, we need to isolate the gene from the ID to correctly pass this to the data object.
     if ($sObject == 'Transcript_Variant') {
-        // This line below is redundant as long as it's also called at the lovd_isAuthorized() call. Remove it here maybe...?
-        list($nVariantID, $nTranscriptID) = explode(',', $nID);
         $sObjectID = $_DB->query('SELECT geneid FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ?', array($nTranscriptID))->fetchColumn();
     }
 }

--- a/src/class/object_diseases.php
+++ b/src/class/object_diseases.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-07-28
- * Modified    : 2019-10-01
- * For LOVD    : 3.0-22
+ * Modified    : 2021-07-12
+ * For LOVD    : 3.0-27
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -225,7 +225,7 @@ class LOVD_Disease extends LOVD_Object
                                     'db'   => array('d.id_omim', 'ASC', true)),
                         'inheritance' => array(
                                     'view' => array('Inheritance', 75),
-                                    'db'   => array('inheritance', 'ASC', true),
+                                    'db'   => array('d.inheritance', 'ASC', true),
                                     'legend' => array('Abbreviations:' . strip_tags(str_replace('<TR>', "\n", preg_replace('/\s+/', ' ', $sInheritanceLegend))),
                                         'Values based on OMIM\'s and HPO\'s values for inheritance.<BR>' . str_replace(array("\r", "\n"), '', $sInheritanceLegend),
                                     )),

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2021-07-07
+ * Modified    : 2021-07-12
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -68,7 +68,7 @@ class LOVD_Screening extends LOVD_Custom
 
         // SQL code for viewing an entry.
         $this->aSQLViewEntry['SELECT']   = 's.*, ' .
-                                           'IFNULL(NULLIF(i.license), iuc.default_license) AS license, ' .
+                                           'IFNULL(NULLIF(i.license, ""), iuc.default_license) AS license, ' .
                                            'i.statusid AS individual_statusid, ' .
                                            'GROUP_CONCAT(DISTINCT "=\"", s2g.geneid, "\"" SEPARATOR "|") AS search_geneid, ' .
                                            'IF(s.variants_found = 1 AND COUNT(s2v.variantid) = 0, -1, COUNT(DISTINCT ' . ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? 's2v.variantid' : 'vog.id') . ')) AS variants_found_, ' .

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-12
- * Modified    : 2020-12-28
- * For LOVD    : 3.0-26
+ * Modified    : 2021-07-12
+ * For LOVD    : 3.0-27
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -571,7 +571,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
         global $_DB;
 
         list($nID, $nTranscriptID) = explode(',', $nID);
-        $this->aSQLViewEntry['WHERE'] .= (empty($this->aSQLViewEntry['WHERE'])? '' : ' AND ') . 'vot.transcriptid = \'' . $nTranscriptID . '\'';
+        $this->aSQLViewEntry['WHERE'] .= (empty($this->aSQLViewEntry['WHERE'])? '' : ' AND ') . 'vot.transcriptid = ' . (int) $nTranscriptID;
 
         // Before passing this on to parent::viewEntry(), perform a standard count() check on the transcript ID,
         // to make sure that we won't get a query error when the combination of VariantID/TranscriptID does not yield

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-02-22
- * For LOVD    : 3.0-26
+ * Modified    : 2021-07-12
+ * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -2933,6 +2933,7 @@ class LOVD_Object
                 }
 
                 if ($aOptions['show_navigation']) {
+                    lovd_pagesplitInit(); // Has not run yet when we have bad search syntax.
                     lovd_pagesplitShowNav($sViewListID, $nTotal, $bTrueCount, $bSortableVL, $bLegend);
                 }
 

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2020-10-28
- * For LOVD    : 3.0-26
+ * Modified    : 2021-07-12
+ * For LOVD    : 3.0-27
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -718,9 +718,10 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'removeVariants') {
     if (POST) {
         lovd_errorClean();
 
-        // Preventing notices...
-        // $_SESSION['viewlists']['Screenings_' . $nID . '_removeVariants']['checked'] stores the IDs of the variants that are supposed to be present in TABLE_SCR2VAR.
-        if (isset($_SESSION['viewlists']['Screenings_' . $nID . '_removeVariants']['checked'])) {
+        if (empty($_SESSION['viewlists']['Screenings_' . $nID . '_removeVariants']['checked'])) {
+            // No variants selected.
+            lovd_errorAdd('', 'Please select at least one variant to remove.');
+        } else {
             // Check if all checked variants are actually from this screening.
             $aDiff = array_diff($_SESSION['viewlists']['Screenings_' . $nID . '_removeVariants']['checked'], $aValidVariants);
             if (!empty($aDiff)) {


### PR DESCRIPTION
Fix several query errors collected from the logs.
- Fix stupid typo that my test scripts should have picked up. If only my tests were working... still need to migrate to Travis.com.
- Fix notices with bad search syntax VLs.
- Fix query error in the query optimizer.
  - Searching in the inheritance field using `HAVING` was confusing the query optimizer. It's a local column, so it should use `WHERE`.
- Fix SQL injection vulnerability.
  - IDs sent through ajax weren't fully sanitized.
- Fix query error when not selecting variants to remove from a screening.
  - Now, removing variants from a screening checks if you have selected at least one. This is the same as confirming variants to be added to a screening, so it's odd that this code differed.

Closes #527.