### PR TITLE
Fix lovd_checkXSS().

### DIFF
--- a/src/class/object_diseases.php
+++ b/src/class/object_diseases.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-07-28
- * Modified    : 2021-08-10
- * For LOVD    : 3.0-27
+ * Modified    : 2021-09-27
+ * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -319,7 +319,7 @@ class LOVD_Disease extends LOVD_Object
         }
 
         // XSS attack prevention. Deny input of HTML.
-        lovd_checkXSS();
+        lovd_checkXSS($aData);
     }
 
 

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2021-08-12
- * For LOVD    : 3.0-27
+ * Modified    : 2021-09-27
+ * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -290,7 +290,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
 
         parent::checkFields($aData, $zData, $aOptions);
 
-        lovd_checkXSS();
+        lovd_checkXSS($aData);
     }
 
 

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2021-07-07
- * For LOVD    : 3.0-27
+ * Modified    : 2021-09-27
+ * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -339,7 +339,7 @@ class LOVD_Individual extends LOVD_Custom
             }
         }
 
-        lovd_checkXSS();
+        lovd_checkXSS($aData);
     }
 
 

--- a/src/class/object_phenotypes.php
+++ b/src/class/object_phenotypes.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2021-07-07
- * For LOVD    : 3.0-27
+ * Modified    : 2021-09-27
+ * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -159,7 +159,7 @@ class LOVD_Phenotype extends LOVD_Custom
                       );
         parent::checkFields($aData, $zData, $aOptions);
 
-        lovd_checkXSS();
+        lovd_checkXSS($aData);
     }
 
 

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2021-07-12
- * For LOVD    : 3.0-27
+ * Modified    : 2021-09-27
+ * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -183,7 +183,7 @@ class LOVD_Screening extends LOVD_Custom
             }
         }
 
-        lovd_checkXSS();
+        lovd_checkXSS($aData);
     }
 
 

--- a/src/class/object_system_settings.php
+++ b/src/class/object_system_settings.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-23
- * Modified    : 2021-02-03
- * For LOVD    : 3.0-26
+ * Modified    : 2021-09-27
+ * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -188,7 +188,7 @@ class LOVD_SystemSetting extends LOVD_Object
         }
 
         // XSS attack prevention. Deny input of HTML.
-        lovd_checkXSS();
+        lovd_checkXSS($aData);
     }
 
 

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-12
- * Modified    : 2021-08-12
- * For LOVD    : 3.0-27
+ * Modified    : 2021-09-27
+ * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -275,7 +275,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
         // Bypass LOVD_Custom::checkFields(), since it's functionality has been copied above.
         LOVD_Object::checkFields($aData, $zData, $aOptions);
 
-        lovd_checkXSS();
+        lovd_checkXSS($aData);
     }
 
 

--- a/src/class/object_transcripts.php
+++ b/src/class/object_transcripts.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2020-11-02
- * For LOVD    : 3.0-26
+ * Modified    : 2021-09-27
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -168,7 +168,7 @@ class LOVD_Transcript extends LOVD_Object
         parent::checkFields($aData, $zData, $aOptions);
 
         // XSS attack prevention. Deny input of HTML.
-        lovd_checkXSS();
+        lovd_checkXSS($aData);
     }
 
 

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-07-27
- * For LOVD    : 3.0-27
+ * Modified    : 2021-09-27
+ * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -312,7 +312,7 @@ class LOVD_User extends LOVD_Object
         }
 
         // XSS attack prevention. Deny input of HTML.
-        lovd_checkXSS();
+        lovd_checkXSS($aData);
     }
 
 

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-09-24
+ * Modified    : 2021-09-27
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -174,7 +174,12 @@ function lovd_checkXSS ($aInput = '')
     foreach ($aInput as $key => $val) {
         if (is_array($val)) {
             $bSuccess = $bSuccess && lovd_checkXSS($val);
-        } elseif (strpos($val, '<') !== false) {
+        } elseif (!empty($val) && strpos($key, '/') !== false && preg_match('/<.*>/s', $val)) {
+            // Disallowed tag found. This check is for custom columns, that often contain < characters.
+            $bSuccess = false;
+            lovd_errorAdd($key, 'Disallowed tag found in form field' . (is_numeric($key)? '.' : ' "' . htmlspecialchars($key) . '".') . ' XSS attack?');
+        } elseif (strpos($key, '/') === false && strpos($val, '<') !== false) {
+            // This check is for any fixed field, such as the registration form.
             // Just disallow any use of <; it can introduce XSS even without a matching >.
             $bSuccess = false;
             lovd_errorAdd($key, 'The use of \'&lt;\' in form fields is now allowed.' .


### PR DESCRIPTION
Fix lovd_checkXSS().
- Relaxed the new XSS check a bit.
  - The less-than sign (`<`) wasn't allowed at all in fields anymore, but they are in use for age fields and probably other phenotype fields as well. So relaxed this check for all custom columns back to the previous XSS check. The newer check for no less-than at all, remains for non-custom columns.
- During import, make sure the XSS check is run on the import data.
  - When `lovd_checkXSS()` is run without arguments, it runs on `$_POST` by default. During import, this is not the correct variable to run on. Make sure it runs on `$aData`, which resolves to either `$_POST` or, during import, to `$aLine`.