### PR TITLE
Improve security.

### DIFF
--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-07-12
+ * Modified    : 2021-07-13
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -3102,9 +3102,9 @@ FROptions
                 // FIXME; This code is sort of duplicated, some 100 lines below we also print this, *if* results are found.
                 print('</TABLE><BR>' . "\n"); // <BR> is necessary to keep the InfoTable apart from the data headers.
                 if ($aOptions['show_navigation']) {
-                    print('        <INPUT type="hidden" name="total" value="' . $nTotal . '" disabled>' . "\n" .
-                          '        <INPUT type="hidden" name="page_size" value="' . $_GET['page_size'] . '">' . "\n" .
-                          '        <INPUT type="hidden" name="page" value="' . $_GET['page'] . '">' . "\n");
+                    print('        <INPUT type="hidden" name="total" value="' . (int) $nTotal . '" disabled>' . "\n" .
+                          '        <INPUT type="hidden" name="page_size" value="' . (int) $_GET['page_size'] . '">' . "\n" .
+                          '        <INPUT type="hidden" name="page" value="' . (int) $_GET['page'] . '">' . "\n");
                 }
                 lovd_showInfoTable($sMessage, 'stop');
                 print('      </DIV></FORM>' . "\n\n");

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2021-07-07
+ * Modified    : 2021-07-13
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -877,12 +877,15 @@ if (!defined('NOT_INSTALLED')) {
     $sPath = preg_replace('/^' . preg_quote(lovd_getInstallURL(false), '/') . '/', '', lovd_cleanDirName(rawurldecode($_SERVER['REQUEST_URI']))); // 'login' or 'genes?create' or 'users/00001?edit'
     $sPath = strip_tags($sPath); // XSS tag removal on entire string (and no longer on individual parts).
     $sPath = strstr($sPath . '?', '?', true); // Cut off the Query string, that will be handled later.
-    if (strpos($sPath, '"') !== false) {
-        // XSS attack. Filter everything out.
-        $sPath = strstr($sPath, '"', true);
-        // Also overwrite $_SERVER['REQUEST_URI'] as it's used more often (e.g., gene switcher) and we want it cleaned.
-        $_SERVER['REQUEST_URI'] = strstr($_SERVER['REQUEST_URI'], '%22', true) .
-            (empty($_SERVER['QUERY_STRING'])? '' : '?' . $_SERVER['QUERY_STRING']);
+    foreach (array("'", '"', '`', '+') as $sChar) {
+        // All these kind of quotes that we'll never have unless somebody is messing with us.
+        if (strpos($sPath, $sChar) !== false) {
+            // XSS attack. Filter everything out.
+            $sPath = strstr($sPath, $sChar, true);
+            // Also overwrite $_SERVER['REQUEST_URI'] as it's used more often (e.g., gene switcher) and we want it cleaned.
+            $_SERVER['REQUEST_URI'] = strstr($_SERVER['REQUEST_URI'], rawurlencode($sChar), true) .
+                (empty($_SERVER['QUERY_STRING'])? '' : '?' . $_SERVER['QUERY_STRING']);
+        }
     }
     $_PE = explode('/', rtrim($sPath, '/')); // array('login') or array('genes') or array('users', '00001')
 

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -927,8 +927,12 @@ if (!defined('NOT_INSTALLED')) {
 
         // Load DB admin data; needed by sending messages.
         if ($_AUTH && $_AUTH['level'] == LEVEL_ADMIN) {
-            // Saves me quering the database!
-            $_SETT['admin'] = array('name' => $_AUTH['name'], 'email' => $_AUTH['email']);
+            // Saves me querying the database!
+            $_SETT['admin'] = array(
+                'name' => $_AUTH['name'],
+                'email' => $_AUTH['email'],
+                'address_formatted' => $_AUTH['name'] . ' <' . str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_AUTH['email'])) . '>',
+            );
         } else {
             $_SETT['admin'] = array('name' => '', 'email' => ''); // We must define the keys first, or the order of the keys will not be correct.
             list($_SETT['admin']['name'], $_SETT['admin']['email']) = $_DB->query('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ? AND id > 0 ORDER BY id ASC', array(LEVEL_ADMIN))->fetchRow();

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -874,7 +874,7 @@ if (!defined('NOT_INSTALLED')) {
     // Define $_PE ($_PATH_ELEMENTS) and CURRENT_PATH.
     // FIXME: Running lovd_cleanDirName() on the entire URI causes it to run also on the arguments.
     //  If there are arguments with ../ in there, this will take effect and arguments or even the path itself is eaten.
-    $sPath = preg_replace('/^' . preg_quote(lovd_getInstallURL(false), '/') . '/', '', lovd_cleanDirName(rawurldecode($_SERVER['REQUEST_URI']))); // 'login' or 'genes?create' or 'users/00001?edit'
+    $sPath = preg_replace('/^' . preg_quote(lovd_getInstallURL(false), '/') . '/', '', lovd_cleanDirName(html_entity_decode(rawurldecode($_SERVER['REQUEST_URI']), ENT_HTML5))); // 'login' or 'genes?create' or 'users/00001?edit'
     $sPath = strip_tags($sPath); // XSS tag removal on entire string (and no longer on individual parts).
     $sPath = strstr($sPath . '?', '?', true); // Cut off the Query string, that will be handled later.
     foreach (array("'", '"', '`', '+') as $sChar) {

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -73,9 +73,9 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
             $_T->printHeader();
             $_T->printTitle();
             lovd_writeLog('Auth', LOG_EVENT, $_SERVER['REMOTE_ADDR'] . ' (' . lovd_php_gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') tried to reset password for non-existent account ' . $_POST['username']);
-            print('      If you entered the username or email address correctly, we have successfully reset your password and we have sent you an email.' . "\n" .
+            print('      If you entered the username or email address correctly, we have successfully reset your password and we have sent you an email containing your new password.' . "\n" .
                   '      With this new password, you can <A href="' . ROOT_PATH . 'login">unlock your account</A> and choose a new password.<BR><BR>' . "\n" .
-                  '      If you don\'t receive this email, it is possible that the username or email address that you entered is not correct. Please double-check it. Another possibility is that you registered at a different LOVD installation. Accounts are not shared between different LOVD installations, so please double-check where you are registered.<BR><BR>' . "\n\n");
+                  '      If you don\'t receive this email, it is possible that the username or email address that you entered was not correct. In that case, please double-check it. Another possibility is that you registered at a different LOVD installation. Accounts are not shared between different LOVD installations, so please double-check where you are registered.<BR><BR>' . "\n\n");
             $_T->printFooter();
             exit;
 
@@ -154,8 +154,9 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
             $_T->printTitle();
 
             if ($bMail) {
-                print('      Successfully reset your password.<BR>' . "\n" .
-                      '      We\'ve sent you an email containing your new password. With this new password, you can <A href="' . ROOT_PATH . 'login.php">unlock your account</A> and choose a new password.<BR><BR>' . "\n\n");
+                print('      If you entered the username or email address correctly, we have successfully reset your password and we have sent you an email containing your new password.' . "\n" .
+                      '      With this new password, you can <A href="' . ROOT_PATH . 'login">unlock your account</A> and choose a new password.<BR><BR>' . "\n" .
+                      '      If you don\'t receive this email, it is possible that the username or email address that you entered was not correct. In that case, please double-check it. Another possibility is that you registered at a different LOVD installation. Accounts are not shared between different LOVD installations, so please double-check where you are registered.<BR><BR>' . "\n\n");
             } else {
                 // Couldn't send confirmation...
                 lovd_writeLog('Error', LOG_EVENT, 'Error sending email for account ' . $_AUTH['username'] . ' (' . $zData['name'] . ')');

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -52,6 +52,11 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
     if (POST && !empty($_POST['username'])) {
         lovd_errorClean();
 
+        // Sleep a second to prevent this script from being run
+        //  too many times in sequence. Run it here so people can't see the
+        //  difference between a successful attempt or a failure.
+        sleep(1);
+
         // Find account.
         $zData = array($_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE username = ?',
             array($_POST['username']))->fetchAssoc());
@@ -83,10 +88,6 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
 
         if (!lovd_error()) {
             // Found account... unlock and generate new passwd.
-
-            // Sleep a second to prevent this script from being run
-            //  too many times in sequence.
-            sleep(1);
 
             $aChars =
                      array(

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-20
- * Modified    : 2021-04-14
+ * Modified    : 2021-07-13
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -83,6 +83,10 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
 
         if (!lovd_error()) {
             // Found account... unlock and generate new passwd.
+
+            // Sleep a second to prevent this script from being run
+            //  too many times in sequence.
+            sleep(1);
 
             $aChars =
                      array(


### PR DESCRIPTION
Improve security.
- Force some printed variables into integers.
  - Although they're safe now (as long as the pagination is inited), we'd better force some variables into integers since they should be integers, before printing them to the screen.
- Also protect against other characters that can cause an XSS.
  - None of these belong in our URLs.
  - HTML entity encoded characters can also be used for XSS.
- Sleep for one second when resetting a password.
  - This was reported as a possible dos vulnerability. Rate-limiting this client-side could easily be circumvented. I don't want to go through the trouble now and rate-limit this server-side (per IP address or so). Just a `sleep()` will be fine for now.
- Also synced the two different messages printed to the screen.
  - Whether the password reset was successful or not (i.e., whether the username or email address was found in the system), could be recognized by the message printed to the screen. Now the messages are the same to not leak information on which usernames exist.

Also:
- Fix notice that could occur in the APIs when admin was logged in.
  - There wasn't a formatted admin email address when admin was logged in; it was only collected when admin wasn't the user triggering the error.