### PR TITLE
Fix LOVD for PHP8

### DIFF
--- a/src/ajax/curate_set.php
+++ b/src/ajax/curate_set.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-04
- * Modified    : 2020-03-11
- * For LOVD    : 3.0-24
+ * Modified    : 2021-11-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -364,10 +364,10 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
 
                     $_POST += $zData; // Won't overwrite existing key (statusid).
                     // Now loop through $_POST to find the effectid fields, that need to be split.
-                    foreach ($_POST as $key => $val) {
-                        if (preg_match('/^(\d+_)?effect(id)$/', $key, $aRegs)) { // (id) instead of id to make sure we have a $aRegs (so to prevent notices).
-                            $_POST[$aRegs[1] . 'effect_reported'] = $val{0};
-                            $_POST[$aRegs[1] . 'effect_concluded'] = $val{1};
+                    foreach ($_POST as $sKey => $sVal) {
+                        if (preg_match('/^(\d+_)?effect(id)$/', $sKey, $aRegs)) { // (id) instead of id to make sure we have a $aRegs (so to prevent notices).
+                            $_POST[$aRegs[1] . 'effect_reported'] = $sVal[0];
+                            $_POST[$aRegs[1] . 'effect_concluded'] = $sVal[1];
                         }
                     }
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-09-17
+ * Modified    : 2021-11-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -346,21 +346,21 @@ class LOVD_API_GA4GH
             if ($sIDEffect) {
                 list($nID, $nEffectID) = explode(':', $sIDEffect);
                 $aReturn[$nID] = array();
-                if ($nEffectID{0}) {
+                if ($nEffectID[0]) {
                     $aReturn[$nID][] = array(
                         'scope' => 'individual', // Always the same for us.
                         'source' => 'LOVD',
-                        'term' => $this->aValueMappings['effect'][(int) $nEffectID{0}],
+                        'term' => $this->aValueMappings['effect'][(int) $nEffectID[0]],
                         'data_source' => array(
                             'name' => 'submitter',
                         ),
                     );
                 }
-                if ($nEffectID{1}) {
+                if ($nEffectID[1]) {
                     $aReturn[$nID][] = array(
                         'scope' => 'individual', // Always the same for us.
                         'source' => 'LOVD',
-                        'term' => $this->aValueMappings['effect'][(int) $nEffectID{1}],
+                        'term' => $this->aValueMappings['effect'][(int) $nEffectID[1]],
                         'data_source' => array(
                             'name' => 'curator',
                         ),

--- a/src/class/api.submissions.php
+++ b/src/class/api.submissions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-22
- * Modified    : 2021-10-27
+ * Modified    : 2021-11-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -308,7 +308,7 @@ class LOVD_API_Submissions
         if (is_array($aInput)) {
             foreach ($aInput as $sKey => $Value) {
                 // Attributes or text values can never be repeated, so check only possible arrays.
-                if ($sKey{0} != '@' && $sKey{0} != '#') {
+                if ($sKey[0] != '@' && $sKey[0] != '#') {
                     // Check if this key is listed as one that can be repeated.
                     if (in_array((string) $sKey, $this->aRepeatableElements['varioml'])) {
                         // This element can be repeated. Make sure it's a proper array of values.
@@ -977,7 +977,7 @@ class LOVD_API_Submissions
         $sInputClean = trim(preg_replace('/\/\*.+\*\//Us', '', $sInput));
 
         // Then, check the first character. Should be an '{'.
-        if ($sInputClean{0} != '{') {
+        if ($sInputClean[0] != '{') {
             // Can't be JSON...
             $this->API->aResponse['errors'][] = 'Unsupported media type. Expecting: application/json.';
             $this->API->nHTTPStatus = 415; // Send 415 Unsupported Media Type.

--- a/src/class/object_custom.php
+++ b/src/class/object_custom.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-17
- * Modified    : 2021-07-27
- * For LOVD    : 3.0-27
+ * Modified    : 2021-11-10
+ * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -161,7 +161,7 @@ class LOVD_Custom extends LOVD_Object
             if (in_array($this->sCategory, array('VariantOnGenome', 'VariantOnTranscript'))) {
                 $sAlias = 'vog';
             } else {
-                $sAlias = strtolower($this->sCategory{0});
+                $sAlias = strtolower($this->sCategory[0]);
             }
 
             // Construct list of user IDs for current user and users who share access with them.

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2021-09-27
+ * Modified    : 2021-11-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -413,13 +413,13 @@ class LOVD_GenomeVariant extends LOVD_Custom
             //  'not classified', will the form field be shown so that the user
             //  must manually correct the current value.
             $bHideEffectConcluded = false;
-            $nVOGEffectConcluded = intval($zData['effectid']{1});
+            $nVOGEffectConcluded = intval($zData['effectid'][1]);
             if ($nVOGEffectConcluded === 0) {
                 // Set to "Not classified", we'll fill it in.
                 $bHideEffectConcluded = true;
             } else {
                 $nMaxEffectReported = max(array_map(function ($sEffectID) {
-                    return intval($sEffectID{1});
+                    return intval($sEffectID[1]);
                 }, $aTranscriptEffects));
                 if ($nVOGEffectConcluded == $nMaxEffectReported) {
                     $bHideEffectConcluded = true;
@@ -442,13 +442,13 @@ class LOVD_GenomeVariant extends LOVD_Custom
             //  'not classified', will the form field be shown so that the user
             //  must manually correct the current value.
             $bHideEffectReported = false;
-            $nVOGEffectReported = intval($zData['effectid']{0});
+            $nVOGEffectReported = intval($zData['effectid'][0]);
             if ($nVOGEffectReported === 0) {
                 // Set to "Not classified", we'll fill it in.
                 $bHideEffectReported = true;
             } else {
                 $nMaxEffectReported = max(array_map(function ($sEffectID) {
-                    return intval($sEffectID{0});
+                    return intval($sEffectID[0]);
                 }, $aTranscriptEffects));
                 if ($nVOGEffectReported == $nMaxEffectReported) {
                     $bHideEffectReported = true;
@@ -497,8 +497,8 @@ class LOVD_GenomeVariant extends LOVD_Custom
             if (empty($zData['individualid_'])) {
                 unset($this->aColumnsViewEntry['individualid_']);
             }
-            $zData['effect_reported'] = $_SETT['var_effect'][$zData['effectid']{0}];
-            $zData['effect_concluded'] = $_SETT['var_effect'][$zData['effectid']{1}];
+            $zData['effect_reported'] = $_SETT['var_effect'][$zData['effectid'][0]];
+            $zData['effect_concluded'] = $_SETT['var_effect'][$zData['effectid'][1]];
 
             if (!empty($zData['VariantOnGenome/DBID'])) {
                 // Allow linking to view of all these variants.

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-12
- * Modified    : 2021-09-27
+ * Modified    : 2021-11-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -426,9 +426,9 @@ class LOVD_TranscriptVariant extends LOVD_Custom
         if ($sView == 'entry') {
             $zData['geneid_'] = '<A href="genes/' . $zData['geneid'] . '">' . $zData['geneid'] . '</A>';
             $zData['id_ncbi_'] = '<A href="transcripts/' . $zData['transcriptid'] . '">' . $zData['id_ncbi'] . '</A>';
-            $zData['effect_reported'] = $_SETT['var_effect'][$zData['effectid']{0}];
-            $zData['effect_concluded'] = $_SETT['var_effect'][$zData['effectid']{1}];
-            if (LOVD_plus && lovd_verifyInstance('mgha', false)) { // Display the Genomizer URL in the VOT ViewEntry. TODO Once the ref and alt are separated we need to add it into this URL. Should we add this to the links table so as it can be used elsewhere?
+            $zData['effect_reported'] = $_SETT['var_effect'][$zData['effectid'][0]];
+            $zData['effect_concluded'] = $_SETT['var_effect'][$zData['effectid'][1]];
+            if (LOVD_plus && lovd_verifyInstance('mgha', false)) { // Display the Genomizer URL in the VOT ViewEntry.
                 $zData['genomizer_url_'] = '<A href="http://genomizer.com/?chr=' . $zData['chromosome'] . '&gene=' . $zData['geneid'] . '&ref_seq=' . $zData['id_ncbi'] . '&variant=' . $zData['VariantOnTranscript/DNA'] . '" target="_blank">Genomizer Link</A>';
                 if (isset($zData['VariantOnTranscript/dbNSFP/ClinVar/Clinical_Significance'])) {
                     $zData['clinvar_'] = implode(', ', lovd_mapCodeToDescription(explode(',', $zData['VariantOnTranscript/dbNSFP/ClinVar/Clinical_Significance']), $_SETT['clinvar_var_effect']));
@@ -541,7 +541,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
 
             // Although these fields should of course exist, this method should not assume they do.
             if (in_array('effectid', $aGeneFields[$sGene])) {
-                $aData['effectid'] = $aData[$nTranscriptID . '_effect_reported'] . ($_AUTH['level'] >= LEVEL_CURATOR? $aData[$nTranscriptID . '_effect_concluded'] : $zData[$nTranscriptID . '_effectid']{1});
+                $aData['effectid'] = $aData[$nTranscriptID . '_effect_reported'] . ($_AUTH['level'] >= LEVEL_CURATOR? $aData[$nTranscriptID . '_effect_concluded'] : $zData[$nTranscriptID . '_effectid'][1]);
             }
             if (in_array('position_c_start', $aGeneFields[$sGene])) {
                 $aData['position_c_start'] = $aData[$nTranscriptID . '_position_c_start'];

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-09-24
+ * Modified    : 2021-11-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -244,20 +244,20 @@ class LOVD_Object
     function autoExplode ($zData)
     {
         // Automatically explode GROUP_CONCAT values based on their name.
-        foreach ($zData as $key => $val) {
-            if ($key{0} == '_') {
-                unset($zData[$key]);
-                if (!empty($val)) {
-                    if ($key{1} == '_') {
+        foreach ($zData as $sKey => $sVal) {
+            if ($sKey[0] == '_') {
+                unset($zData[$sKey]);
+                if (!empty($sVal)) {
+                    if ($sKey[1] == '_') {
                         // Explode GROUP_CONCAT nested array
-                        $aValues = explode(';;', $val);
-                        $zData[ltrim($key, '_')] = array_map('explode', array_fill(0, count($aValues), ';'), $aValues);
+                        $aValues = explode(';;', $sVal);
+                        $zData[ltrim($sKey, '_')] = array_map('explode', array_fill(0, count($aValues), ';'), $aValues);
                     } else {
                         // Explode GROUP_CONCAT array
-                        $zData[ltrim($key, '_')] = explode(';', $val);
+                        $zData[ltrim($sKey, '_')] = explode(';', $sVal);
                     }
                 } else {
-                    $zData[ltrim($key, '_')] = array();
+                    $zData[ltrim($sKey, '_')] = array();
                 }
             }
         }
@@ -1633,7 +1633,7 @@ class LOVD_Object
 
             // Handle JSON data (well, in a VL, we hide it).
             foreach ($zData as $sKey => $Value) {
-                if (is_string($Value) && $Value && $Value{0} == '{'
+                if (is_string($Value) && $Value && $Value[0] == '{'
                     && is_array(json_decode(htmlspecialchars_decode($Value), true))) {
                     // We don't show JSON data in the VLs.
                     $zData[$sKey] = '<I>(data)</I>';
@@ -1653,7 +1653,7 @@ class LOVD_Object
 
             // Handle JSON well.
             foreach ($zData as $sKey => $Value) {
-                if (is_string($Value) && $Value && $Value{0} == '{'
+                if (is_string($Value) && $Value && $Value[0] == '{'
                     && is_array(json_decode(htmlspecialchars_decode($Value), true))) {
                     // Restructure the JSON.
                     $zData[$sKey] = $this->formatArrayToTable(json_decode(htmlspecialchars_decode($Value), true));

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-27
- * Modified    : 2021-10-14
+ * Modified    : 2021-11-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -776,7 +776,7 @@ foreach ($zAnnouncements as $zAnnouncement) {
                         if (!$sURL) {
                             // Default action of default page.
                             $sURL = $sPrefix;
-                        } elseif ($sURL{0} == '/') {
+                        } elseif ($sURL[0] == '/') {
                             // Direct URL.
                             $sURL = substr($sURL, 1);
                         } else {

--- a/src/columns.php
+++ b/src/columns.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-03-04
- * Modified    : 2020-11-24
- * For LOVD    : 3.0-26
+ * Modified    : 2021-11-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -385,7 +385,7 @@ if (PATH_COUNT == 1 && ACTION == 'data_type_wizard') {
         }
 
         // Check regexp syntax.
-        if (!empty($_POST['preg_pattern']) && ($_POST['preg_pattern']{0} != '/' || @preg_match($_POST['preg_pattern'], '') === false)) {
+        if (!empty($_POST['preg_pattern']) && ($_POST['preg_pattern'][0] != '/' || @preg_match($_POST['preg_pattern'], '') === false)) {
             lovd_errorAdd('preg_pattern', 'The \'Regular expression pattern\' field does not seem to contain valid PHP Perl compatible regexp syntax.');
         }
 

--- a/src/import.php
+++ b/src/import.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2021-08-11
- * For LOVD    : 3.0-27
+ * Modified    : 2021-11-10
+ * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -1492,14 +1492,14 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
                         if (strlen($aLine['effectid']) != 2) {
                             lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): Please select a valid entry for the \'effectid\' field.');
                         } else {
-                            $aLine['effect_reported'] = $aLine['effectid']{0};
-                            $aLine['effect_concluded'] = $aLine['effectid']{1};
+                            $aLine['effect_reported'] = $aLine['effectid'][0];
+                            $aLine['effect_concluded'] = $aLine['effectid'][1];
                         }
                     } else {
                         // Apply the default values.
                         $aLine['effectid'] = $_SETT['var_effect_default']; // Defaults for import.
-                        $aLine['effect_reported'] = $aLine['effectid']{0}; // Defaults for checkFields().
-                        $aLine['effect_concluded'] = $aLine['effectid']{1}; // Defaults for checkFields().
+                        $aLine['effect_reported'] = $aLine['effectid'][0]; // Defaults for checkFields().
+                        $aLine['effect_concluded'] = $aLine['effectid'][1]; // Defaults for checkFields().
                     }
                 }
 
@@ -1632,7 +1632,7 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
                         }
                     }
                     // Check regexp syntax.
-                    if (!empty($aLine['preg_pattern']) && ($aLine['preg_pattern']{0} != '/' || @preg_match($aLine['preg_pattern'], '') === false)) {
+                    if (!empty($aLine['preg_pattern']) && ($aLine['preg_pattern'][0] != '/' || @preg_match($aLine['preg_pattern'], '') === false)) {
                         lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): The \'Regular expression pattern\' field does not seem to contain valid PHP Perl compatible regexp syntax.');
                     }
 

--- a/src/inc-auth.php
+++ b/src/inc-auth.php
@@ -4,12 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-23
- * Modified    : 2016-09-01
- * For LOVD    : 3.0-17
+ * Modified    : 2021-11-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2016 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmers : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
- *               Ing. Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
  *
@@ -59,7 +59,7 @@ if (isset($_SESSION['auth']) && is_array($_SESSION['auth'])) {
 
         // Decode saved work.
         // FIXME; Later when we add a decent json_decode library, we want to remove the unserialize() part.
-        $_AUTH['saved_work'] = (!empty($_AUTH['saved_work'])? ($_AUTH['saved_work']{0} == 'a'? unserialize($_AUTH['saved_work']) : json_decode($_AUTH['saved_work'])) : array());
+        $_AUTH['saved_work'] = (!empty($_AUTH['saved_work'])? ($_AUTH['saved_work'][0] == 'a'? unserialize($_AUTH['saved_work']) : json_decode($_AUTH['saved_work'])) : array());
 
         // Get an array of IDs of users that share their permissions with current user.
         $q = $_DB->query('SELECT userid_from, allow_edit FROM ' . TABLE_COLLEAGUES .

--- a/src/inc-lib-api.php
+++ b/src/inc-lib-api.php
@@ -4,11 +4,11 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-11-09
- * Modified    : 2012-11-09
- * For LOVD    : 3.0-beta-10
+ * Modified    : 2021-11-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2012 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -47,11 +47,12 @@ function lovd_convertDNAPositionToDB ($nPositionMRNAStart, $nPositionMRNAEnd, $n
         if (empty($aRegs[3])) {
             $aRegs[3] = 0;
         } else {
-            $aRegs[3] = intval($aRegs[2]{0} . $aRegs[3]);
+            // Prefix with + or - to create the integer.
+            $aRegs[3] = intval($aRegs[2][0] . $aRegs[3]);
         }
 
         // Change c.*50 notation to c.500.
-        if ($aRegs[1]{0} == '*') {
+        if ($aRegs[1][0] == '*') {
             $aRegs[1] = substr($aRegs[1], 1) + $nPositionCDSEnd;
         }
 

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-09-27
+ * Modified    : 2021-11-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -141,7 +141,7 @@ function lovd_checkORCIDChecksum ($sID)
     $sBaseDigits = ltrim(str_replace('-', '', substr($sID, 0, -1)), '0'); // '0000-0002-1368-1939' => 21368193
     $nTotal = 0;
     for ($i = 0; $i < strlen($sBaseDigits); $i++) {
-        $nDigit = (int) $sBaseDigits{$i};
+        $nDigit = (int) $sBaseDigits[$i];
         $nTotal = ($nTotal + $nDigit) * 2;
     }
     $nRemainder = $nTotal % 11;
@@ -857,7 +857,7 @@ function lovd_trimField ($sVal)
     // Instead, we check if the field is surrounded by quotes. If so, we take the first and last character off and return the field.
 
     $sVal = trim($sVal);
-    if ($sVal && $sVal{0} == '"' && substr($sVal, -1) == '"') {
+    if ($sVal && $sVal[0] == '"' && substr($sVal, -1) == '"') {
         $sVal = substr($sVal, 1, -1); // Just trim the first and last quote off, nothing else!
     }
     return trim($sVal);
@@ -1138,7 +1138,7 @@ function lovd_wrapText ($s, $l = 70, $sCut = ' ')
     if (empty($sCut) || !is_string($sCut)) {
         $sCut = ' ';
     } elseif (strlen($sCut) > 1) {
-        $sCut = $sCut{0};
+        $sCut = $sCut[0];
     }
     if ($sCut != ' ') {
         // If it's not a space, we will add it to the end of each line as well, so we use extra space.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2021-09-22
+ * Modified    : 2021-11-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1031,7 +1031,7 @@ function lovd_getFilesFromDir ($sPath = '', $sPrefix = '', $aSuffixes = array())
         return false;
     }
     while (($sFile = readdir($h)) !== false) {
-        if ($sFile{0} == '.') {
+        if ($sFile[0] == '.') {
             // Current dir, parent dir, and hidden files.
             continue;
         }

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2020-11-19
- * For LOVD    : 3.0-26
+ * Modified    : 2021-11-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Daan Asscheman <D.Asscheman@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -59,10 +59,10 @@ function lovd_fixHGVS ($sVariant, $sType = 'g')
     $sVariant = (string) $sVariant;
 
     // Forgot a prefix?
-    if (ctype_digit($sVariant{0})) {
+    if (ctype_digit($sVariant[0])) {
         // Variant starts with a number. Try including a prefix.
         return lovd_fixHGVS($sType . '.' . $sVariant, $sType);
-    } elseif ($sVariant{0} == '.') {
+    } elseif ($sVariant[0] == '.') {
         // Variant starts with a period. Try including a prefix.
         return lovd_fixHGVS($sType . $sVariant, $sType);
     }
@@ -77,7 +77,7 @@ function lovd_fixHGVS ($sVariant, $sType = 'g')
         // Return as a delins.
         // The annoying thing is that 'con' never needed a square bracket,
         //  but a delins does, when other reference sequences are involved.
-        if (in_array($aRegs[2]{0}, array('N', 'X'))) {
+        if (in_array($aRegs[2][0], array('N', 'X'))) {
             $aRegs[2] = '[' . $aRegs[2] . ']';
         }
         return lovd_fixHGVS($sType . '.' . $aRegs[1] . 'delins' . $aRegs[2]);

--- a/src/inc-lib-viewlist.php
+++ b/src/inc-lib-viewlist.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-22
- * Modified    : 2020-10-12
- * For LOVD    : 3.0-25
+ * Modified    : 2021-11-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -80,11 +80,11 @@ function lovd_formatSearchExpression ($sExpression, $sColumnType)
                         $sFormattedExpression .= 'Is empty';
                     } elseif (substr($sORExpression, 0, 2) == '!=') {
                         $sFormattedExpression .= 'Does not exactly match ' . trim($sORExpression, '!="');
-                    } elseif ($sORExpression{0} == '!') {
+                    } elseif ($sORExpression[0] == '!') {
                         $sFormattedExpression .= 'Does not contain ' . trim($sORExpression, '!=');
-                    } elseif ($sORExpression{0} == '=') {
+                    } elseif ($sORExpression[0] == '=') {
                         $sFormattedExpression .= 'Exactly matches ' . trim($sORExpression, '="');
-                    } elseif ($sORExpression{0} == '^') {
+                    } elseif ($sORExpression[0] == '^') {
                         $sFormattedExpression .= 'Starts with ' . ltrim($sORExpression, '^');
                     } elseif (substr($sORExpression, -1) == '$') {
                         $sFormattedExpression .= 'Ends with ' . rtrim($sORExpression, '$');
@@ -98,7 +98,7 @@ function lovd_formatSearchExpression ($sExpression, $sColumnType)
                 case 'DECIMAL_UNSIGNED':
                 case 'DATE':
                 case 'DATETIME':
-                    if (!in_array($sORExpression{0}, array('<', '>', '!'))) {
+                    if (!in_array($sORExpression[0], array('<', '>', '!'))) {
                         $sFormattedExpression .= '=' . $sORExpression;
                     } else {
                         $sFormattedExpression .= $sORExpression;

--- a/src/scripts/convert_lovd2.php
+++ b/src/scripts/convert_lovd2.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-10-04
- * Modified    : 2021-09-24
+ * Modified    : 2021-11-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2014-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -556,7 +556,7 @@ function lovd_getHeaders ($aData, $aFieldLinks, $aSections, $aCustomColLinks)
     // Walk through lines until header is found, then parse the header.
     foreach ($aData as $i => $sLine) {
         $sLine = trim($sLine);
-        if (empty($sLine) || $sLine{0} == '#') {
+        if (empty($sLine) || $sLine[0] == '#') {
             // Ignore blank lines and comments.
             continue;
         }
@@ -926,7 +926,7 @@ function lovd_parseData ($aData, $zTranscript, $aFieldLinks, $aInputHeaders, $aO
         $oProgressBar->setMessage('Converting record ' . strval($nCounter) . ' of ' .
             strval($nNumLines) . '...');
 
-        if (empty($sLine) || $sLine{0} == '#' || preg_match('/^"?{{.*/', $sLine)) {
+        if (empty($sLine) || $sLine[0] == '#' || preg_match('/^"?{{.*/', $sLine)) {
             // Ignore blank lines, comments and the header line.
             continue;
         }

--- a/src/scripts/readingFrameChecker.php
+++ b/src/scripts/readingFrameChecker.php
@@ -4,16 +4,16 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-09-28 (based on Reading Frame Checker 1.9/2009-03-03)
- * Modified    : 2019-07-25
+ * Modified    : 2021-11-10
  * Version     : 1.4
- * For LOVD    : 3.0-22
+ * For LOVD    : 3.0-28
  *
  * Access      : Public
  * Purpose     : Provide information on effect of whole-exon changes of a gene,
  *               based on the gene structure table, created by the Reference
  *               Sequence Parser.
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Gerard C.P. Schaafsma <G.C.P.Schaafsma@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -140,7 +140,7 @@ if (is_readable($sFilePath)) {
                             $nStart = 0; // For easier calculation of "End - Start".
                         }
                     }
-                    if (!$nStopExon && $nEnd{0} == '*') {
+                    if (!$nStopExon && $nEnd[0] == '*') {
                         $nStopExon = $nExon;
                     }
                     $aReadingFrame[$nExon] = ($aReadingFrame[$nExon - 1] + $nLength)%3;

--- a/src/scripts/refseq_parser.php
+++ b/src/scripts/refseq_parser.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-29
- * Modified    : 2020-03-31
- * For LOVD    : 3.0-22
+ * Modified    : 2021-11-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Gerard C.P. Schaafsma <G.C.P.Schaafsma@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -510,7 +510,7 @@ if ($_GET['step'] == 2) {
             $_POST['gene'] = $_DB->query('SELECT name FROM ' . TABLE_GENES . ' WHERE id = ?', array($_POST['symbol']))->fetchColumn();
 
             for ($i = 0; $i < strlen($sSeq); $i ++) {
-                $s = $sSeq{$i};
+                $s = $sSeq[$i];
                 // We will need to loop through the sequence to provided detailed error messages.
                 // up and downstream are first considered introns (first and last elements of the
                 // intron array $aIntron)
@@ -1265,7 +1265,7 @@ if ($_GET['step'] == 3) {
             $_POST['gene'] = $_DB->query('SELECT name FROM ' . TABLE_GENES . ' WHERE id = ?', array($_POST['symbol']))->fetchColumn();
 
             for ($i = 0; $i < strlen($sSeq); $i ++) {
-                $s = $sSeq{$i};
+                $s = $sSeq[$i];
                 // We will need to loop through the sequence to provided detailed error messages
                 if (!$started) {
                     // We are still before the translation
@@ -1762,7 +1762,7 @@ if ($_GET['step'] == 3) {
                         $sPrntFinl .= $c_prnt;
 
                         // Create number at the right of the sequence.
-                        if ($l_prnt{0} != '*') {
+                        if ($l_prnt[0] != '*') {
                             // Maybe this is a weird check. Will there ever be no $c_prnt?
                             $l_prnt = ($c_prnt? $l_prnt+1 : $l_prnt);
                         } elseif ($c_prnt) {
@@ -1890,7 +1890,7 @@ if ($_GET['step'] == 3) {
                     if (isset($n_break)) {
                         $n_break = LENGTH_LINE - $n_break;
                         $i -= $n_break;
-                        if ($l_prnt{1} == '*') {
+                        if ($l_prnt[1] == '*') {
                             $l_prnt = (substr($l_prnt, 1) - $n_break);
                         } else {
                             $l_prnt = '*0';

--- a/src/submit.php
+++ b/src/submit.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-21
- * Modified    : 2020-09-17
- * For LOVD    : 3.0-25
+ * Modified    : 2021-11-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -54,12 +54,12 @@ function lovd_prepareSubmitData ($sDataType, $aData) {
         case 'variant':
             if (!empty($aData['aTranscripts'])) {
                 foreach ($aData['aTranscripts'] as $nTranscriptID) {
-                    $aData[$nTranscriptID . '_effect_reported'] = $_SETT['var_effect'][$aData[$nTranscriptID . '_effectid']{0}];
-                    $aData[$nTranscriptID . '_effect_concluded'] = $_SETT['var_effect'][$aData[$nTranscriptID . '_effectid']{1}];
+                    $aData[$nTranscriptID . '_effect_reported'] = $_SETT['var_effect'][$aData[$nTranscriptID . '_effectid'][0]];
+                    $aData[$nTranscriptID . '_effect_concluded'] = $_SETT['var_effect'][$aData[$nTranscriptID . '_effectid'][1]];
                 }
             }
-            $aData['effect_reported'] = $_SETT['var_effect'][$aData['effectid']{0}];
-            $aData['effect_concluded'] = $_SETT['var_effect'][$aData['effectid']{1}];
+            $aData['effect_reported'] = $_SETT['var_effect'][$aData['effectid'][0]];
+            $aData['effect_concluded'] = $_SETT['var_effect'][$aData['effectid'][1]];
             break;
     }
 

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2021-10-12
+ * Modified    : 2021-11-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1669,7 +1669,14 @@ if (PATH_COUNT == 2 && $_PE[1] == 'upload' && ACTION == 'create') {
                     } elseif (preg_match('/^I(\d+)$/', $aVariant['sampleGenotype'], $aMatches)) {
                         // Insertions, from BED.
                         $aFieldsVariantOnGenome[0]['allele'] = 0;
-                        if (!empty($aVariant['sampleAlleles']) && $aMatches[1] == 1 && ($nPos = array_search($aVariant['sampleAlleles']{1}, array($aVariant['referenceBase']{0}, $aVariant['referenceBase']{2}))) !== false) {
+                        if (!empty($aVariant['sampleAlleles']) && $aMatches[1] == 1
+                            && ($nPos = array_search(
+                                substr($aVariant['sampleAlleles'], 1, 1),
+                                array(
+                                    substr($aVariant['referenceBase'], 0, 1),
+                                    substr($aVariant['referenceBase'], 2, 0)
+                                )
+                            )) !== false) {
                             // It's a duplication.
                             $aFieldsVariantOnGenome[0]['type'] = 'dup';
                             $aFieldsVariantOnGenome[0]['position_g_start'] = $aFieldsVariantOnGenome[0]['position_g_end'] = $aVariant['position'] + $nPos;
@@ -2498,10 +2505,10 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
         // 2013-09-10; 3.0-08; Don't just throw away $_POST, because it contains info we need (such as for DB-ID prediction).
         $_POST = array_replace($_POST, $zData);
         // Now loop through $_POST to find the effectid fields, that need to be split.
-        foreach ($_POST as $key => $val) {
-            if (preg_match('/^(\d+_)?effect(id)$/', $key, $aRegs)) { // (id) instead of id to make sure we have a $aRegs (so to prevent notices).
-                $_POST[$aRegs[1] . 'effect_reported'] = $val{0};
-                $_POST[$aRegs[1] . 'effect_concluded'] = $val{1};
+        foreach ($_POST as $sKey => $sVal) {
+            if (preg_match('/^(\d+_)?effect(id)$/', $sKey, $aRegs)) { // (id) instead of id to make sure we have a $aRegs (so to prevent notices).
+                $_POST[$aRegs[1] . 'effect_reported'] = $sVal[0];
+                $_POST[$aRegs[1] . 'effect_concluded'] = $sVal[1];
             }
         }
         $_POST['statusid'] = STATUS_OK;
@@ -2536,7 +2543,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
                                 $_DATA['Genome']->buildFields());
 
             // Prepare values.
-            $_POST['effectid'] = $_POST['effect_reported'] . ($_AUTH['level'] >= $_SETT['user_level_settings']['set_concluded_effect']? $_POST['effect_concluded'] : $zData['effectid']{1});
+            $_POST['effectid'] = $_POST['effect_reported'] . ($_AUTH['level'] >= $_SETT['user_level_settings']['set_concluded_effect']? $_POST['effect_concluded'] : $zData['effectid'][1]);
             if ($_AUTH['level'] >= LEVEL_CURATOR) {
                 $aFieldsGenome[] = 'owned_by';
                 $aFieldsGenome[] = 'statusid';
@@ -2656,16 +2663,16 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
         foreach ($zData as $key => $val) {
             $_POST[$key] = $val;
         }
-        $_POST['effect_reported'] = $zData['effectid']{0};
-        $_POST['effect_concluded'] = $zData['effectid']{1};
+        $_POST['effect_reported'] = $zData['effectid'][0];
+        $_POST['effect_concluded'] = $zData['effectid'][1];
         if ($zData['statusid'] < STATUS_HIDDEN) {
             $_POST['statusid'] = STATUS_OK;
         }
         if ($bGene) {
             foreach ($aGenes as $sGene) {
                 foreach($_DATA['Transcript'][$sGene]->aTranscripts as $nTranscriptID => $aTranscript) {
-                    $_POST[$nTranscriptID . '_effect_reported'] = $zData[$nTranscriptID . '_effectid']{0};
-                    $_POST[$nTranscriptID . '_effect_concluded'] = $zData[$nTranscriptID . '_effectid']{1};
+                    $_POST[$nTranscriptID . '_effect_reported'] = $zData[$nTranscriptID . '_effectid'][0];
+                    $_POST[$nTranscriptID . '_effect_concluded'] = $zData[$nTranscriptID . '_effectid'][1];
                 }
             }
         }


### PR DESCRIPTION
LOVD is currently incompatible with PHP8 due to the removal of curly braces as a string access operator. The simple fix is to replace the curly braces with square brackets, but this may create confusion between strings and arrays (if it wasn't for our variable-naming). Using `$s[0]` rather than `substr($s, 0, 1)` is much faster, so whenever that wasn't losing readability, I used this. In the end, only in one place, I chose to use `substr()` to not create confusion between strings and arrays.

Replaced curly braces as string access operators in all files. Only skipped the `lovd_getVariantInfo()` function in `inc-lib-init.php`, as it's being rebuilt by @loeswerkman. Making changes there would just cause senseless merge conflicts.

Depends on #566.
Closes #571, but in reality only when `lovd_getVariantInfo()` has been rebuilt.