### PR TITLE
Have genome builds table created, and data viewable

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -35,6 +35,7 @@ php_value suhosin.request.max_vars 15000
     RewriteRule ^genes(.*)$ genes.php
     RewriteRule ^gene_statistics(.*)$ gene_statistics.php
     RewriteRule ^gene_panels(.*)$ gene_panels.php
+    RewriteRule ^genome_builds(.*)$ genome_builds.php
     RewriteRule ^import(.*)$ import.php
 #    RewriteRule ^install(.*)$ install/index.php # I'm having trouble using /install?etc because Apache is redirecting to /install/?etc which loses the $_POST info. Very annoying.
     RewriteRule ^individuals(.*)$ individuals.php

--- a/src/class/object_genome_builds.php
+++ b/src/class/object_genome_builds.php
@@ -9,7 +9,7 @@
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               L. Werkman <l.werkman@lumc.nl>
+ *               L. Werkman <L.Werkman@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -40,20 +40,40 @@ require_once ROOT_PATH . 'class/objects.php';
 
 class LOVD_GenomeBuild extends LOVD_Object
 {
-    // This class extends the basic Object class and it handles the GenomeBuilds.
+    // This class extends the basic Object class and it handles the Genome Builds.
     var $sObject = 'Genome_Build';
     var $sTable = 'TABLE_GENOME_BUILDS';
+
+
+
 
 
     function __construct ()
     {
         // Default constructor.
 
+        // SQL code for viewing an entry.
+        $this->aSQLViewEntry['SELECT']   = 'gb.*, u.name AS created_by_';
+        $this->aSQLViewEntry['FROM']     = TABLE_GENOME_BUILDS . ' AS gb ' .
+            'LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (gb.created_by = u.id) ';
+        $this->aSQLViewEntry['GROUP_BY'] = 'gb.id';
+
         // SQL code for viewing a list of entries.
         $this->aSQLViewList['SELECT']   = 'gb.*, u.name AS created_by_';
         $this->aSQLViewList['FROM']     = TABLE_GENOME_BUILDS . ' AS gb LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ' .
                                           'ON (gb.created_by = u.id)';
         $this->aSQLViewList['ORDER_BY'] = 'id';
+
+        // List of columns and (default?) order for viewing an entry.
+        $this->aColumnsViewEntry =
+            array(
+                'TableHeader_General' => 'General information',
+                'id' => 'Genome build ID',
+                'name' => 'Genome build name',
+                'column_suffix' => 'Column suffix',
+                'created_by' => 'Created by',
+                'created_date' => 'Date created'
+            );
 
         // List of columns and (default?) order for viewing a list of entries.
         $this->aColumnsViewList =
@@ -74,25 +94,6 @@ class LOVD_GenomeBuild extends LOVD_Object
                                     'view' => array('Column suffix', 100),
                                     'db'   => array('gb.column_suffix', 'ASC', true))
                       );
-
-        // SQL code for viewing an entry.
-        $this->aSQLViewEntry['SELECT']   = 'gb.*, u.name AS created_by_';
-
-        $this->aSQLViewEntry['FROM']     = TABLE_GENOME_BUILDS . ' AS gb ' .
-            'LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (gb.created_by = u.id) ';
-        $this->aSQLViewEntry['GROUP_BY'] = 'gb.id';
-
-        // List of columns and (default?) order for viewing an entry.
-        $this->aColumnsViewEntry =
-            array(
-                'TableHeader_General' => 'General information',
-                'id' => 'Genome build ID',
-                'name' => 'Genome build name',
-                'column_suffix' => 'Column suffix',
-                'created_by' => 'Created by',
-                'created_date' => 'Date created'
-            );
-
         $this->sSortDefault = 'id';
 
         parent::__construct();

--- a/src/class/object_genome_builds.php
+++ b/src/class/object_genome_builds.php
@@ -67,11 +67,10 @@ class LOVD_GenomeBuild extends LOVD_Object
         // List of columns and (default?) order for viewing an entry.
         $this->aColumnsViewEntry =
             array(
-                'TableHeader_General' => 'General information',
                 'id' => 'Genome build ID',
                 'name' => 'Genome build name',
                 'column_suffix' => 'Column suffix',
-                'created_by' => 'Created by',
+                'created_by_' => 'Created by',
                 'created_date' => 'Date created'
             );
 
@@ -79,20 +78,20 @@ class LOVD_GenomeBuild extends LOVD_Object
         $this->aColumnsViewList =
                  array(
                         'id' => array(
-                                    'view' => array('ID', 50),
+                                    'view' => array('Genome build ID', 50),
                                     'db'   => array('gb.id', 'ASC', true)),
                         'name' => array(
-                                    'view' => array('name', 50),
+                                    'view' => array('Name', 160),
                                     'db'   => array('gb.name', 'ASC', true)),
+                         'column_suffix' => array(
+                                     'view' => array('Column suffix', 50),
+                                     'db'   => array('gb.column_suffix', 'ASC', true)),
+                         'created_by_' => array(
+                                     'view' => array('Created by', 100),
+                                     'db'   => array('u.name', 'ASC', true)),
                         'created_date' => array(
-                                    'view' => array('created on', 130),
-                                    'db'   => array('gb.created_by', 'DESC', 'DATETIME')),
-                        'created_by_' => array(
-                                    'view' => array('User', 160),
-                                    'db'   => array('u.name', 'ASC', true)),
-                        'column_suffix' => array(
-                                    'view' => array('Column suffix', 100),
-                                    'db'   => array('gb.column_suffix', 'ASC', true))
+                                    'view' => array('Date created', 130),
+                                    'db'   => array('gb.created_by', 'DESC', 'DATETIME'))
                       );
         $this->sSortDefault = 'id';
 

--- a/src/class/object_genome_builds.php
+++ b/src/class/object_genome_builds.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-09-21
- * Modified    : 2021-09-21
+ * Modified    : 2021-09-22
  * For LOVD    : 3.5-pre-01
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -41,7 +41,7 @@ require_once ROOT_PATH . 'class/objects.php';
 class LOVD_GenomeBuild extends LOVD_Object
 {
     // This class extends the basic Object class and it handles the GenomeBuilds.
-    var $sObject = 'GenomeBuild';
+    var $sObject = 'Genome_Build';
     var $sTable = 'TABLE_GENOME_BUILDS';
 
 

--- a/src/class/object_genome_builds.php
+++ b/src/class/object_genome_builds.php
@@ -40,7 +40,7 @@ require_once ROOT_PATH . 'class/objects.php';
 
 class LOVD_GenomeBuild extends LOVD_Object
 {
-    // This class extends the basic Object class and it handles the Logs.
+    // This class extends the basic Object class and it handles the GenomeBuilds.
     var $sObject = 'GenomeBuild';
     var $sTable = 'TABLE_GENOME_BUILDS';
 
@@ -51,7 +51,8 @@ class LOVD_GenomeBuild extends LOVD_Object
 
         // SQL code for viewing a list of entries.
         $this->aSQLViewList['SELECT']   = 'gb.*, u.name AS created_by_';
-        $this->aSQLViewList['FROM']     = TABLE_GENOME_BUILDS . ' AS gb LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (gb.created_by = u.id)';
+        $this->aSQLViewList['FROM']     = TABLE_GENOME_BUILDS . ' AS gb LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ' .
+                                          'ON (gb.created_by = u.id)';
         $this->aSQLViewList['ORDER_BY'] = 'id';
 
         // List of columns and (default?) order for viewing a list of entries.
@@ -73,10 +74,28 @@ class LOVD_GenomeBuild extends LOVD_Object
                                     'view' => array('Column suffix', 100),
                                     'db'   => array('gb.column_suffix', 'ASC', true))
                       );
+
+        // SQL code for viewing an entry.
+        $this->aSQLViewEntry['SELECT']   = 'gb.*, u.name AS created_by_';
+
+        $this->aSQLViewEntry['FROM']     = TABLE_GENOME_BUILDS . ' AS gb ' .
+            'LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (gb.created_by = u.id) ';
+        $this->aSQLViewEntry['GROUP_BY'] = 'gb.id';
+
+        // List of columns and (default?) order for viewing an entry.
+        $this->aColumnsViewEntry =
+            array(
+                'TableHeader_General' => 'General information',
+                'id' => 'Genome build ID',
+                'name' => 'Genome build name',
+                'column_suffix' => 'Column suffix',
+                'created_by' => 'Created by',
+                'created_date' => 'Date created'
+            );
+
         $this->sSortDefault = 'id';
 
         parent::__construct();
     }
 }
-
 ?>

--- a/src/class/object_genome_builds.php
+++ b/src/class/object_genome_builds.php
@@ -78,24 +78,45 @@ class LOVD_GenomeBuild extends LOVD_Object
         $this->aColumnsViewList =
                  array(
                         'id' => array(
-                                    'view' => array('Genome build ID', 50),
+                                    'view' => array('Genome build ID', 130),
                                     'db'   => array('gb.id', 'ASC', true)),
                         'name' => array(
                                     'view' => array('Name', 160),
                                     'db'   => array('gb.name', 'ASC', true)),
                          'column_suffix' => array(
-                                     'view' => array('Column suffix', 50),
+                                     'view' => array('Column suffix', 120),
                                      'db'   => array('gb.column_suffix', 'ASC', true)),
                          'created_by_' => array(
-                                     'view' => array('Created by', 100),
+                                     'view' => array('Created by', 160),
                                      'db'   => array('u.name', 'ASC', true)),
-                        'created_date' => array(
-                                    'view' => array('Date created', 130),
+                        'created_date_' => array(
+                                    'view' => array('Date created', 100),
                                     'db'   => array('gb.created_date', 'DESC', true))
                       );
         $this->sSortDefault = 'id';
 
         parent::__construct();
+    }
+
+
+
+
+
+    function prepareData ($zData = '', $sView = 'list')
+    {
+        // Prepares the data by "enriching" the variable received with links, pictures, etc.
+
+        if (!in_array($sView, array('list', 'entry'))) {
+            $sView = 'list';
+        }
+
+        // Makes sure it's an array and htmlspecialchars() all the values.
+        $zData = parent::prepareData($zData, $sView);
+
+        if ($sView == 'list') {
+            $zData['created_date_'] = substr($zData['created_date'], 0, 10);
+        }
+        return $zData;
     }
 }
 ?>

--- a/src/class/object_genome_builds.php
+++ b/src/class/object_genome_builds.php
@@ -1,0 +1,82 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2021-09-21
+ * Modified    : 2021-09-21
+ * For LOVD    : 3.5-pre-01
+ *
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               L. Werkman <l.werkman@lumc.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
+// Don't allow direct access.
+if (!defined('ROOT_PATH')) {
+    exit;
+}
+// Require parent class definition.
+require_once ROOT_PATH . 'class/objects.php';
+
+
+
+class LOVD_GenomeBuild extends LOVD_Object
+{
+    // This class extends the basic Object class and it handles the Logs.
+    var $sObject = 'GenomeBuild';
+    var $sTable = 'TABLE_GENOME_BUILDS';
+
+
+    function __construct ()
+    {
+        // Default constructor.
+
+        // SQL code for viewing a list of entries.
+        $this->aSQLViewList['SELECT']   = 'gb.*, u.name AS created_by_';
+        $this->aSQLViewList['FROM']     = TABLE_GENOME_BUILDS . ' AS gb LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (gb.created_by = u.id)';
+        $this->aSQLViewList['ORDER_BY'] = 'id';
+
+        // List of columns and (default?) order for viewing a list of entries.
+        $this->aColumnsViewList =
+                 array(
+                        'id' => array(
+                                    'view' => array('ID', 50),
+                                    'db'   => array('gb.id', 'ASC', true)),
+                        'name' => array(
+                                    'view' => array('name', 50),
+                                    'db'   => array('gb.name', 'ASC', true)),
+                        'created_date' => array(
+                                    'view' => array('created on', 130),
+                                    'db'   => array('gb.created_by', 'DESC', 'DATETIME')),
+                        'created_by_' => array(
+                                    'view' => array('User', 160),
+                                    'db'   => array('u.name', 'ASC', true)),
+                        'column_suffix' => array(
+                                    'view' => array('Column suffix', 100),
+                                    'db'   => array('gb.column_suffix', 'ASC', true))
+                      );
+        $this->sSortDefault = 'id';
+
+        parent::__construct();
+    }
+}
+
+?>

--- a/src/class/object_genome_builds.php
+++ b/src/class/object_genome_builds.php
@@ -71,7 +71,7 @@ class LOVD_GenomeBuild extends LOVD_Object
                 'name' => 'Genome build name',
                 'column_suffix' => 'Column suffix',
                 'created_by_' => 'Created by',
-                'created_date' => 'Date created'
+                'created_date_' => 'Date created'
             );
 
         // List of columns and (default?) order for viewing a list of entries.

--- a/src/class/object_genome_builds.php
+++ b/src/class/object_genome_builds.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-09-21
- * Modified    : 2021-09-22
+ * Modified    : 2021-09-23
  * For LOVD    : 3.5-pre-01
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -91,7 +91,7 @@ class LOVD_GenomeBuild extends LOVD_Object
                                      'db'   => array('u.name', 'ASC', true)),
                         'created_date' => array(
                                     'view' => array('Date created', 130),
-                                    'db'   => array('gb.created_by', 'DESC', 'DATETIME'))
+                                    'db'   => array('gb.created_date', 'DESC', true))
                       );
         $this->sSortDefault = 'id';
 

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -59,4 +59,25 @@ if (PATH_COUNT == 1 && !ACTION) {
     $_T->printFooter();
     exit;
 }
+
+
+if (PATH_COUNT == 2 && !ACTION) {
+    // URL: /genomebuilds/hg19
+    // View specific genome build.
+
+    $sID = lovd_getCurrentID();
+    define('PAGE_TITLE', lovd_getCurrentPageTitle());
+    $_T->printHeader();
+    $_T->printTitle();
+
+    // Load appropriate user level for this genome build.
+    lovd_isAuthorized('genome build', $sID);
+
+    require ROOT_PATH . 'class/object_genome_builds.php';
+    $_DATA = new LOVD_GenomeBuild();
+    $zData = $_DATA->viewEntry($sID);
+
+    $_T->printFooter();
+    exit;
+}
 ?>

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -1,0 +1,60 @@
+<?php
+/*******************************************************************************
+ *
+ * LEIDEN OPEN VARIATION DATABASE (LOVD)
+ *
+ * Created     : 2021-09-21
+ * Modified    : 2021-09-21
+ * For LOVD    : 3.5-pre-01
+ *
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               L. Werkman <l.werkman@lumc.nl>
+ *
+ *
+ * This file is part of LOVD.
+ *
+ * LOVD is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * LOVD is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LOVD.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *************/
+
+const ROOT_PATH = './';
+const TAB_SELECTED = 'setup';
+require ROOT_PATH . 'inc-init.php';
+
+if ($_AUTH) {
+    // If authorized, check for updates.
+    require ROOT_PATH . 'inc-upgrade.php';
+}
+
+// URL: /genome_builds
+// View all genome builds.
+
+const PAGE_TITLE = 'Genome builds';
+$_T->printHeader();
+$_T->printTitle();
+
+lovd_requireAUTH(LEVEL_MANAGER);
+
+
+
+
+
+require ROOT_PATH . 'class/object_genome_builds.php';
+$_DATA = new LOVD_GenomeBuild();
+
+$_DATA->viewList('GenomeBuilds', array());
+
+$_T->printFooter();
+?>

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -71,7 +71,7 @@ if (PATH_COUNT == 2 && !ACTION) {
     $_T->printTitle();
 
     // Load appropriate user level for this genome build.
-    lovd_isAuthorized('genome build', $sID);
+    lovd_requireAUTH(LEVEL_MANAGER);
 
     require ROOT_PATH . 'class/object_genome_builds.php';
     $_DATA = new LOVD_GenomeBuild();

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -4,12 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-09-21
- * Modified    : 2021-09-21
+ * Modified    : 2021-09-22
  * For LOVD    : 3.5-pre-01
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               L. Werkman <l.werkman@lumc.nl>
+ *               L. Werkman <L.Werkman@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -41,7 +41,7 @@ if ($_AUTH) {
 // URL: /genome_builds
 // View all genome builds.
 
-const PAGE_TITLE = 'Genome builds';
+define('PAGE_TITLE', 'Genome builds');
 $_T->printHeader();
 $_T->printTitle();
 

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -38,23 +38,25 @@ if ($_AUTH) {
     require ROOT_PATH . 'inc-upgrade.php';
 }
 
-// URL: /genome_builds
-// View all genome builds.
-
-define('PAGE_TITLE', 'Genome builds');
-$_T->printHeader();
-$_T->printTitle();
-
-lovd_requireAUTH(LEVEL_MANAGER);
 
 
 
 
+if (PATH_COUNT == 1 && !ACTION) {
+    // URL: /genome_builds
+    // View all genome builds.
 
-require ROOT_PATH . 'class/object_genome_builds.php';
-$_DATA = new LOVD_GenomeBuild();
+    define('PAGE_TITLE', 'Genome builds');
+    $_T->printHeader();
+    $_T->printTitle();
 
-$_DATA->viewList('GenomeBuilds', array());
+    lovd_requireAUTH(LEVEL_MANAGER);
 
-$_T->printFooter();
+    require ROOT_PATH . 'class/object_genome_builds.php';
+    $_DATA = new LOVD_GenomeBuild();
+    $_DATA->viewList('GenomeBuilds', array());
+
+    $_T->printFooter();
+    exit;
+}
 ?>

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -174,7 +174,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-27',
+                            'version' => '3.5-pre-01',
                           ),
                 'user_levels' =>
                      array(

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -850,7 +850,7 @@ function lovd_getCurrentPageTitle ()
     }
 
     // Capitalize the first letter, trim off the last 's' from the data object.
-    $sTitle = ucfirst($sTitle . substr($sObject, 0, -1));
+    $sTitle = ucfirst($sTitle . substr(str_replace('_', ' ', $sObject), 0, -1));
 
     if ($sObject == 'users' && ACTION != 'boot') {
         $sTitle .= ' account';
@@ -885,7 +885,7 @@ function lovd_getCurrentPageTitle ()
         // We're accessing just one entry.
         if ($sObject == 'genes') {
             $sTitle = preg_replace('/gene$/', ' the ' . $ID . ' gene', $sTitle);
-        } elseif ($sObject == 'columns') {
+        } elseif ($sObject == 'columns' || $sObject == 'genome_builds') {
             $sTitle .= ' ' . $ID;
         } else {
             $sTitle .= ' #' . $ID;

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -816,6 +816,18 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                  '3.0-26c' => array(
                      'ALTER TABLE ' . TABLE_LOGS . ' MODIFY COLUMN event VARCHAR(25) NOT NULL',
                  ),
+                 '3.5-pre-01' => array(
+                     'CREATE TABLE ' . TABLE_GENOME_BUILDS . ' (
+                        id VARCHAR(4) NOT NULL,
+                        name VARCHAR(20) NOT NULL,
+                        column_suffix VARCHAR(6) NOT NULL,
+                        created_by SMALLINT(5) UNSIGNED ZEROFILL,
+                        created_date DATETIME NOT NULL,
+                        PRIMARY KEY (id),
+                        CONSTRAINT ' . TABLE_GENOME_BUILDS . '_fk_created_by FOREIGN KEY (created_by) REFERENCES ' . TABLE_USERS . ' (id) ON DELETE SET NULL ON UPDATE CASCADE)    
+                        ENGINE=InnoDB,
+                        DEFAULT CHARACTER SET utf8'
+                 )
              );
 
     if ($sCalcVersionDB < lovd_calculateVersion('3.0-alpha-01')) {


### PR DESCRIPTION
- Create the genome builds table when installing LOVD.
- Create the genome builds table when upgrading an existing LOVD instance.
- Create the genome builds VL.
- Create the genome builds VE.
- Version bump to 3.5-pre-01.

Related to #550.