### PR TITLE
Allow passing the classification method to the submission API using the pathogenicity's `@source` value.

### DIFF
--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2021-10-26
+ * Modified    : 2021-10-27
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -516,6 +516,12 @@ class LOVD_API_Submissions
                             $aClassificationMethods = explode("\r\n", $sClassificationMethods);
                             // Isolate only the option values.
                             $aClassificationMethods = preg_replace('/\s*(=.*)?$/', '', $aClassificationMethods);
+                        }
+
+                        // Load the method from the source, if given.
+                        if (isset($aVariant['pathogenicity'][0]['@source'])
+                            && in_array($aVariant['pathogenicity'][0]['@source'], $aClassificationMethods)) {
+                            $aVOG['VariantOnGenome/ClinicalClassification/Method'] = $aVariant['pathogenicity'][0]['@source'];
                         }
                     }
                 }


### PR DESCRIPTION
Currently, you can only pass the clinical classification method as a remark to the `pathogenicity` element. However, that remark also ends up in the `VOG/Remarks` field. It would be better to allow the format that the VarioML API (GA4GH framework) is using - providing a `source` to the `pathogenicity` element. So the submission API now accepts this format:

```json
    "pathogenicity": {
        "@scope": "individual",
        "@source": "ACMG",
        "@term": "Pathogenic"
    }
```

Allowed values for `@source` are currently; `ACMG`, `ACGS`, `EAHAD-CFDB`, `ENIGMA`, `IARC`, `InSiGHT`, `kConFab`, and `other`.

Closes #568.

@beboche; I need to run the tests, to see if everything works still. When that succeeds, I will update the shared and let you know.