### PR TITLE
Fix #537.

### DIFF
--- a/src/class/object_diseases.php
+++ b/src/class/object_diseases.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-07-28
- * Modified    : 2021-07-12
+ * Modified    : 2021-08-10
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -195,7 +195,7 @@ class LOVD_Disease extends LOVD_Object
                         'name' => 'Name',
                         'id_omim' => 'OMIM ID',
                         'link_HPO_' => 'Human Phenotype Ontology Project (HPO)',
-                        'inheritance' => 'Inheritance',
+                        'inheritance_' => 'Inheritance',
                         'individuals' => 'Individuals reported having this disease',
                         'phenotypes_' => 'Phenotype entries for this disease',
                         'genes_' => 'Associated with',
@@ -390,6 +390,7 @@ class LOVD_Disease extends LOVD_Object
     function prepareData ($zData = '', $sView = 'list')
     {
         // Prepares the data by "enriching" the variable received with links, pictures, etc.
+        global $_SETT;
 
         if (!in_array($sView, array('list', 'entry'))) {
             $sView = 'list';
@@ -416,6 +417,7 @@ class LOVD_Disease extends LOVD_Object
             } else {
                 $zData['genes_'] = implode(', ', $zData['genes']);
             }
+
         } else {
             if (!empty($zData['id_omim'])) {
                 $zData['link_HPO_'] = '<A href="' . lovd_getExternalSource('hpo_disease',
@@ -425,6 +427,14 @@ class LOVD_Disease extends LOVD_Object
                 // Cannot link to HPO without OMIM ID, hide this row.
                 unset($this->aColumnsViewEntry['link_HPO_']);
             }
+
+            $zData['inheritance_'] = '';
+            $aInheritances = explode(';', $zData['inheritance']);
+            foreach ($aInheritances as $sInheritance) {
+                $zData['inheritance_'] .= (!$zData['inheritance_']? '' : ', ') .
+                    (!isset($_SETT['diseases_inheritance'][$sInheritance])? $sInheritance : $_SETT['diseases_inheritance'][$sInheritance]);
+            }
+
             $zData['phenotypes_'] = $zData['phenotypes'];
             if ($zData['phenotypes']) {
                 $zData['phenotypes_'] = '<A href="phenotypes/disease/' . $zData['id'] . '">' . $zData['phenotypes'] . '</A>';

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2021-07-13
+ * Modified    : 2021-08-10
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -268,6 +268,7 @@ $_SETT = array(
                         'PI' => 'Autosomal dominant with paternal imprinting',
                         'MI' => 'Autosomal dominant with maternal imprinting',
                         'AR' => 'Autosomal recessive',
+                        'Di' => 'Digenic', // HPO 0010984, OMIM doesn't have this.
                         'DD' => 'Digenic dominant',
                         'DR' => 'Digenic recessive',
                         'IC' => 'Isolated Cases (Sporadic)',


### PR DESCRIPTION
Explain inheritance codes on Diseases VE, instead of showing the abbreviations only.

Also:
- Add Digenic as an inheritance mode for Diseases. HPO has this, but OMIM doesn't. It does make sense, as sometimes you
might not know whether the inheritance is dominant or recessive, or it might be mixed.

Closes #537.
