### PR TITLE
Fixed multiple issues.

### DIFF
--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-11-10
+ * Modified    : 2022-01-17
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -3277,8 +3277,8 @@ FROptions
             print('</TABLE>' . "\n");
             if ($aOptions['show_navigation']) {
                 print('        <INPUT type="hidden" name="total" value="' . $nTotal . '" disabled>' . "\n" .
-                      '        <INPUT type="hidden" name="page_size" value="' . $_GET['page_size'] . '">' . "\n" .
-                      '        <INPUT type="hidden" name="page" value="' . $_GET['page'] . '">' . "\n\n");
+                      '        <INPUT type="hidden" name="page_size" value="' . htmlspecialchars($_GET['page_size']) . '">' . "\n" .
+                      '        <INPUT type="hidden" name="page" value="' . htmlspecialchars($_GET['page']) . '">' . "\n\n");
 
                 lovd_pagesplitShowNav($sViewListID, $nTotal, $bTrueCount, $bSortableVL, $bLegend);
             }

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-27
- * Modified    : 2021-11-10
+ * Modified    : 2022-01-12
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -363,7 +363,7 @@ class LOVD_Template
 
         }
         print('  Powered by <A href="' . $_SETT['upstream_URL'] . $_STAT['tree'] . '/" target="_blank">LOVD v.' . $_STAT['tree'] . '</A> Build ' . $_STAT['build'] . '<BR>' . "\n" .
-              '  LOVD' . (LOVD_plus? '+' : '') . ' software &copy;2004-2021 <A href="http://www.lumc.nl/" target="_blank">Leiden University Medical Center</A>' . "\n");
+              '  LOVD' . (LOVD_plus? '+' : '') . ' software &copy;2004-2022 <A href="http://www.lumc.nl/" target="_blank">Leiden University Medical Center</A>' . "\n");
 ?>
     </TD>
     <TD width="42" align="right">

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -770,7 +770,9 @@ foreach ($zAnnouncements as $zAnnouncement) {
                     }
                     list($sIMG, $sName, $nRequiredLevel) = $aItem;
                     $bDisabled = false;
-                    if ($nRequiredLevel && (($nRequiredLevel == LEVEL_CURATOR && !$bCurator) || ($nRequiredLevel != LEVEL_CURATOR && $nRequiredLevel > $_AUTH['level']))) {
+                    if ($nRequiredLevel && $_AUTH
+                        && (($nRequiredLevel == LEVEL_CURATOR && !$bCurator)
+                            || ($nRequiredLevel != LEVEL_CURATOR && $nRequiredLevel > $_AUTH['level']))) {
                         $bDisabled = true;
                     } else {
                         if (!$sURL) {
@@ -794,10 +796,6 @@ foreach ($zAnnouncements as $zAnnouncement) {
                                 '</A></LI>' . "\n";
                         $bHR = false;
                     }
-// class disabled, disabled. Nu gewoon maar even weggehaald.
-//                    $sUL .= '  <LI class="disabled">' .
-//                        (!$sIMG? '' : '<SPAN class="icon" style="background-image: url(gfx/' . preg_replace('/(\.[a-z]+)$/', '_disabled' . "$1", $sIMG) . ');"></SPAN>') . $sName .
-//                        '</LI>' . "\n";
                 }
                 $sUL .= '</UL>' . "\n";
 

--- a/src/columns.php
+++ b/src/columns.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-03-04
- * Modified    : 2021-11-10
+ * Modified    : 2022-01-17
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -564,7 +564,7 @@ if (PATH_COUNT == 1 && ACTION == 'data_type_wizard') {
     lovd_includeJS('inc-js-tooltip.php');
 
     print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '&amp;workID=' . $_GET['workID'] . '" method="post">' . "\n" .
-          '        <INPUT type="hidden" name="form_type" value="' . $_POST['form_type'] . '">' . "\n");
+          '        <INPUT type="hidden" name="form_type" value="' . htmlspecialchars($_POST['form_type']) . '">' . "\n");
 
     // Array which will make up the form table.
     $aForm = array(
@@ -797,13 +797,13 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
     lovd_includeJS('inc-js-columns.php');
 
     print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '" method="post">' . "\n" .
-          '        <INPUT type="hidden" name="category" value="' . $_POST['category'] . '">' . "\n" .
-          '        <INPUT type="hidden" name="description_form" value="' . $_POST['description_form'] . '">' . "\n" .
-          '        <INPUT type="hidden" name="select_options" value="' . $_POST['select_options'] . '">' . "\n" .
-          '        <INPUT type="hidden" name="preg_pattern" value="' . $_POST['preg_pattern'] . '">' . "\n" .
+          '        <INPUT type="hidden" name="category" value="' . htmlspecialchars($_POST['category']) . '">' . "\n" .
+          '        <INPUT type="hidden" name="description_form" value="' . htmlspecialchars($_POST['description_form']) . '">' . "\n" .
+          '        <INPUT type="hidden" name="select_options" value="' . htmlspecialchars($_POST['select_options']) . '">' . "\n" .
+          '        <INPUT type="hidden" name="preg_pattern" value="' . htmlspecialchars($_POST['preg_pattern']) . '">' . "\n" .
 // FIXME; remove this when implemented properly.
-          '        <INPUT type="hidden" name="allow_count_all" value="' . $_POST['allow_count_all'] . '">' . "\n" .
-          '        <INPUT type="hidden" name="workID" value="' . $_POST['workID'] . '">' . "\n");
+          '        <INPUT type="hidden" name="allow_count_all" value="' . htmlspecialchars($_POST['allow_count_all']) . '">' . "\n" .
+          '        <INPUT type="hidden" name="workID" value="' . htmlspecialchars($_POST['workID']) . '">' . "\n");
 
     // Array which will make up the form table.
     $aForm = array_merge(
@@ -1156,13 +1156,13 @@ if (PATH_COUNT > 2 && ACTION == 'edit') {
     lovd_includeJS('inc-js-columns.php');
 
     print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '" method="post" onsubmit="return lovd_checkSubmittedForm();">' . "\n" .
-          '        <INPUT type="hidden" name="category" value="' . $_POST['category'] . '">' . "\n" .
-          '        <INPUT type="hidden" name="description_form" value="' . $_POST['description_form'] . '">' . "\n" .
-          '        <INPUT type="hidden" name="select_options" value="' . $_POST['select_options'] . '">' . "\n" .
-          '        <INPUT type="hidden" name="preg_pattern" value="' . $_POST['preg_pattern'] . '">' . "\n" .
+          '        <INPUT type="hidden" name="category" value="' . htmlspecialchars($_POST['category']) . '">' . "\n" .
+          '        <INPUT type="hidden" name="description_form" value="' . htmlspecialchars($_POST['description_form']) . '">' . "\n" .
+          '        <INPUT type="hidden" name="select_options" value="' . htmlspecialchars($_POST['select_options']) . '">' . "\n" .
+          '        <INPUT type="hidden" name="preg_pattern" value="' . htmlspecialchars($_POST['preg_pattern']) . '">' . "\n" .
 // FIXME; remove this when implemented properly.
-          '        <INPUT type="hidden" name="allow_count_all" value="' . $_POST['allow_count_all'] . '">' . "\n" .
-          '        <INPUT type="hidden" name="workID" value="' . $_POST['workID'] . '">' . "\n");
+          '        <INPUT type="hidden" name="allow_count_all" value="' . htmlspecialchars($_POST['allow_count_all']) . '">' . "\n" .
+          '        <INPUT type="hidden" name="workID" value="' . htmlspecialchars($_POST['workID']) . '">' . "\n");
 
     // Array which will make up the form table.
     $aForm = array_merge(
@@ -1541,7 +1541,7 @@ if (!isset($_GET['in_window'])) {
         // If the target is received through $_GET do not show the selection list unless there is a problem with the target.
         if (!empty($_POST['target']) && !is_array($_POST['target']) && !in_array('target', $_ERROR['fields'])) {
             $aForm[] = array('', '', 'print', '<B>Enabling the ' . $zData['id'] . ' column for the ' . $aTableInfo['unit'] . ' ' . $_POST['target'] . '</B><BR><BR>' . "\n");
-            print('      <INPUT type="hidden" name="target" value="' . $_POST['target'] . '">' . "\n");
+            print('      <INPUT type="hidden" name="target" value="' . htmlspecialchars($_POST['target']) . '">' . "\n");
         } else {
             print('      Please select the ' . $aTableInfo['unit'] . '(s) for which you want to add the ' . $zData['colid'] . ' column.<BR><BR>' . "\n");
             $nPossibleTargets = ($nPossibleTargets > 15? 15 : $nPossibleTargets);
@@ -1818,7 +1818,7 @@ if (PATH_COUNT > 2 && ACTION == 'remove') {
             // General query for phenotype data and VOT columns, but for VOT we need to put a join to table_transcripts...
             $nEntriesWithData = $_DB->query('SELECT COUNT(*) FROM ' . $aTableInfo['table_sql'] . ($sCategory != 'VariantOnTranscript'? '' : ' AS vot INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id)') . ' WHERE ' . $aTableInfo['unit'] . 'id = ? AND `' . $zData['id'] . '` IS NOT NULL AND `' . $zData['id'] . '` != "" AND `' . $zData['id'] . '` != "-"', array($_POST['target']))->fetchColumn();
             $aForm[] = array('', '', 'print', '<B>Removing the ' . $zData['id'] . ' column from ' . $aTableInfo['unit'] . ' ' . $_POST['target'] . '<BR>(' . $sTarget . ')</B><BR><BR>');
-            print('      <INPUT type="hidden" name="target" value="' . $_POST['target'] . '">' . "\n");
+            print('      <INPUT type="hidden" name="target" value="' . htmlspecialchars($_POST['target']) . '">' . "\n");
         } else {
             $nEntriesWithData = -1; // We need to determine this on the fly.
             print('      Please select the ' . $aTableInfo['unit'] . '(s) for which you want to remove the ' . $zData['colid'] . ' column.<BR><BR>' . "\n");

--- a/src/genes.php
+++ b/src/genes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2021-09-22
+ * Modified    : 2022-01-17
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -337,7 +337,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                 require ROOT_PATH . 'class/progress_bar.php';
 
                 $sFormNextPage = '<FORM action="' . $sPath . '" id="createGene" method="post">' . "\n" .
-                                 '          <INPUT type="hidden" name="workID" value="' . $_POST['workID'] . '">' . "\n" .
+                                 '          <INPUT type="hidden" name="workID" value="' . htmlspecialchars($_POST['workID']) . '">' . "\n" .
                                  '          <INPUT type="submit" value="Continue &raquo;">' . "\n" .
                                  '        </FORM>';
 
@@ -516,7 +516,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                             array('', '', 'submit', 'Continue &raquo;'),
                           );
         lovd_viewForm($aFormData);
-        print('<INPUT type="hidden" name="workID" value="' . $_POST['workID'] . '">' . "\n");
+        print('<INPUT type="hidden" name="workID" value="' . htmlspecialchars($_POST['workID']) . '">' . "\n");
         print('</TABLE></FORM>' . "\n\n");
         print('<SCRIPT type="text/javascript">' . "\n" .
               '  <!--' . "\n" .
@@ -715,7 +715,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                           ));
         lovd_viewForm($aForm);
 
-        print('<INPUT type="hidden" name="workID" value="' . $_POST['workID'] . '">' . "\n");
+        print('<INPUT type="hidden" name="workID" value="' . htmlspecialchars($_POST['workID']) . '">' . "\n");
         print('</FORM>' . "\n\n");
 
         $_T->printFooter();
@@ -916,7 +916,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', $_PE[1]) && ACTION =
                       ));
     lovd_viewForm($aForm);
 
-    print('<INPUT type="hidden" name="workID" value="' . $_POST['workID'] . '">' . "\n");
+    print('<INPUT type="hidden" name="workID" value="' . htmlspecialchars($_POST['workID']) . '">' . "\n");
     print('</FORM>' . "\n\n");
 
     $_T->printFooter();

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2021-08-16
- * For LOVD    : 3.0-27
+ * Modified    : 2022-01-14
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -803,7 +803,7 @@ if (defined('MISSING_CONF') || defined('MISSING_STAT') || !preg_match('/^([1-9]\
 
 
 // Force GPC magic quoting OFF.
-if (get_magic_quotes_gpc()) {
+if (function_exists('get_magic_quotes_gpc') && @get_magic_quotes_gpc()) {
     lovd_magicUnquoteAll();
 }
 

--- a/src/inc-js-submit-settings.php
+++ b/src/inc-js-submit-settings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-23
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2022-01-14
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -31,19 +31,7 @@
 
 define('ROOT_PATH', './');
 require ROOT_PATH . 'inc-init.php';
-
-// Stupid solution, but because of the (sane) JS restrictions to access files on other domains, I have to do it this way.
-if (isset($_GET['check_url'])) {
-    // Verify signature also.
-    if (empty($_GET['check_url'])) {
-        readfile($_SETT['check_location_URL'] . '?url=' . rawurlencode(lovd_getInstallURL()) . '&signature=' . rawurlencode($_STAT['signature']));
-    } else {
-        readfile($_SETT['check_location_URL'] . '?url=' . rawurlencode(rtrim($_GET['check_url'], '/') . '/') . '&signature=' . rawurlencode($_STAT['signature']));
-    }
-    exit;
-}
-
-require ROOT_PATH . 'inc-js-ajax.php';
+header('Content-type: text/javascript; charset=UTF-8');
 
 // If not installed...
 if (!isset($_CONF['location_url'])) {
@@ -76,44 +64,5 @@ function lovd_checkForm () {
         }
     } else {
         return true;
-    }
-}
-
-
-
-function lovd_checkURL () {
-    var objField = document.getElementById('location_url');
-    var objCheck = document.getElementById('location_url_check');
-
-    // Reset (check) link.
-    // 2009-06-26; 2.0-19; Fixed URL such that it works from all locations.
-    objCheck.innerHTML = '<IMG src="<?php echo lovd_getInstallURL(); ?>gfx/lovd_loading.gif" align="top">';
-
-    // Create HTTP request object to contact the LOVD website to verify the database URL.
-    var objHTTP = lovd_createHTTPRequest();
-    if (objHTTP) {
-        // 2009-06-26; 2.0-19; Fixed URL such that it works from all locations.
-        objHTTP.open("GET", "<?php echo lovd_getInstallURL(); ?>inc-js-submit-settings.php?check_url=" + escape(objField.value), false);
-        objHTTP.send(null);
-        if (objHTTP.status == 200 && objHTTP.responseText.substring(0,4) == "http") {
-            objField.value = objHTTP.responseText;
-            // 2009-06-26; 2.0-19; Fixed URL such that it works from all locations.
-            objCheck.innerHTML = '<IMG src="<?php echo lovd_getInstallURL(); ?>gfx/check.png">';
-        } else {
-            // Throw error.
-            if (!objField.value) {
-                // Well no, we were just trying the automated values. So, it doesn't work. Big deal.
-                window.alert("Please fill in a value in this field.");
-            } else {
-                window.alert("Error!\n" + objHTTP.responseText);
-            }
-            objCheck.innerHTML = '(<A href="#" onclick="javascript:lovd_checkURL(); return false;">check</A>)';
-        }
-
-    } else {
-        // Change "loading" image with a clean "Failed" image.
-        window.alert("Sorry, your browser does not support automated verification of the URL.");
-        // 2009-06-26; 2.0-19; Fixed URL such that it works from all locations.
-        objCheck.innerHTML = '<IMG src="<?php echo lovd_getInstallURL(); ?>gfx/cross.png">';
     }
 }

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-23
- * Modified    : 2021-09-22
+ * Modified    : 2022-01-17
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -344,7 +344,7 @@ if (PATH_COUNT == 1 && ACTION == 'create' && !empty($_GET['target']) && ctype_di
     lovd_viewForm($aForm);
 
     print("\n" .
-          '        <INPUT type="hidden" name="diseaseid" value="' . $_POST['diseaseid'] . '">' . "\n" .
+          '        <INPUT type="hidden" name="diseaseid" value="' . htmlspecialchars($_POST['diseaseid']) . '">' . "\n" .
           '      </FORM>' . "\n\n");
 
     $_T->printFooter();

--- a/src/scripts/refseq_parser.php
+++ b/src/scripts/refseq_parser.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-29
- * Modified    : 2021-11-10
+ * Modified    : 2022-01-17
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Gerard C.P. Schaafsma <G.C.P.Schaafsma@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -377,15 +377,15 @@ if ($_GET['step'] == 1) {
 
             // To continue to step 2, we need to create a form and send all data.
             print('<FORM action="' . $_SERVER['SCRIPT_NAME'] . '?step=2" method="post">' . "\n" .
-                '  <INPUT type="hidden" name="symbol" value="' . $_POST['symbol'] . '">' . "\n" .
-                '  <INPUT type="hidden" name="sequence" value="' . $_POST['sequence'] . '">' . "\n" .
-                '  <INPUT type="hidden" name="exists" value="' . $_POST['exists'] . '">' . "\n" .
-                '  <INPUT type="hidden" name="version_id" value="' . $_POST['version_id'] . '">' . "\n" . // 2009-12-03; 2.0-23; Add GenBank ID.
-                '  <INPUT type="hidden" name="transcript_id" value="' . $_POST['transcript_id'] . '">' . "\n" . // 2009-03-09; 2.0-17 by Gerard: to fill in the textboxes if you come from step 1
-                '  <INPUT type="hidden" name="protein_id" value="' . $_POST['protein_id'] . '">' . "\n" . // 2009-03-09; 2.0-17 by Gerard: to fill in the textboxes if you come from step 1
-                '  <INPUT type="hidden" name="step1" value="true">' . "\n" . // 2009-06-22; 2.0-19; by Gerard: need to know if you came from step 1
-                '  <INPUT type="submit" value="Continue to next step &raquo;">' . "\n" .
-                '</FORM><BR>' . "\n\n");
+                  '  <INPUT type="hidden" name="symbol" value="' . htmlspecialchars($_POST['symbol']) . '">' . "\n" .
+                  '  <INPUT type="hidden" name="sequence" value="' . htmlspecialchars($_POST['sequence']) . '">' . "\n" .
+                  '  <INPUT type="hidden" name="exists" value="' . htmlspecialchars($_POST['exists']) . '">' . "\n" .
+                  '  <INPUT type="hidden" name="version_id" value="' . htmlspecialchars($_POST['version_id']) . '">' . "\n" . // 2009-12-03; 2.0-23; Add GenBank ID.
+                  '  <INPUT type="hidden" name="transcript_id" value="' . htmlspecialchars($_POST['transcript_id']) . '">' . "\n" . // 2009-03-09; 2.0-17 by Gerard: to fill in the textboxes if you come from step 1
+                  '  <INPUT type="hidden" name="protein_id" value="' . htmlspecialchars($_POST['protein_id']) . '">' . "\n" . // 2009-03-09; 2.0-17 by Gerard: to fill in the textboxes if you come from step 1
+                  '  <INPUT type="hidden" name="step1" value="true">' . "\n" . // 2009-06-22; 2.0-19; by Gerard: need to know if you came from step 1
+                  '  <INPUT type="submit" value="Continue to next step &raquo;">' . "\n" .
+                  '</FORM><BR>' . "\n\n");
 
             $_T->printFooter();
             exit;
@@ -1118,12 +1118,12 @@ if ($_GET['step'] == 2) {
 
                 // To continue to step 3, we need to create a form and send all data.
                 print('<FORM action="' . $_SERVER['SCRIPT_NAME'] . '?step=3" method="post">' . "\n" .
-                    '  <INPUT type="hidden" name="symbol" value="' . $_POST['symbol'] . '">' . "\n" .
-                    '  <INPUT type="hidden" name="sequence" value="' . $_POST['sequence'] . '">' . "\n" .
-                    '  <INPUT type="hidden" name="version_id" value="' . $_POST['version_id'] . '">' . "\n" . // 2009-12-03; 2.0-23; accession number with version added
-                    '  <INPUT type="hidden" name="transcript_id" value="' . $_POST['transcript_id'] . '">' . "\n" .
-                    '  <INPUT type="hidden" name="exists" value="' . $_POST['exists'] . '">' . "\n" .
-                    '  <INPUT type="hidden" name="step2" value="true">' . "\n"); // 2009-03-09; 2.0-17; by Gerard: need to know if you created the up- and downstream sequences in step 2
+                      '  <INPUT type="hidden" name="symbol" value="' . htmlspecialchars($_POST['symbol']) . '">' . "\n" .
+                      '  <INPUT type="hidden" name="sequence" value="' . htmlspecialchars($_POST['sequence']) . '">' . "\n" .
+                      '  <INPUT type="hidden" name="version_id" value="' . htmlspecialchars($_POST['version_id']) . '">' . "\n" . // 2009-12-03; 2.0-23; accession number with version added
+                      '  <INPUT type="hidden" name="transcript_id" value="' . htmlspecialchars($_POST['transcript_id']) . '">' . "\n" .
+                      '  <INPUT type="hidden" name="exists" value="' . htmlspecialchars($_POST['exists']) . '">' . "\n" .
+                      '  <INPUT type="hidden" name="step2" value="true">' . "\n"); // 2009-03-09; 2.0-17; by Gerard: need to know if you created the up- and downstream sequences in step 2
 
                 // 2009-02-27; 2.0-16; you need these lengths for the g. numbering
                 if (!empty($aLengthsSequenceParts)) {
@@ -1155,9 +1155,9 @@ if ($_GET['step'] == 2) {
 
     // Need to pass symbol.
     if ($bStep1) {
-        print('        <INPUT type="hidden" name="symbol" value="' . $_POST['symbol'] . '">'. "\n" .
-              '        <INPUT type="hidden" name="transcript_id" value="' . $_POST['transcript_id'] . '">' . "\n" .
-              '        <INPUT type="hidden" name="version_id" value="' . $_POST['version_id'] . '">'. "\n");
+        print('        <INPUT type="hidden" name="symbol" value="' . htmlspecialchars($_POST['symbol']) . '">'. "\n" .
+              '        <INPUT type="hidden" name="transcript_id" value="' . htmlspecialchars($_POST['transcript_id']) . '">' . "\n" .
+              '        <INPUT type="hidden" name="version_id" value="' . htmlspecialchars($_POST['version_id']) . '">'. "\n");
     }
 
 
@@ -2059,10 +2059,10 @@ if ($_GET['step'] == 3) {
     // 2009-06-22; 2.0-19; added symbol which you need if you come from step 2
     // 2009-12-03; 2.0-23; added the accession number, including version
     if ($bStep2) {
-        print('  <INPUT type="hidden" name="step2" value="' . $_POST['step2'] . '">' . "\n" .
-            '  <INPUT type="hidden" name="symbol" value="' . $_POST['symbol'] . '">' . "\n" .
-            '  <INPUT type="hidden" name="version_id" value="' . $_POST['version_id'] . '">' . "\n" .
-            '  <INPUT type="hidden" name="transcript_id" value="' . $_POST['transcript_id']. '">' . "\n");
+        print('  <INPUT type="hidden" name="step2" value="' . htmlspecialchars($_POST['step2']) . '">' . "\n" .
+              '  <INPUT type="hidden" name="symbol" value="' . htmlspecialchars($_POST['symbol']) . '">' . "\n" .
+              '  <INPUT type="hidden" name="version_id" value="' . htmlspecialchars($_POST['version_id']) . '">' . "\n" .
+              '  <INPUT type="hidden" name="transcript_id" value="' . htmlspecialchars($_POST['transcript_id']) . '">' . "\n");
     }
 
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,10 +3,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-20
- * Modified    : 2017-11-08
- * For LOVD    : 3.0-21
+ * Modified    : 2022-01-11
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -276,6 +276,6 @@ table.option tr.disabled td            {background : #EAEAEA; color : #525252;}
 table.option tr.disabled:hover span    {visibility : hidden;}
 
 /* For option grouping*/
-optgroup        {font-weight : bold; color : #FFFFFF; background : #224488; text-align : center;}
-option          {font-weight : normal; color : #000000; background : #FFFFFF; text-align : left;}
+optgroup        {font-weight : bold;}
+optgroup option {font-weight : normal;}
 

--- a/src/transcripts.php
+++ b/src/transcripts.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2021-04-15
- * For LOVD    : 3.0-27
+ * Modified    : 2022-01-17
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -250,7 +250,7 @@ if (ACTION == 'create') {
         $_POST['workID'] = $nTime['sec'] . $nTime['usec'];
 
         $sFormNextPage = '<FORM action="' . $sPath . '" id="createTranscript" method="post">' . "\n" .
-                         '          <INPUT type="hidden" name="workID" value="' . $_POST['workID'] . '">' . "\n" .
+                         '          <INPUT type="hidden" name="workID" value="' . htmlspecialchars($_POST['workID']) . '">' . "\n" .
                          '          <INPUT type="submit" value="Continue &raquo;">' . "\n" .
                          '        </FORM>';
 
@@ -470,7 +470,7 @@ if (ACTION == 'create') {
                       ));
     lovd_viewForm($aForm);
 
-    print('<INPUT type="hidden" name="workID" value="' . $_POST['workID'] . '">' . "\n");
+    print('<INPUT type="hidden" name="workID" value="' . htmlspecialchars($_POST['workID']) . '">' . "\n");
     print('</FORM>' . "\n\n");
 
     $_T->printFooter();

--- a/src/users.php
+++ b/src/users.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2021-09-24
+ * Modified    : 2022-01-27
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -634,7 +634,7 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
     }
 
     print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '" method="post" onsubmit="return lovd_checkForm();">' . "\n" .
-          '        <INPUT type="hidden" name="orcid_id" value="' . $_POST['orcid_id'] . '">' . "\n");
+          '        <INPUT type="hidden" name="orcid_id" value="' . htmlspecialchars($_POST['orcid_id']) . '">' . "\n");
 
     // Array which will make up the form table.
     if (ACTION == 'create') {


### PR DESCRIPTION
Fixed multiple issues:
- Remove some styling for optgroups, so users can see pre-selected items.
  - Closes #570.
- Updated the copyright statement to 2022.
- Fix notice when not logged in, and remove unused code.
- Handle missing or deprecated `get_magic_quotes_gpc()`.
- Complete rebuild of the URL validation on the system settings form.
  - We were notified of a blind SSRF in this feature (#577). We carefully reviewed the current functionality, and decided that some details about the review of the given URL could be left out. We'll otherwise NOT remove this feature, as it's important to validate an LOVD's URL. However, some improvements have been made.
  - A sleep of half a second has been introduced in the upstream code. This makes abuse of the feature a bit harder.
  - Any details of whether or not the remote URL is accessible or not, has been removed.
  - Validation of the LOVD instance has improved (also upstream), and the correct base URL of the instance is returned.
  - Validation of the LOVD instance is now no longer a JS feature, but incorporated into the `checkForm()` which makes abusing the feature much harder as you *must* be logged in.
  - As no sensitive information is shared, nor with the given URL, nor with the user who initiated the URL check, the request causes no harm and we can close the issue.
  - Closes #577.
- Rigorously applying `htmlspecialchars()` to all hidden input fields.
  - An XSS bug has been identified by `bugbuster09` (gmail) in such a field that, although difficult to exploit, might also apply elsewhere. Rigorously applying `htmlspecialchars()` everywhere to make sure we catch everything.


