### PR TITLE
Improve the GA4GH API.

### DIFF
--- a/src/api.php
+++ b/src/api.php
@@ -33,6 +33,7 @@
  *  3.0-27 (v2)  /api/v#/ga4gh (GET/HEAD) (redirects)
  *  3.0-27 (v2)  /api/v#/ga4gh/service-info (GET/HEAD)
  *  3.0-27 (v2)  /api/v#/ga4gh/tables (GET/HEAD)
+ *  3.0-27 (v2)  /api/v#/ga4gh/table/variants (GET/HEAD) (redirects)
  *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/info (GET/HEAD)
  *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data (GET/HEAD)
  *  3.0-27 (v2)  /api/v#/ga4gh/table/variants/data:hg19:chr1:123456 (GET/HEAD)

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -453,7 +453,7 @@ class LOVD_API_GA4GH
         $aReturn = array();
 
         foreach (explode(';', str_replace('}', '};', $sReference)) as $sRef) {
-            $sRef = trim($sRef);
+            $sRef = trim($sRef, ', ');
             if ($sRef) {
                 if (preg_match('/^\{PMID:([^}]+):([0-9]+)\}$/', $sRef, $aRegs)
                     && in_array('pubmed', $aOptions)) {

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -515,7 +515,7 @@ class LOVD_API_GA4GH
 
         } else {
             $sToken = substr($aHeaders['Authorization'], 7);
-            if ($sToken != md5($_STAT['signature'])) {
+            if ($sToken != md5('auth:' . $_STAT['signature'])) {
                 $this->API->nHTTPStatus = 401; // Send 401 Unauthorized.
                 $this->API->aResponse = array('errors' => array(
                     'title' => 'Access denied.',
@@ -608,8 +608,8 @@ class LOVD_API_GA4GH
         global $_STAT;
 
         $aOutput = array(
-            'id' => 'nl.lovd.ga4gh.' . md5(md5($_STAT['signature'])), // Note, a double md5(), to not leak the LSDB ID nor the signature.
-            'name' => 'GA4GH Data Connect API for LOVD instance ' . md5(md5($_STAT['signature'])),
+            'id' => 'nl.lovd.ga4gh.' . md5($_STAT['signature']),
+            'name' => 'GA4GH Data Connect API for LOVD instance ' . md5($_STAT['signature']),
             'type' => array(
                 'group' => 'org.ga4gh',
                 'artifact' => 'service-registry',

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-07-15
+ * Modified    : 2021-07-16
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -871,9 +871,9 @@ class LOVD_API_GA4GH
             (!$bdbSNP? '' : ',
                        IFNULL(vog.`VariantOnGenome/dbSNP`, "")') . ', "||"' .
             (!$bVOGReference? '' : ',
-                       IFNULL(vog.`VariantOnGenome/Reference`, "")') . ', "||"' .
+                       REPLACE(IFNULL(vog.`VariantOnGenome/Reference`, ""), ";", ",")') . ', "||"' .
             (!$bVOGRemarks? '' : ',
-                       IFNULL(vog.`VariantOnGenome/Remarks`, "")') . ', "||",
+                       REPLACE(IFNULL(vog.`VariantOnGenome/Remarks`, ""), ";", ",")') . ', "||",
                        IFNULL(
                          (SELECT
                             GROUP_CONCAT(
@@ -1280,9 +1280,9 @@ class LOVD_API_GA4GH
                     (!$bdbSNP? '' : ',
                           IFNULL(vog.`VariantOnGenome/dbSNP`, "")') . ', "||"' .
                     (!$bVOGReference? '' : ',
-                          IFNULL(vog.`VariantOnGenome/Reference`, "")') . ', "||"' .
+                          REPLACE(IFNULL(vog.`VariantOnGenome/Reference`, ""), ";", ",")') . ', "||"' .
                     (!$bVOGRemarks? '' : ',
-                          IFNULL(vog.`VariantOnGenome/Remarks`, "")') . ', "||",
+                          REPLACE(IFNULL(vog.`VariantOnGenome/Remarks`, ""), ";", ",")') . ', "||",
                           IFNULL(s.`Screening/Template`, ""), "||",
                           IFNULL(s.`Screening/Technique`, ""), "||",
                           IFNULL(

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-07-09
+ * Modified    : 2021-07-14
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1563,6 +1563,26 @@ class LOVD_API_GA4GH
                         current($this->convertEffectsToVML($nID . ':' . $sEffects)),
                         array_values($this->convertClassificationToVML($nID . ':' . $sClassification . ':' . $sClassificationMethod))
                     );
+                    if ($sChr == 'M') {
+                        // The GV shared sometimes uses "pathogenic (maternal)"
+                        //  for chrM variants, which makes no sense. These
+                        //  values are meant to indicate imprinting,
+                        //  so this should be removed here.
+                        $aVariant['pathogenicities'] = array_map(function ($aPathogenicity) {
+                            if (isset($aPathogenicity['comments'])) {
+                                foreach ($aPathogenicity['comments'] as $nKey => $aComment) {
+                                    if (isset($aComment['term']) && $aComment['term'] == 'IIMPRINTING') {
+                                        // Delete this.
+                                        unset($aPathogenicity['comments'][$nKey]);
+                                    }
+                                }
+                                if (!count($aPathogenicity['comments'])) {
+                                    unset($aPathogenicity['comments']);
+                                }
+                            }
+                            return $aPathogenicity;
+                        }, $aVariant['pathogenicities']);
+                    }
 
                     if ($sOrigin && isset($this->aValueMappings['genetic_origin'][$sOrigin])) {
                         $aVariant['genetic_origin'] = array(

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -834,7 +834,7 @@ class LOVD_API_GA4GH
         $aLicensesSummaryData = array_keys(array_diff($aLicenses, array(1)));
 
         // We'll need lots of space for GROUP_CONCAT().
-        $_DB->query('SET group_concat_max_len = 200000');
+        $_DB->query('SET group_concat_max_len = 1000000');
 
         // Fetch data. We do this in two steps; first the basic variant
         //  information and after that the full submission data.

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-07-14
+ * Modified    : 2021-07-15
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1021,7 +1021,9 @@ class LOVD_API_GA4GH
             }
 
             $aReturn['effectids'] = $this->convertEffectsToVML($zData['effectids']);
-            $aReturn['classifications'] = $this->convertClassificationToVML($zData['classifications']);
+            if (!empty($zData['classifications'])) {
+                $aReturn['classifications'] = $this->convertClassificationToVML($zData['classifications']);
+            }
 
             // Further annotate the entries.
             $aSubmissions = array();
@@ -1834,10 +1836,13 @@ class LOVD_API_GA4GH
             }
 
             // The aggregate pathogenicities aren't stored well yet.
-            $aReturn['pathogenicities'] = array_merge(
-                call_user_func_array('array_merge', $aReturn['effectids']),
-                array_values($aReturn['classifications'])
-            );
+            $aReturn['pathogenicities'] = call_user_func_array('array_merge', $aReturn['effectids']);
+            if (!empty($aReturn['classifications'])) {
+                $aReturn['pathogenicities'] = array_merge(
+                    $aReturn['pathogenicities'],
+                    array_values($aReturn['classifications'])
+                );
+            }
             unset($aReturn['effectids'], $aReturn['classifications']);
 
             // Clean "individuals", "panels" and "variants" when empty.

--- a/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
+++ b/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
@@ -104,5 +104,39 @@ class VerifyGA4GHAPITest extends LOVDSeleniumWebdriverBaseTestCase
             'url' => 'https://lovd.nl/',
         ), $aResult['organization']);
     }
+
+
+
+
+
+    /**
+     * @depends testServiceInfo
+     */
+    public function testTables ()
+    {
+        $sResult = file_get_contents(
+            ROOT_URL . '/src/api/ga4gh/tables', false, stream_context_create(
+            array(
+                'http' => array(
+                    'method' => 'GET',
+                    'user_agent' => 'LOVD/phpunit',
+                    'follow_location' => 0,
+                ))));
+        $aResult = json_decode($sResult, true);
+
+        $this->assertRegExp('/^HTTP\/1\.. 200 OK$/', $http_response_header[0]);
+        $this->assertArrayHasKey('tables', $aResult);
+        $this->assertCount(1, $aResult['tables']);
+        $this->assertEquals('variants', $aResult['tables'][0]['name']);
+        $this->assertArrayHasKey('data_model', $aResult['tables'][0]);
+        $this->assertArrayHasKey('$ref', $aResult['tables'][0]['data_model']);
+        $sDataModel = @file_get_contents($aResult['tables'][0]['data_model']['$ref']);
+        $this->assertStringStartsWith('{', $sDataModel);
+        $aDataModel = @json_decode($sDataModel, true);
+        $this->assertTrue(is_array($aDataModel));
+        $this->assertArrayHasKey('$schema', $aDataModel);
+        $this->assertArrayHasKey('title', $aDataModel);
+        $this->assertEquals('Variant', $aDataModel['title']);
+    }
 }
 ?>

--- a/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
+++ b/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
@@ -138,5 +138,32 @@ class VerifyGA4GHAPITest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertArrayHasKey('title', $aDataModel);
         $this->assertEquals('Variant', $aDataModel['title']);
     }
+
+
+
+
+
+    /**
+     * @depends testTables
+     */
+    public function testTableVariants ()
+    {
+        $sResult = file_get_contents(
+            ROOT_URL . '/src/api/ga4gh/table/variants', false, stream_context_create(
+            array(
+                'http' => array(
+                    'method' => 'GET',
+                    'user_agent' => 'LOVD/phpunit',
+                    'follow_location' => 0,
+                ))));
+        $aResult = json_decode($sResult, true);
+
+        $this->assertRegExp('/^HTTP\/1\.. 302 (Moved Temporarily|Found)$/', $http_response_header[0]);
+        $this->assertEquals(array(), $aResult['warnings']);
+        $this->assertEquals(array(), $aResult['errors']);
+        $this->assertEquals(array(), $aResult['data']);
+        $this->assertRegExp('/^Location: ' . preg_quote(ROOT_URL, '/') . '\/src\/api\/v[0-9]\/ga4gh\/table\/variants\/data$/',
+            $aResult['messages'][0]);
+    }
 }
 ?>

--- a/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
+++ b/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
@@ -47,5 +47,32 @@ class VerifyGA4GHAPITest extends LOVDSeleniumWebdriverBaseTestCase
             $this->markTestSkipped('Gene does not exist yet.');
         }
     }
+
+
+
+
+
+    /**
+     * @depends testSetUp
+     */
+    public function testAPIRoot ()
+    {
+        $sResult = file_get_contents(
+            ROOT_URL . '/src/api/ga4gh', false, stream_context_create(
+                array(
+                    'http' => array(
+                        'method' => 'GET',
+                        'user_agent' => 'LOVD/phpunit',
+                        'follow_location' => 0,
+                    ))));
+        $aResult = json_decode($sResult, true);
+
+        $this->assertRegExp('/^HTTP\/1\.. 302 (Moved Temporarily|Found)$/', $http_response_header[0]);
+        $this->assertEquals(array(), $aResult['warnings']);
+        $this->assertEquals(array(), $aResult['errors']);
+        $this->assertEquals(array(), $aResult['data']);
+        $this->assertRegExp('/^Location: ' . preg_quote(ROOT_URL, '/') . '\/src\/api\/v[0-9]\/ga4gh\/service-info$/',
+            $aResult['messages'][0]);
+    }
 }
 ?>

--- a/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
+++ b/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
@@ -1,0 +1,51 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2021-07-14
+ * Modified    : 2021-07-14
+ * For LOVD    : 3.0-27
+ *
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
+require_once 'LOVDSeleniumBaseTestCase.php';
+
+use \Facebook\WebDriver\WebDriverBy;
+
+class VerifyGA4GHAPITest extends LOVDSeleniumWebdriverBaseTestCase
+{
+    public function testSetUp ()
+    {
+        // A normal setUp() runs for every test in this file. We only need this once,
+        //  so we disguise this setUp() as a test that we depend on just once.
+        $this->driver->get(ROOT_URL . '/src/genes/IVD');
+        $sBody = $this->driver->findElement(WebDriverBy::tagName('body'))->getText();
+        if (preg_match('/LOVD was not installed yet/', $sBody)) {
+            $this->markTestSkipped('LOVD was not installed yet.');
+        }
+        if (preg_match('/No such ID!/', $sBody)) {
+            $this->markTestSkipped('Gene does not exist yet.');
+        }
+    }
+}
+?>

--- a/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
+++ b/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
@@ -74,5 +74,35 @@ class VerifyGA4GHAPITest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertRegExp('/^Location: ' . preg_quote(ROOT_URL, '/') . '\/src\/api\/v[0-9]\/ga4gh\/service-info$/',
             $aResult['messages'][0]);
     }
+
+
+
+
+
+    /**
+     * @depends testAPIRoot
+     */
+    public function testServiceInfo ()
+    {
+        $sResult = file_get_contents(
+            ROOT_URL . '/src/api/ga4gh/service-info', false, stream_context_create(
+            array(
+                'http' => array(
+                    'method' => 'GET',
+                    'user_agent' => 'LOVD/phpunit',
+                    'follow_location' => 0,
+                ))));
+        $aResult = json_decode($sResult, true);
+
+        $this->assertRegExp('/^HTTP\/1\.. 200 OK$/', $http_response_header[0]);
+        $this->assertStringStartsWith('nl.lovd.ga4gh.', $aResult['id']);
+        $this->assertStringStartsWith('GA4GH Data Connect API', $aResult['name']);
+        $this->assertEquals('org.ga4gh', $aResult['type']['group']);
+        $this->assertEquals('service-registry', $aResult['type']['artifact']);
+        $this->assertEquals(array(
+            'name' => 'Leiden Open Variation Database (LOVD)',
+            'url' => 'https://lovd.nl/',
+        ), $aResult['organization']);
+    }
 }
 ?>

--- a/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
+++ b/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
@@ -36,6 +36,7 @@ class VerifyGA4GHAPITest extends LOVDSeleniumWebdriverBaseTestCase
 {
     public function testSetUp ()
     {
+$this->login('admin', 'test1234');
         // A normal setUp() runs for every test in this file. We only need this once,
         //  so we disguise this setUp() as a test that we depend on just once.
         $this->driver->get(ROOT_URL . '/src/genes/IVD');
@@ -164,6 +165,31 @@ class VerifyGA4GHAPITest extends LOVDSeleniumWebdriverBaseTestCase
         $this->assertEquals(array(), $aResult['data']);
         $this->assertRegExp('/^Location: ' . preg_quote(ROOT_URL, '/') . '\/src\/api\/v[0-9]\/ga4gh\/table\/variants\/data$/',
             $aResult['messages'][0]);
+    }
+
+
+
+
+
+    /**
+     * @depends testTableVariants
+     */
+    public function testTableVariantsInfo ()
+    {
+        $sResult = file_get_contents(
+            ROOT_URL . '/src/api/ga4gh/table/variants/info', false, stream_context_create(
+            array(
+                'http' => array(
+                    'method' => 'GET',
+                    'user_agent' => 'LOVD/phpunit',
+                    'follow_location' => 0,
+                ))));
+        $aResult = json_decode($sResult, true);
+
+        $this->assertRegExp('/^HTTP\/1\.. 200 OK$/', $http_response_header[0]);
+        $this->assertArrayHasKey('name', $aResult);
+        $this->assertEquals('variants', $aResult['name']);
+        $this->assertArrayHasKey('data_model', $aResult);
     }
 }
 ?>

--- a/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
+++ b/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
@@ -221,5 +221,41 @@ $this->login('admin', 'test1234');
         $this->assertRegExp('/^' . preg_quote(ROOT_URL, '/') . '\/src\/api\/v[0-9]\/ga4gh\/table\/variants\/data%3Ahg[0-9]{2}%3Achr1$/',
             $aResult['pagination']['next_page_url']);
     }
+
+
+
+
+
+    /**
+     * @depends testTableVariants
+     */
+    public function testTableVariantsDataChr15 ()
+    {
+        $sResult = file_get_contents(
+            ROOT_URL . '/src/api/ga4gh/table/variants/data:hg19:chr15', false, stream_context_create(
+            array(
+                'http' => array(
+                    'method' => 'GET',
+                    'user_agent' => 'LOVD/phpunit',
+                    'follow_location' => 0,
+                ))));
+        $aResult = json_decode($sResult, true);
+
+        $this->assertRegExp('/^HTTP\/1\.. 200 OK$/', $http_response_header[0]);
+        $this->assertArrayHasKey('data_model', $aResult);
+        $this->assertArrayHasKey('data', $aResult);
+        $this->assertCount(2, $aResult['data']);
+        $this->assertArrayHasKey('pagination', $aResult);
+        $this->assertArrayHasKey('next_page_url', $aResult['pagination']);
+        $this->assertCount(1, $aResult['pagination']);
+        $this->assertRegExp('/^' . preg_quote(ROOT_URL, '/') . '\/src\/api\/v[0-9]\/ga4gh\/table\/variants\/data%3Ahg[0-9]{2}%3Achr16%3A1$/',
+            $aResult['pagination']['next_page_url']);
+
+        // Now compare the two files.
+        $this->assertEquals(
+            trim(file_get_contents(ROOT_PATH . '../tests/test_data_files/AdminTestSuiteResult-GA4GH.txt')),
+            preg_replace('/\b[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\+[0-9]{2}:[0-9]{2}\b/', '0000-00-00T00:00:00+00:00', trim($sResult))
+        );
+    }
 }
 ?>

--- a/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
+++ b/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
@@ -191,5 +191,35 @@ $this->login('admin', 'test1234');
         $this->assertEquals('variants', $aResult['name']);
         $this->assertArrayHasKey('data_model', $aResult);
     }
+
+
+
+
+
+    /**
+     * @depends testTableVariantsInfo
+     */
+    public function testTableVariantsData ()
+    {
+        $sResult = file_get_contents(
+            ROOT_URL . '/src/api/ga4gh/table/variants/data', false, stream_context_create(
+            array(
+                'http' => array(
+                    'method' => 'GET',
+                    'user_agent' => 'LOVD/phpunit',
+                    'follow_location' => 0,
+                ))));
+        $aResult = json_decode($sResult, true);
+
+        $this->assertRegExp('/^HTTP\/1\.. 200 OK$/', $http_response_header[0]);
+        $this->assertArrayHasKey('data_model', $aResult);
+        $this->assertArrayHasKey('data', $aResult);
+        $this->assertCount(0, $aResult['data']);
+        $this->assertArrayHasKey('pagination', $aResult);
+        $this->assertArrayHasKey('next_page_url', $aResult['pagination']);
+        $this->assertCount(1, $aResult['pagination']);
+        $this->assertRegExp('/^' . preg_quote(ROOT_URL, '/') . '\/src\/api\/v[0-9]\/ga4gh\/table\/variants\/data%3Ahg[0-9]{2}%3Achr1$/',
+            $aResult['pagination']['next_page_url']);
+    }
 }
 ?>

--- a/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
+++ b/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-07-14
- * Modified    : 2021-07-15
+ * Modified    : 2021-07-16
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -251,9 +251,12 @@ class VerifyGA4GHAPITest extends LOVDSeleniumWebdriverBaseTestCase
             $aResult['pagination']['next_page_url']);
 
         // Now compare the two files.
+        // Removing \/git from the path of next_page_url to make sure
+        //  that local tests and remote tests have the same string.
         $this->assertEquals(
             trim(file_get_contents(ROOT_PATH . '../tests/test_data_files/AdminTestSuiteResult-GA4GH.txt')),
-            preg_replace('/\b[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\+[0-9]{2}:[0-9]{2}\b/', '0000-00-00T00:00:00+00:00', trim($sResult))
+            str_replace('\/git', '',
+                preg_replace('/\b[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\+[0-9]{2}:[0-9]{2}\b/', '0000-00-00T00:00:00+00:00', trim($sResult)))
         );
     }
 }

--- a/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
+++ b/tests/selenium_tests/admin_tests/verify_GA4GH_API.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-07-14
- * Modified    : 2021-07-14
+ * Modified    : 2021-07-15
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -36,7 +36,6 @@ class VerifyGA4GHAPITest extends LOVDSeleniumWebdriverBaseTestCase
 {
     public function testSetUp ()
     {
-$this->login('admin', 'test1234');
         // A normal setUp() runs for every test in this file. We only need this once,
         //  so we disguise this setUp() as a test that we depend on just once.
         $this->driver->get(ROOT_URL . '/src/genes/IVD');

--- a/tests/selenium_tests/phpunit.xml
+++ b/tests/selenium_tests/phpunit.xml
@@ -26,6 +26,7 @@
             <file>shared_tests/create_summary_data_upload_vcf.php</file>
             <file>shared_tests/submission_API.php</file>
             <file>admin_tests/verify_full_download.php</file>
+            <file>admin_tests/verify_GA4GH_API.php</file>
             <file>admin_tests/multi_value_search.php</file>
             <file>admin_tests/find_and_replace.php</file>
             <file>shared_tests/check_all_authorization_levels.php</file>

--- a/tests/test_data_files/AdminTestSuiteResult-GA4GH.txt
+++ b/tests/test_data_files/AdminTestSuiteResult-GA4GH.txt
@@ -1,0 +1,541 @@
+{
+    "data_model": {
+        "$ref": "https:\/\/raw.githubusercontent.com\/VarioML\/VarioML\/master\/json\/schemas\/v.2.0\/variant.json"
+    },
+    "data": [
+        {
+            "type": "DNA",
+            "genes": [
+                {
+                    "source": "HGNC",
+                    "accession": "6186",
+                    "db_xrefs": [
+                        {
+                            "source": "HGNC.symbol",
+                            "accession": "IVD"
+                        },
+                        {
+                            "source": "MIM",
+                            "accession": "607036"
+                        }
+                    ]
+                }
+            ],
+            "ref_seq": {
+                "source": "genbank",
+                "accession": "NC_000015.9"
+            },
+            "name": {
+                "scheme": "HGVS",
+                "value": "g.40698142A>T"
+            },
+            "pathogenicities": [
+                {
+                    "scope": "individual",
+                    "source": "LOVD",
+                    "term": "functionNotAffected",
+                    "data_source": {
+                        "name": "submitter"
+                    },
+                    "phenotypes": [
+                        {
+                            "term": "isovaleric acidemia (IVA)",
+                            "source": "MIM",
+                            "accession": "243500"
+                        },
+                        {
+                            "term": "Additional information.",
+                            "inheritance_pattern": {
+                                "term": "familial"
+                            }
+                        },
+                        {
+                            "term": "More additional information.",
+                            "inheritance_pattern": {
+                                "term": "familial"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "scope": "individual",
+                    "source": "LOVD",
+                    "term": "functionNotAffected",
+                    "data_source": {
+                        "name": "curator"
+                    }
+                }
+            ],
+            "creation_date": {
+                "value": "0000-00-00T00:00:00+00:00"
+            },
+            "modification_date": {
+                "value": "0000-00-00T00:00:00+00:00"
+            },
+            "panel": {
+                "individuals": [
+                    {
+                        "id": "00000001",
+                        "phenotypes": [
+                            {
+                                "term": "isovaleric acidemia (IVA)",
+                                "source": "MIM",
+                                "accession": "243500"
+                            },
+                            {
+                                "term": "Additional information.",
+                                "inheritance_pattern": {
+                                    "term": "familial"
+                                }
+                            },
+                            {
+                                "term": "More additional information.",
+                                "inheritance_pattern": {
+                                    "term": "familial"
+                                }
+                            }
+                        ],
+                        "db_xrefs": [
+                            {
+                                "source": "pubmed",
+                                "accession": "21520333",
+                                "name": "Fokkema et al (2011)"
+                            }
+                        ],
+                        "data_source": {
+                            "contacts": [
+                                {
+                                    "role": "submitter",
+                                    "name": "LOVD3 Admin",
+                                    "email": "test@lovd.nl"
+                                },
+                                {
+                                    "role": "owner",
+                                    "name": "Test Owner",
+                                    "email": "owner@lovd.nl"
+                                }
+                            ]
+                        },
+                        "sharing_policy": {
+                            "type": "OpenAccess",
+                            "use_permission": {
+                                "term": "Creative Commons Attribution 4.0 International",
+                                "source": "CC",
+                                "accession": "cc_by_4.0",
+                                "uri": "https:\/\/creativecommons.org\/licenses\/by\/4.0"
+                            }
+                        },
+                        "variants": [
+                            {
+                                "id": "0000000001",
+                                "copy_count": 1,
+                                "type": "DNA",
+                                "ref_seq": {
+                                    "source": "genbank",
+                                    "accession": "NC_000015.9"
+                                },
+                                "name": {
+                                    "scheme": "HGVS",
+                                    "value": "g.40698142A>T"
+                                },
+                                "pathogenicities": [
+                                    {
+                                        "scope": "individual",
+                                        "source": "LOVD",
+                                        "term": "functionNotAffected",
+                                        "data_source": {
+                                            "name": "submitter"
+                                        }
+                                    },
+                                    {
+                                        "scope": "individual",
+                                        "source": "LOVD",
+                                        "term": "functionNotAffected",
+                                        "data_source": {
+                                            "name": "curator"
+                                        }
+                                    }
+                                ],
+                                "db_xrefs": [
+                                    {
+                                        "source": "pubmed",
+                                        "accession": "21520333",
+                                        "name": "Fokkema et al (2011)"
+                                    }
+                                ],
+                                "variant_detection": [
+                                    {
+                                        "template": "DNA",
+                                        "technique": "SEQ"
+                                    },
+                                    {
+                                        "template": "RNA",
+                                        "technique": "RT-PCR"
+                                    }
+                                ],
+                                "seq_changes": {
+                                    "variants": [
+                                        {
+                                            "type": "cDNA",
+                                            "gene": {
+                                                "source": "HGNC",
+                                                "accession": "IVD"
+                                            },
+                                            "ref_seq": {
+                                                "source": "genbank",
+                                                "accession": "NM_002225.3"
+                                            },
+                                            "name": {
+                                                "scheme": "HGVS",
+                                                "value": "c.123A>T"
+                                            },
+                                            "seq_changes": {
+                                                "variants": [
+                                                    {
+                                                        "type": "RNA",
+                                                        "name": {
+                                                            "scheme": "HGVS",
+                                                            "value": "r.(=)"
+                                                        },
+                                                        "seq_changes": {
+                                                            "variants": [
+                                                                {
+                                                                    "type": "AA",
+                                                                    "ref_seq": {
+                                                                        "source": "genbank",
+                                                                        "accession": "NP_002216.2"
+                                                                    },
+                                                                    "name": {
+                                                                        "scheme": "HGVS",
+                                                                        "value": "p.(=)"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "0000000002",
+                                "copy_count": 1,
+                                "type": "DNA",
+                                "ref_seq": {
+                                    "source": "genbank",
+                                    "accession": "NC_000015.9"
+                                },
+                                "name": {
+                                    "scheme": "HGVS",
+                                    "value": "g.40702876G>T"
+                                },
+                                "pathogenicities": [
+                                    {
+                                        "scope": "individual",
+                                        "source": "LOVD",
+                                        "term": "unknown",
+                                        "data_source": {
+                                            "name": "submitter"
+                                        }
+                                    },
+                                    {
+                                        "scope": "individual",
+                                        "source": "LOVD",
+                                        "term": "unknown",
+                                        "data_source": {
+                                            "name": "curator"
+                                        }
+                                    }
+                                ],
+                                "db_xrefs": [
+                                    {
+                                        "source": "pubmed",
+                                        "accession": "21520333",
+                                        "name": "Fokkema et al (2011)"
+                                    }
+                                ],
+                                "variant_detection": [
+                                    {
+                                        "template": "DNA",
+                                        "technique": "SEQ"
+                                    },
+                                    {
+                                        "template": "RNA",
+                                        "technique": "RT-PCR"
+                                    },
+                                    {
+                                        "template": "Protein",
+                                        "technique": "Western"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "DNA",
+            "genes": [],
+            "ref_seq": {
+                "source": "genbank",
+                "accession": "NC_000015.9"
+            },
+            "name": {
+                "scheme": "HGVS",
+                "value": "g.40702876G>T"
+            },
+            "pathogenicities": [
+                {
+                    "scope": "individual",
+                    "source": "LOVD",
+                    "term": "unknown",
+                    "data_source": {
+                        "name": "submitter"
+                    },
+                    "phenotypes": [
+                        {
+                            "term": "isovaleric acidemia (IVA)",
+                            "source": "MIM",
+                            "accession": "243500"
+                        },
+                        {
+                            "term": "Additional information.",
+                            "inheritance_pattern": {
+                                "term": "familial"
+                            }
+                        },
+                        {
+                            "term": "More additional information.",
+                            "inheritance_pattern": {
+                                "term": "familial"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "scope": "individual",
+                    "source": "LOVD",
+                    "term": "unknown",
+                    "data_source": {
+                        "name": "curator"
+                    }
+                }
+            ],
+            "creation_date": {
+                "value": "0000-00-00T00:00:00+00:00"
+            },
+            "modification_date": {
+                "value": "0000-00-00T00:00:00+00:00"
+            },
+            "panel": {
+                "individuals": [
+                    {
+                        "id": "00000001",
+                        "phenotypes": [
+                            {
+                                "term": "isovaleric acidemia (IVA)",
+                                "source": "MIM",
+                                "accession": "243500"
+                            },
+                            {
+                                "term": "Additional information.",
+                                "inheritance_pattern": {
+                                    "term": "familial"
+                                }
+                            },
+                            {
+                                "term": "More additional information.",
+                                "inheritance_pattern": {
+                                    "term": "familial"
+                                }
+                            }
+                        ],
+                        "db_xrefs": [
+                            {
+                                "source": "pubmed",
+                                "accession": "21520333",
+                                "name": "Fokkema et al (2011)"
+                            }
+                        ],
+                        "data_source": {
+                            "contacts": [
+                                {
+                                    "role": "submitter",
+                                    "name": "LOVD3 Admin",
+                                    "email": "test@lovd.nl"
+                                },
+                                {
+                                    "role": "owner",
+                                    "name": "Test Owner",
+                                    "email": "owner@lovd.nl"
+                                }
+                            ]
+                        },
+                        "sharing_policy": {
+                            "type": "OpenAccess",
+                            "use_permission": {
+                                "term": "Creative Commons Attribution 4.0 International",
+                                "source": "CC",
+                                "accession": "cc_by_4.0",
+                                "uri": "https:\/\/creativecommons.org\/licenses\/by\/4.0"
+                            }
+                        },
+                        "variants": [
+                            {
+                                "id": "0000000001",
+                                "copy_count": 1,
+                                "type": "DNA",
+                                "ref_seq": {
+                                    "source": "genbank",
+                                    "accession": "NC_000015.9"
+                                },
+                                "name": {
+                                    "scheme": "HGVS",
+                                    "value": "g.40698142A>T"
+                                },
+                                "pathogenicities": [
+                                    {
+                                        "scope": "individual",
+                                        "source": "LOVD",
+                                        "term": "functionNotAffected",
+                                        "data_source": {
+                                            "name": "submitter"
+                                        }
+                                    },
+                                    {
+                                        "scope": "individual",
+                                        "source": "LOVD",
+                                        "term": "functionNotAffected",
+                                        "data_source": {
+                                            "name": "curator"
+                                        }
+                                    }
+                                ],
+                                "db_xrefs": [
+                                    {
+                                        "source": "pubmed",
+                                        "accession": "21520333",
+                                        "name": "Fokkema et al (2011)"
+                                    }
+                                ],
+                                "variant_detection": [
+                                    {
+                                        "template": "DNA",
+                                        "technique": "SEQ"
+                                    },
+                                    {
+                                        "template": "RNA",
+                                        "technique": "RT-PCR"
+                                    }
+                                ],
+                                "seq_changes": {
+                                    "variants": [
+                                        {
+                                            "type": "cDNA",
+                                            "gene": {
+                                                "source": "HGNC",
+                                                "accession": "IVD"
+                                            },
+                                            "ref_seq": {
+                                                "source": "genbank",
+                                                "accession": "NM_002225.3"
+                                            },
+                                            "name": {
+                                                "scheme": "HGVS",
+                                                "value": "c.123A>T"
+                                            },
+                                            "seq_changes": {
+                                                "variants": [
+                                                    {
+                                                        "type": "RNA",
+                                                        "name": {
+                                                            "scheme": "HGVS",
+                                                            "value": "r.(=)"
+                                                        },
+                                                        "seq_changes": {
+                                                            "variants": [
+                                                                {
+                                                                    "type": "AA",
+                                                                    "ref_seq": {
+                                                                        "source": "genbank",
+                                                                        "accession": "NP_002216.2"
+                                                                    },
+                                                                    "name": {
+                                                                        "scheme": "HGVS",
+                                                                        "value": "p.(=)"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "0000000002",
+                                "copy_count": 1,
+                                "type": "DNA",
+                                "ref_seq": {
+                                    "source": "genbank",
+                                    "accession": "NC_000015.9"
+                                },
+                                "name": {
+                                    "scheme": "HGVS",
+                                    "value": "g.40702876G>T"
+                                },
+                                "pathogenicities": [
+                                    {
+                                        "scope": "individual",
+                                        "source": "LOVD",
+                                        "term": "unknown",
+                                        "data_source": {
+                                            "name": "submitter"
+                                        }
+                                    },
+                                    {
+                                        "scope": "individual",
+                                        "source": "LOVD",
+                                        "term": "unknown",
+                                        "data_source": {
+                                            "name": "curator"
+                                        }
+                                    }
+                                ],
+                                "db_xrefs": [
+                                    {
+                                        "source": "pubmed",
+                                        "accession": "21520333",
+                                        "name": "Fokkema et al (2011)"
+                                    }
+                                ],
+                                "variant_detection": [
+                                    {
+                                        "template": "DNA",
+                                        "technique": "SEQ"
+                                    },
+                                    {
+                                        "template": "RNA",
+                                        "technique": "RT-PCR"
+                                    },
+                                    {
+                                        "template": "Protein",
+                                        "technique": "Western"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ],
+    "pagination": {
+        "next_page_url": "http:\/\/localhost\/git\/LOVD3\/src\/api\/v2\/ga4gh\/table\/variants\/data%3Ahg19%3Achr16%3A1"
+    }
+}

--- a/tests/test_data_files/AdminTestSuiteResult-GA4GH.txt
+++ b/tests/test_data_files/AdminTestSuiteResult-GA4GH.txt
@@ -536,6 +536,6 @@
         }
     ],
     "pagination": {
-        "next_page_url": "http:\/\/localhost\/git\/LOVD3\/src\/api\/v2\/ga4gh\/table\/variants\/data%3Ahg19%3Achr16%3A1"
+        "next_page_url": "http:\/\/localhost\/LOVD3\/src\/api\/v2\/ga4gh\/table\/variants\/data%3Ahg19%3Achr16%3A1"
     }
 }


### PR DESCRIPTION
Improve the GA4GH API.
- Remove imprinting comment for chrM variants.
  - GV shared users often misuse this value.
- Let the LSDB ID just be and use something else for authorization.
  - We now had `md5($_STAT['signature'])` already for quite some time as the LSDB ID, so no need to change it in the GA4GH API; it can already be read out through cookies, and anyway it only provides rights to use the submission API. Use something else for varcache to obtain rights in LOVD.
- Users calling the GA4GH API from localhost don't need authorization.
- Add skeleton file for the GA4GH API test.
- Test root of GA4GH API; it should redirect to `service-info`.
- Add test for the Service Info endpoint.
- Add test for the Tables endpoint.
- Add test for the Variants table URL, it should redirect to its data.
- Add test for the Variants table Info endpoint.
- Add test for the Variants table Data endpoint.
- Add test for Variants table chr15 Data endpoint.
- Fix notice when Classifications column isn't in use.
- Clean up after tests.
- Protect against double semicolons in data fields.
  - We use double semicolons for grouping variants. The GV shared has a few variants with double semicolons in the Remarks fields. Had to protect this field (and the Reference field just in case) against this by replacing semicolons with commas.
- Increase `group_concat_max_len` limit.
  - Some variants had so many observations that the length of 200.000 characters was not enough. Increase to 1MB, which should be more than enough.
- Adapt `convertReferenceToVML()` to deal with the loss of semicolons.