### PR TITLE
Gb/disable

### DIFF
--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -371,8 +371,8 @@ if (PATH_COUNT == 2 && ACTION == 'remove') {
             }
 
             // Deactivate custom DNA column.
-            $_DB->query('DELETE FROM ' . TABLE_ACTIVE_COLS .
-                ' WHERE colid = "VariantOnGenome/DNA' . $sSuffixWithSlash . '"');
+            $_DB->query('DELETE FROM ' . TABLE_ACTIVE_COLS . ' WHERE colid = ?',
+                array('VariantOnGenome/DNA' . $sSuffixWithSlash));
 
             // Write to log...
             lovd_writeLog('Event', LOG_EVENT, 'Removed Genome Build ' . $sID);

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -291,16 +291,19 @@ if (PATH_COUNT == 2 && ACTION == 'remove') {
                             `VariantOnGenome/DNA' . $sColumnSuffix . '` = "")';
         }
 
-        $bVariantsLostAfterRemovingGenomeBuild = (bool) $_DB->query($sSQL)->fetchColumn();
-
-        if ($bVariantsLostAfterRemovingGenomeBuild) {
-            $sReason = 'not all variants that are mapped on this reference genome are safely mapped on a second build.';
+        $nVariantsLostAfterRemovingGenomeBuild = $_DB->query($sSQL)->fetchColumn();
+        if ($nVariantsLostAfterRemovingGenomeBuild > 0) {
+            $sReason = 'not all variants mapped on this reference genome are also mapped on another genome build.<BR>' .
+                'Therefore, removing this genome build will break ' . ($nVariantsLostAfterRemovingGenomeBuild == 1? 'this ' : 'these ') .
+                 $nVariantsLostAfterRemovingGenomeBuild . ' variant' . ($nVariantsLostAfterRemovingGenomeBuild == 1? '' : 's') .
+                ' as they will no longer have a genomic DNA description.<BR>' .
+                'Make sure all variants are mapped to at least one other genome build.';
         }
     }
 
     // Throw error if any was found.
     if ($sReason) {
-        lovd_showInfoTable('The genome build cannot be deactivated, since ' . $sReason, 'warning');
+        lovd_showInfoTable('The genome build cannot be deactivated since ' . $sReason, 'warning');
         $_T->printFooter();
         exit;
     }

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -206,9 +206,6 @@ if (PATH_COUNT == 1 && ACTION == 'add') {
 
     lovd_errorPrint();
 
-    // Tooltip JS code.
-    lovd_includeJS('inc-js-tooltip.php');
-
     // Table.
     print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '" method="post">' . "\n");
 
@@ -288,8 +285,7 @@ if (PATH_COUNT == 2 && ACTION == 'remove') {
     } else {
         // Check to make sure that all variants are safely stored on the
         //  genome builds that will remain active.
-        $sSQL = 'SELECT COUNT(id) FROM ' . TABLE_VARIANTS . ' WHERE 1 = 1';
-
+        $sSQL = 'SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' WHERE 1 = 1';
         foreach(array_diff_key($aActiveBuilds, array($sID => '_')) as $sBuild => $sColumnSuffix) {
             $sColumnSuffix = (!$sColumnSuffix? '' : '/' . $sColumnSuffix);
             $sSQL .= ' AND (`VariantOnGenome/DNA' . $sColumnSuffix . '` IS NULL OR
@@ -325,26 +321,25 @@ if (PATH_COUNT == 2 && ACTION == 'remove') {
         // Accept and realise removal of the genome build after passing the checks.
         if (!lovd_error()) {
             // Remove genome build from database.
-            $_DB->query('DELETE FROM ' . TABLE_GENOME_BUILDS .
-                        ' WHERE id = ?', array($sID));
+            $_DB->query('DELETE FROM ' . TABLE_GENOME_BUILDS . ' WHERE id = ?', array($sID));
 
             // Prepare a slash and underscore only if needed.
             // The default genome build does not have a column suffix, so
             //  in this case we also do not want a slash and/or underscore.
-            $sSlash = (!$aActiveBuilds[$sID]? '' : '/');
-            $sUnderscore = (!$aActiveBuilds[$sID]? '' : '_');
+            $sSuffixWithSlash = (!$aActiveBuilds[$sID]? '' : '/' . $aActiveBuilds[$sID]);
+            $sSuffixWithUnderscore = (!$aActiveBuilds[$sID]? '' : '_' . $aActiveBuilds[$sID]);
 
             // Prepare an array to more easily remove the columns from the
             //  VOG and transcripts tables.
             $aTablesAndTheirColumns = array(
                 TABLE_VARIANTS => array(
-                    'VariantOnGenome/DNA' . $sSlash . $aActiveBuilds[$sID],
-                    'position_g_start' . $sUnderscore . $aActiveBuilds[$sID],
-                    'position_g_end' . $sUnderscore . $aActiveBuilds[$sID],
+                    'VariantOnGenome/DNA' . $sSuffixWithSlash,
+                    'position_g_start' . $sSuffixWithUnderscore,
+                    'position_g_end' . $sSuffixWithUnderscore,
                 ),
                 TABLE_TRANSCRIPTS => array(
-                    'position_g_mrna_start' . $sUnderscore . $aActiveBuilds[$sID],
-                    'position_g_mrna_end' . $sUnderscore . $aActiveBuilds[$sID],
+                    'position_g_mrna_start' . $sSuffixWithUnderscore,
+                    'position_g_mrna_end' . $sSuffixWithUnderscore,
                 ),
             );
 
@@ -374,9 +369,8 @@ if (PATH_COUNT == 2 && ACTION == 'remove') {
             }
 
             // Deactivate custom DNA column.
-            // TODO: Colsuffix / dependant
             $_DB->query('DELETE FROM ' . TABLE_ACTIVE_COLS .
-                ' WHERE colid = "VariantOnGenome/DNA' . $sSlash . $aActiveBuilds[$sID] . '"');
+                ' WHERE colid = "VariantOnGenome/DNA' . $sSuffixWithSlash . '"');
 
             // Write to log...
             lovd_writeLog('Event', LOG_EVENT, 'Removed Genome Build ' . $sID);
@@ -407,9 +401,6 @@ if (PATH_COUNT == 2 && ACTION == 'remove') {
 
     lovd_errorPrint();
 
-    // Tooltip JS code.
-    lovd_includeJS('inc-js-tooltip.php');
-
     // Table.
     print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '" method="post">' . "\n");
 
@@ -426,5 +417,4 @@ if (PATH_COUNT == 2 && ACTION == 'remove') {
     $_T->printFooter();
     exit;
 }
-
 ?>

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -277,7 +277,7 @@ if (PATH_COUNT == 2 && ACTION == 'remove') {
         // Check to make sure there would be a genome build left after the removal.
         $sReason = 'there must be at least one reference genome left after the removal.';
 
-    } elseif (!in_array($sID, $aActiveBuilds)) {
+    } elseif (!isset($aActiveBuilds[$sID])) {
         // Check whether the given ID is one of the active IDs in the database.
         $sReason = 'an invalid genome build was given.';
 

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -242,9 +242,8 @@ if (PATH_COUNT == 2 && !ACTION) {
     $zData = $_DATA->viewEntry($sID);
 
     // Show the option to deactivate the genome build if there are more than one active.
-    $aAmountOfActiveGBs = count($_DB->query('SELECT id FROM ' . TABLE_GENOME_BUILDS)->fetchAllColumn());
-
-    if ($aAmountOfActiveGBs > 1) {
+    $nAmountOfActiveGBs = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_GENOME_BUILDS)->fetchColumn();
+    if ($nAmountOfActiveGBs > 1) {
         $aNavigation = array(
             CURRENT_PATH . '?remove' => array('cross.png', 'Deactivate this genome build', 1),
         );


### PR DESCRIPTION
Allows users to deactivate a given genome build.
- Adds option to deactivate in VE of genome builds, ONLY if there is more than one genome build active.
- Checks to make sure all variants are safely stored on remaining genome builds, and cancels the removal when this is not the case.

Closes #557 
Related to #550 
