### PR TITLE
Fix display of LOVD owned records

### DIFF
--- a/src/class/object_custom.php
+++ b/src/class/object_custom.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-17
- * Modified    : 2021-07-07
+ * Modified    : 2021-07-27
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -607,7 +607,7 @@ class LOVD_Custom extends LOVD_Object
                 } else {
                     // Normal case, one license only (but still possibly from multiple individuals).
                     // The license contains both the license for the world as well as the license for LOVD.
-                    $zData['license'] = strstr($zData['license'], ';', true);
+                    $zData['license'] = strstr($zData['license'] . ';', ';', true);
                     $sLicenseName = substr($zData['license'], 3, -4);
                     $sLicenseVersion = substr($zData['license'], -3);
                     $nIndividualID = false;

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-04-16
+ * Modified    : 2021-07-27
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -552,7 +552,7 @@ class LOVD_User extends LOVD_Object
                 $zData['default_license_'] = 'No default license selected';
             } else {
                 // The license contains both the license for the world as well as the license for LOVD.
-                $zData['default_license'] = strstr($zData['default_license'], ';', true);
+                $zData['default_license'] = strstr($zData['default_license'] . ';', ';', true);
                 $sLicenseName = substr($zData['default_license'], 3, -4);
                 $sLicenseVersion = substr($zData['default_license'], -3);
                 $zData['default_license_'] =

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-07-13
+ * Modified    : 2021-07-27
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1650,7 +1650,7 @@ class LOVD_Object
                 $zData['owner'] = array($zData['owner']);
             }
             // We are going to overwrite the 'owned_by_' field.
-            $zData['owned_by_'] = '';
+            $sOwnedBy = '';
             foreach($zData['owner'] as $aLinkData) {
                 if (count($aLinkData) >= 6) {
                     list($nID, $sName, $sEmail, $sInstitute, $sDepartment, $sCountryID) = $aLinkData;
@@ -1660,11 +1660,16 @@ class LOVD_Object
                     }
                     // For VLs, call the tooltip function with a request to move the tooltip left, because "Owner" is often the last column in the table,
                     //  and we don't want it to run off the page. I have found no way of moving the tooltip left whenever it's enlarging the document size.
-                    $zData['owned_by_'] .= (!$zData['owned_by_']? '' : ', ') .
+                    $sOwnedBy .= (!$sOwnedBy? '' : ', ') .
                         '<SPAN class="custom_link" onmouseover="lovd_showToolTip(\'' .
                         addslashes('<TABLE border=0 cellpadding=0 cellspacing=0 width=350 class=S11><TR><TH valign=top>User&nbsp;ID</TH><TD>' . ($_AUTH['level'] < LEVEL_MANAGER? $nID : '<A href=users/' . $nID . '>' . $nID . '</A>') . '</TD></TR><TR><TH valign=top>Name</TH><TD>' . $sName . '</TD></TR><TR><TH valign=top>Email&nbsp;address</TH><TD>' . str_replace("\r\n", '<BR>', lovd_hideEmail($sEmail)) . '</TD></TR><TR><TH valign=top>Institute</TH><TD>' . $sInstitute . '</TD></TR><TR><TH valign=top>Department</TH><TD>' . $sDepartment . '</TD></TR><TR><TH valign=top>Country</TH><TD>' . $sCountryID . '</TD></TR></TABLE>') .
                         '\', this, [' . ($sView == 'list'? '-200' : '0') . ', 0]);">' . $sName . '</SPAN>';
                 }
+            }
+            if ($sOwnedBy) {
+                // Overwrite only if we came up with something better
+                //  (which won't happen for LOVD-owned data).
+                $zData['owned_by_'] = $sOwnedBy;
             }
         }
         if (LOVD_plus) {


### PR DESCRIPTION
Fix display of LOVD owned records. The owner field was displayed as empty for data owned by LOVD.

Also:
- Fix notice when stored license doesn't contain a semicolon.

Closes #533.