### PR TITLE
Fix various issues, preparing for release

### DIFF
--- a/src/ajax/licenses.php
+++ b/src/ajax/licenses.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-02-25
- * Modified    : 2021-07-07
+ * Modified    : 2021-08-11
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -207,7 +207,7 @@ if ($sObject == 'individual') {
     unset($aFields['overwrite']);
 } else {
     // Determine whether there are submissions manually set at all.
-    $n = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' WHERE created_by = ? AND license IS NOT NULL',
+    $n = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' WHERE created_by = ? AND NULLIF(license, "") IS NOT NULL',
         array($nID))->fetchColumn();
     if (!$n) {
         unset($aFields['overwrite']);

--- a/src/api.php
+++ b/src/api.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-11-08
- * Modified    : 2021-02-01
- * For LOVD    : 3.0-26
+ * Modified    : 2021-08-12
+ * For LOVD    : 3.0-27
  *
  * Supported URIs:
  *  3.0-26       /api/rest.php/get_frequencies (POST)
@@ -356,15 +356,15 @@ if ($sDataType == 'variants') {
                             }
                         } else {
                             // This does a first match; trying to find the position at the start of the DNA field. Later this match will be made more accurate!
-                            $sQ .= ' AND REPLACE(REPLACE(REPLACE(REPLACE(vot.`VariantOnTranscript/DNA`, "[", ""), "(", ""), ")", ""), "?", "") LIKE "' . $_GET['search_' . $sField] . '%"';
+                            $sQ .= ' AND REPLACE(REPLACE(REPLACE(REPLACE(vot.`VariantOnTranscript/DNA`, "[", ""), "(", ""), ")", ""), "?", "") LIKE "' . $_DB->quote($_GET['search_' . $sField]) . '%"';
                         }
                     } elseif ($sField == 'Variant/DNA') {
                         // This matches regardless of the characters (, ) and ?.
-                        $sQ .= ' AND REPLACE(REPLACE(REPLACE(vot.`VariantOnTranscript/DNA`, "(", ""), ")", ""), "?", "") = "' . str_replace(array('(', ')', '?'), ' ', $_GET['search_' . $sField]) . '"';
+                        $sQ .= ' AND REPLACE(REPLACE(REPLACE(vot.`VariantOnTranscript/DNA`, "(", ""), ")", ""), "?", "") = "' . str_replace(array('(', ')', '?'), ' ', $_DB->quote($_GET['search_' . $sField])) . '"';
                     } elseif ($sField == 'Variant/DBID') {
-                        $sQ .= ' AND vog.`VariantOnGenome/DBID` LIKE "' . $_GET['search_' . $sField] . '%"';
+                        $sQ .= ' AND vog.`VariantOnGenome/DBID` LIKE "' . $_DB->quote($_GET['search_' . $sField]) . '%"';
                     } else {
-                        $sQ .= ' AND vot.`' . $sField . '` = "' . $_GET['search_' . $sField] . '"';
+                        $sQ .= ' AND vot.`' . $sField . '` = "' . $_DB->quote($_GET['search_' . $sField]) . '"';
                     }
                 }
             }
@@ -413,7 +413,7 @@ if ($sDataType == 'variants') {
             if (!empty($_GET['search_' . $sField])) {
                 $bSearching = true;
                 if ($sField == 'symbol') {
-                    $sQ .= ' AND g.id = "' . $_GET['search_' . $sField] . '"';
+                    $sQ .= ' AND g.id = "' . $_DB->quote(GET['search_' . $sField]) . '"';
                 } elseif ($sField == 'position' && preg_match('/^chr([0-9]{1,2}|[MXY])(:[0-9]{1,9}(_[0-9]+)?)?$/', $_GET['search_' . $sField], $aRegs)) {
                     // $aRegs numbering:                             1                2           3
                     @list(, $sChromosome, $sPositionStart, $sPositionEnd) = $aRegs;

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -250,12 +250,13 @@ class LOVD_GenomeVariant extends LOVD_Custom
                       );
 
         if ($_AUTH['level'] >= LEVEL_CURATOR) {
+            // This still allows for "Unclassified", which anyway is the default.
             $this->aCheckMandatory[] = 'effect_concluded';
         }
 
         if (isset($aData['effect_reported']) && $aData['effect_reported'] === '0') {
-            // `effect_reported` is not allowed to be '0' (Not classified) when user is a submitter
-            // or when the variant has status '9' (Public).
+            // `effect_reported` is not allowed to be '0' (Not classified)
+            //  when user is a submitter or when the variant is set to Marked or Public.
             if ($_AUTH['level'] < LEVEL_CURATOR) {
                 // Remove the mandatory `effect_reported` field to throw an error.
                 unset($aData['effect_reported']);

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2021-07-07
+ * Modified    : 2021-08-12
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -259,10 +259,11 @@ class LOVD_GenomeVariant extends LOVD_Custom
             if ($_AUTH['level'] < LEVEL_CURATOR) {
                 // Remove the mandatory `effect_reported` field to throw an error.
                 unset($aData['effect_reported']);
-            } elseif (isset($aData['statusid']) && $aData['statusid'] == STATUS_OK) {
+            } elseif (isset($aData['statusid']) && $aData['statusid'] >= STATUS_MARKED) {
                 // Show error for curator/manager trying to publish variant without effect.
                 lovd_errorAdd('effect_reported', 'The \'Affects function (as reported)\' field ' .
-                    'may not be "' . $_SETT['var_effect'][0] . '" when variant status is "' . $_SETT['data_status'][STATUS_OK] . '".');
+                    'may not be "' . $_SETT['var_effect'][0] . '" when variant status is "' .
+                    $_SETT['data_status'][STATUS_MARKED] . '" or "' . $_SETT['data_status'][STATUS_OK] . '".');
             }
         }
 

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-07-27
+ * Modified    : 2021-08-11
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -468,8 +468,22 @@ class LOVD_Object
                         $aData[$sName] = array();
                     }
                 }
-                // Simple check on non-custom columns (custom columns have their own function for this) to see if the given value is actually allowed.
-                // 0 is a valid entry for the check for mandatory fields, so we should also check if 0 is a valid entry in the selection list!
+
+                if ($aOptions['explode_strings'] && !is_array($aData[$sName])
+                    && isset($GLOBALS['aLine'][$sName]) && $GLOBALS['aLine'][$sName] == $aData[$sName]) {
+                    // Selection lists imported with spaces around their values
+                    //  (e.g., "PCR; SEQ") will be checked *without* the space, but
+                    //  imported *with* the space. Fix that.
+                    // Selection values can't contain an ";", so this is safe.
+                    $GLOBALS['aLine'][$sName] = $aData[$sName] =
+                        implode(';', array_map('trim', explode(';', $aData[$sName])));
+                }
+
+                // Simple check on non-custom columns (custom columns have
+                //  checkSelectedInput() for this) to see if the given value is
+                //  actually allowed. "0" is a valid entry for the check for
+                //  mandatory fields, so we should also check if "0" is a valid
+                //  entry in the selection list!
                 if (strpos($sName, '/') === false && isset($aData[$sName]) && $aData[$sName] !== '') {
                     $Val = $aData[$sName];
                     $aSelectOptions = array_keys($aField[5]);

--- a/src/import.php
+++ b/src/import.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2020-11-24
- * For LOVD    : 3.0-26
+ * Modified    : 2021-08-11
+ * For LOVD    : 3.0-27
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -755,7 +755,9 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
         if (function_exists('mime_content_type')) {
             $sType = mime_content_type($_FILES['import']['tmp_name']);
         }
-        if ($sType && substr($sType, 0, 5) != 'text/') { // Not all systems report the regular files as "text/plain"; also reported was "text/x-pascal; charset=us-ascii".
+        if ($sType && substr($sType, 0, 5) != 'text/' && $sType != 'application/octet-stream') {
+            // Not all systems report the regular files as "text/plain"; also reported was "text/x-pascal; charset=us-ascii".
+            // Others getting application/octet-stream here. It does seem to depend on the browser, but it's a hard to kill issue.
             lovd_errorAdd('import', 'The upload file is not a tab-delimited text file and cannot be imported. It seems to be of type "' . htmlspecialchars($sType) . '".');
 
         } else {

--- a/src/import.php
+++ b/src/import.php
@@ -1514,6 +1514,8 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
                     'explode_strings' => true,      // Multiple selection lists are input as simple strings here.
                     'show_select_alts' => true,     // Show alternatives in errors for select fields.
                 );
+                // $aLine may get overwritten here for selection lists; spaces
+                //  around select values are removed by checkFields().
                 $aSection['object']->checkFields($aLine, $zData, $aCheckFieldsOptions);
                 for ($i = $nErrors; isset($_ERROR['messages'][$i]); $i++) {
                     // When updating, if a error is triggered by a field that is

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2021-02-26
+ * Modified    : 2021-08-13
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -503,6 +503,11 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
 
     $_T->printHeader();
     $_T->printTitle();
+
+    // If we're not the creator nor the owner, warn.
+    if ($_POST['created_by'] != $_AUTH['id'] && $_POST['owned_by'] != $_AUTH['id']) {
+        lovd_showInfoTable('Warning: You are editing data not created or owned by you. You are free to correct errors such as data inserted into the wrong field or typographical errors, but make sure that all other edits are made in consultation with the submitter. If you disagree with the submitter\'s findings, add a remark rather than removing or overwriting data.', 'warning', 760);
+    }
 
     if (GET) {
         print('      To edit an individual information entry, please fill out the form below.<BR>' . "\n" .

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-23
- * Modified    : 2020-08-26
- * For LOVD    : 3.0-25
+ * Modified    : 2021-08-13
+ * For LOVD    : 3.0-27
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -470,6 +470,11 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
 
     $_T->printHeader();
     $_T->printTitle();
+
+    // If we're not the creator nor the owner, warn.
+    if ($_POST['created_by'] != $_AUTH['id'] && $_POST['owned_by'] != $_AUTH['id']) {
+        lovd_showInfoTable('Warning: You are editing data not created or owned by you. You are free to correct errors such as data inserted into the wrong field or typographical errors, but make sure that all other edits are made in consultation with the submitter. If you disagree with the submitter\'s findings, add a remark rather than removing or overwriting data.', 'warning', 760);
+    }
 
     if (GET) {
         print('      To edit an phenotype information entry, please fill out the form below.<BR>' . "\n" .

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2021-07-12
+ * Modified    : 2021-08-13
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -459,6 +459,11 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
 
     $_T->printHeader();
     $_T->printTitle();
+
+    // If we're not the creator nor the owner, warn.
+    if ($_POST['created_by'] != $_AUTH['id'] && $_POST['owned_by'] != $_AUTH['id']) {
+        lovd_showInfoTable('Warning: You are editing data not created or owned by you. You are free to correct errors such as data inserted into the wrong field or typographical errors, but make sure that all other edits are made in consultation with the submitter. If you disagree with the submitter\'s findings, add a remark rather than removing or overwriting data.', 'warning', 760);
+    }
 
     if (GET) {
         print('      To edit an screening information entry, please fill out the form below.<BR>' . "\n" .

--- a/src/variants.php
+++ b/src/variants.php
@@ -2897,23 +2897,9 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'search_global') {
           '    <TH>Transcript</TH>' . "\n" .
           '    <TH>Position</TH>' . "\n" .
           '    <TH>DNA&nbsp;change</TH>' . "\n" .
-          '    <TH>DB-ID</TH>' . "\n" .
           '    <TH>LOVD&nbsp;location</TH>' . "\n" .
           '  </TR>' . "\n");
     $aHeaders = explode("\"\t\"", trim(array_shift($aData), '"'));
-
-    // Remove all-zero DBIDs from the array.
-    $aDataCleaned = array();
-    foreach ($aData as $sHit) {
-        $aHit = array_combine($aHeaders, explode("\"\t\"", trim($sHit, '"')));
-        if (!preg_match('/_0?00000$/', $aHit['variant_id'])) {
-            $aDataCleaned[] = $sHit;
-        }
-    }
-    if (!empty($aDataCleaned)) {
-        // We've still got variants left, so let's use the cleaned array. We wouldn't want to use a 'cleaned' array if that means we cleared it!
-        $aData = $aDataCleaned;
-    }
 
     foreach ($aData as $sHit) {
         $aHit = array_combine($aHeaders, explode("\"\t\"", trim($sHit, '"')));
@@ -2923,7 +2909,6 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'search_global') {
               '    <TD>' . $aHit['nm_accession'] . '</TD>' . "\n" .
               '    <TD>' . $aHit['g_position'] . '</TD>' . "\n" .
               '    <TD>' . $aHit['DNA'] . '</TD>' . "\n" .
-              '    <TD>' . $aHit['variant_id'] . '</TD>' . "\n" .
               '    <TD>' . substr($aHit['url'], 0, strpos($aHit['url'], '/variants.php')) . '</TD>' . "\n" .
               '  </TR>' . "\n");
     }

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2021-01-12
- * For LOVD    : 3.0-26
+ * Modified    : 2021-08-13
+ * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -2677,6 +2677,11 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
 
     $_T->printHeader();
     $_T->printTitle();
+
+    // If we're not the creator nor the owner, warn.
+    if ($_POST['created_by'] != $_AUTH['id'] && $_POST['owned_by'] != $_AUTH['id']) {
+        lovd_showInfoTable('Warning: You are editing data not created or owned by you. You are free to correct errors such as data inserted into the wrong field or typographical errors, but make sure that all other edits are made in consultation with the submitter. If you disagree with the submitter\'s findings, add a remark rather than removing or overwriting data. In particular, do not overwrite the submitter\'s reported variant effect if you disagree, rather add your own variant effect.', 'warning', 760);
+    }
 
     if (GET) {
         print('      To edit a variant entry, please fill out the form below.<BR>' . "\n" .


### PR DESCRIPTION
Fixed various issues, preparing for release.
- Allow application/octet-stream as an import file.
  - Some users are getting that file type (seems to depend on the browser), so allow it next to all `text/*` types.
- Remove spaces around select values when importing.
  - When importing, providing a value for a multiple selection list like `PCR; SEQ` is valid, and ` SEQ` gets stored. This is because `checkFields()` trims the values, but the original values are left. The value then mismatches, giving some minor issues. When the entry is edited, the problem is also solved. But it's better to not import these spaces.
  - This is now implemented into `checkFields()`, but the importer checks for differences before `checkFields()` is run, so entries with spaces in them will always trigger an update of the entry, even if there is nothing to update. Because this is hard to fix, I'm leaving this.
- Fix unnecessary requests for overwriting licenses.
  - The check whether licenses were already filled in ignored the fact that the license field can sometimes be empty, not a `NULL` value.
- VOG reported effect may not be `Unclassified` when status is `Marked`. This was already enforced for status is `Public`, so `Marked` should be included.
- Don't allow Curators and up to publish Variants without effects. The `VOG/effect` was required for Curators when publishing variants, but this was not set for `VOT/effect`.
- Fixed SQL injection vulnerability in the LOVD2-style API.
- Warn users when editing other user's data.
- Cleaned up code that was generating notices.

Closes #484, #539, #542.