### PR TITLE
Improve the GA4GH endpoint

### DIFF
--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-07-19
+ * Modified    : 2021-07-21
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -756,7 +756,7 @@ class LOVD_API_GA4GH
         global $_DB, $_CONF, $_SETT;
 
         $sTableName = 'variants';
-        $nLimit = 1000; // Get 1000 variants max in one go.
+        $nLimit = 100; // Get 100 variants max in one go.
         // Split position fields (append hyphen to prevent notice).
         list($nPositionStart, $nPositionEnd) = explode('-', $sPosition . '-');
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1870,10 +1870,19 @@ class LOVD_API_GA4GH
 
 
         // Set next seek window.
-        $nNextPosition = (!$zData? 0 : $zData[$n-1]['position_g_start'] + 1);
+        // We're not sure if we're done with this last position, so start there.
+        $nNextPosition = (!$zData? 0 : $zData[$n-1]['position_g_start']);
         if ($nPositionEnd) {
-            // We were looking in a closed range. Continue with the next window.
-            $nNextPosition = $nPositionEnd + 1;
+            // We were looking in a closed range.
+            if ($n < $nLimit) {
+                // We're done; continue after window.
+                $nNextPosition = $nPositionEnd + 1;
+            } else {
+                // We're not sure if we're done.
+                // Continue in this window.
+                $nNextPosition .= '-' . $nPositionEnd;
+            }
+
         } elseif ($n < $nLimit) {
             // We didn't receive everything. This must be because we're at the
             //  end of the chromosome. Let's look at the next.

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-07-16
+ * Modified    : 2021-07-19
  * For LOVD    : 3.0-27
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -955,6 +955,13 @@ class LOVD_API_GA4GH
                     'value' => $zData['DNA'],
                 ),
                 'aliases' => array(),
+                'locations' => array(
+                    array(
+                        'chr' => $sChr,
+                        'start' => (int) $zData['position_g_start'],
+                        'end' => (int) $zData['position_g_end'],
+                    ),
+                ),
                 'pathogenicities' => array(),
                 'creation_date' => array(
                     'value' => date('c', strtotime($zData['created_date'])),

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1859,6 +1859,10 @@ class LOVD_API_GA4GH
                     unset($aReturn['panel'][$sIndex]);
                 }
             }
+            if (!count($aReturn['panel'])) {
+                // Nothing licensed to show.
+                unset($aReturn['panel']);
+            }
 
             return $aReturn;
         }, $zData);

--- a/tests/selenium_tests/admin_tests/multi_value_search.php
+++ b/tests/selenium_tests/admin_tests/multi_value_search.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-11-10
- * Modified    : 2020-05-21
- * For LOVD    : 3.0-24
+ * Modified    : 2021-08-16
+ * For LOVD    : 3.0-27
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
@@ -45,6 +45,9 @@ class MultiValueSearchTest extends LOVDSeleniumWebdriverBaseTestCase
         }
         if (preg_match('/No such ID!/', $sBody)) {
             $this->markTestSkipped('Gene does not exist yet.');
+        }
+        if (!$this->isElementPresent(WebDriverBy::id('tab_setup'))) {
+            $this->markTestSkipped('User was not authorized.');
         }
     }
 

--- a/tests/test_data_files/AdminTestSuiteResult-GA4GH.txt
+++ b/tests/test_data_files/AdminTestSuiteResult-GA4GH.txt
@@ -29,6 +29,13 @@
                 "scheme": "HGVS",
                 "value": "g.40698142A>T"
             },
+            "locations": [
+                {
+                    "chr": "15",
+                    "start": 40698142,
+                    "end": 40698142
+                }
+            ],
             "pathogenicities": [
                 {
                     "scope": "individual",
@@ -287,6 +294,13 @@
                 "scheme": "HGVS",
                 "value": "g.40702876G>T"
             },
+            "locations": [
+                {
+                    "chr": "15",
+                    "start": 40702876,
+                    "end": 40702876
+                }
+            ],
             "pathogenicities": [
                 {
                     "scope": "individual",


### PR DESCRIPTION
Improved the GA4GH endpoint after the first uses in production.
- Add locations array to aggregated variants. These elements are new in VarioML.
  - Fix GA4GH test after addition of location array.
- Remove empty panel array from aggregated variants.
  - Since we're removing all keys in the panel object, PHP makes it an empty array when creating JSON, breaking the validation. Maybe removing these empty keys isn't such a great idea, because it also freaks out JQ.
- Work on 100 variants max, not 1000.
- Fix some issues with the calculation of the next position.
- When converting data for more than 15 seconds, return what you have.

Also:
- Don't let the MultiValueSearch test fail hard when not logged in.