### PR TITLE
Fixed various notices throughout LOVD

### DIFF
--- a/src/ajax/check_seattleseq_columns.php
+++ b/src/ajax/check_seattleseq_columns.php
@@ -4,11 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-01
- * Modified    : 2012-03-01
- * For LOVD    : 3.0-beta-03
+ * Modified    : 2022-02-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2012 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -33,7 +34,7 @@ if (!defined('ROOT_PATH')) {
 }
 require_once ROOT_PATH . 'inc-init.php';
 
-if ($_AUTH['level'] < LEVEL_MANAGER) {
+if (!$_AUTH || $_AUTH['level'] < LEVEL_MANAGER) {
     exit(AJAX_NO_AUTH);
 }
 

--- a/src/ajax/edit_column.php
+++ b/src/ajax/edit_column.php
@@ -4,11 +4,12 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-01
- * Modified    : 2012-04-02
- * For LOVD    : 3.0-beta-04
+ * Modified    : 2022-02-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2012 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmers : Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
+ *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -31,7 +32,7 @@
 define('ROOT_PATH', '../');
 require_once ROOT_PATH . 'inc-init.php';
 
-if ($_AUTH['level'] < LEVEL_MANAGER) {
+if (!$_AUTH || $_AUTH['level'] < LEVEL_MANAGER) {
     exit(AJAX_NO_AUTH);
 } elseif (ACTION == 'set_standard' && !empty($_POST['colid']) && $_DB->query('UPDATE ' . TABLE_COLS . ' SET standard = 1, edited_by = ?, edited_date = NOW() WHERE id = ?', array($_AUTH['id'], $_POST['colid']))->rowCount()) {
     exit(AJAX_TRUE);

--- a/src/ajax/viewentry.php
+++ b/src/ajax/viewentry.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-11-09
- * Modified    : 2021-07-12
- * For LOVD    : 3.0-27
+ * Modified    : 2022-02-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -66,7 +66,7 @@ if ($sObject == 'Transcript_Variant') {
 } elseif ($sObject == 'User') {
     lovd_isAuthorized(strtolower($sObject), $nID);
     // Users viewing their own profile should see a lot more...
-    if ($_AUTH['id'] == $nID && $_AUTH['level'] < LEVEL_CURATOR) {
+    if ($_AUTH && $_AUTH['id'] == $nID && $_AUTH['level'] < LEVEL_CURATOR) {
         $_AUTH['level'] = LEVEL_CURATOR;
     }
 }

--- a/src/class/object_custom.php
+++ b/src/class/object_custom.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-17
- * Modified    : 2021-11-10
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -157,16 +157,20 @@ class LOVD_Custom extends LOVD_Object
         parent::__construct();
 
         // Hide entries that are not marked or public.
-        if ($_AUTH['level'] < $_SETT['user_level_settings']['see_nonpublic_data']) { // This check assumes lovd_isAuthorized() has already been called for gene-specific overviews.
+        if (!$_AUTH || $_AUTH['level'] < $_SETT['user_level_settings']['see_nonpublic_data']) { // This check assumes lovd_isAuthorized() has already been called for gene-specific overviews.
             if (in_array($this->sCategory, array('VariantOnGenome', 'VariantOnTranscript'))) {
                 $sAlias = 'vog';
             } else {
                 $sAlias = strtolower($this->sCategory[0]);
             }
 
-            // Construct list of user IDs for current user and users who share access with them.
-            $aOwnerIDs = array_merge(array($_AUTH['id']), lovd_getColleagues(COLLEAGUE_ALL));
-            $sOwnerIDsSQL = join(', ', $aOwnerIDs);
+            if ($_AUTH) {
+                // Construct list of user IDs for current user and users who share access with them.
+                $aOwnerIDs = array_merge(array($_AUTH['id']), lovd_getColleagues(COLLEAGUE_ALL));
+                $sOwnerIDsSQL = join(', ', $aOwnerIDs);
+            } else {
+                $sOwnerIDsSQL = '';
+            }
 
             $this->aSQLViewList['WHERE'] .= (!empty($this->aSQLViewList['WHERE'])? ' AND ' : '') . '(' . ($this->sObject == 'Screening'? 'i' : $sAlias) . '.statusid >= ' . STATUS_MARKED . (!$_AUTH? '' : ' OR (' . $sAlias . '.created_by = "' . $_AUTH['id'] . '" OR ' . $sAlias . '.owned_by IN (' . $sOwnerIDsSQL . '))') . '';
             $this->aSQLViewEntry['WHERE'] .= (!empty($this->aSQLViewEntry['WHERE'])? ' AND ' : '') . '(' . ($this->sObject == 'Screening'? 'i' : $sAlias) . '.statusid >= ' . STATUS_MARKED . (!$_AUTH? '' : ' OR (' . $sAlias . '.created_by = "' . $_AUTH['id'] . '" OR ' . $sAlias . '.owned_by IN (' . $sOwnerIDsSQL . '))') . ')';
@@ -327,7 +331,7 @@ class LOVD_Custom extends LOVD_Object
 
         $aViewEntry = array();
         foreach ($this->aColumns as $sID => $aCol) {
-            if (!$aCol['public_view'] && $_AUTH['level'] < $_SETT['user_level_settings']['see_nonpublic_data']) {
+            if (!$aCol['public_view'] && (!$_AUTH || $_AUTH['level'] < $_SETT['user_level_settings']['see_nonpublic_data'])) {
                 continue;
             }
             $aViewEntry[$sID] = $aCol['head_column'];
@@ -349,7 +353,7 @@ class LOVD_Custom extends LOVD_Object
         foreach ($this->aColumns as $sID => $aCol) {
             // In LOVD_plus, the public_view field is used to set if a custom column will be displayed in a VL or not.
             // So, in LOVD_plus we need to check for ALL USERS if a custom column has public_view flag turned on or not.
-            if (!$aCol['public_view'] && (LOVD_plus? true : $_AUTH['level'] < $_SETT['user_level_settings']['see_nonpublic_data'])) {
+            if (!$aCol['public_view'] && (LOVD_plus? true : (!$_AUTH || $_AUTH['level'] < $_SETT['user_level_settings']['see_nonpublic_data']))) {
                 continue;
             }
             $bAlignRight = preg_match('/^(DEC|FLOAT|(TINY|SMALL|MEDIUM|BIG)?INT)/', $aCol['mysql_type']);
@@ -573,7 +577,7 @@ class LOVD_Custom extends LOVD_Object
 
         $zData = parent::prepareData($zData, $sView);
         foreach ($this->aColumns as $sCol => $aCol) {
-            if (!$aCol['public_view'] && $_AUTH['level'] < LEVEL_OWNER) {
+            if (!$aCol['public_view'] && (!$_AUTH || $_AUTH['level'] < LEVEL_OWNER)) {
                 continue;
             }
             if (!empty($aCol['custom_links'])) {

--- a/src/class/object_diseases.php
+++ b/src/class/object_diseases.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-07-28
- * Modified    : 2021-09-27
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -160,8 +160,8 @@ class LOVD_Disease extends LOVD_Object
 
         // SQL code for viewing an entry.
         $this->aSQLViewEntry['SELECT']   = 'd.*, ' .
-                                           '(SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' AS i INNER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid) WHERE i2d.diseaseid = d.id' . ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' : ' AND i.statusid >= ' . STATUS_MARKED) . ') AS individuals, ' .
-                                           '(SELECT COUNT(*) FROM ' . TABLE_PHENOTYPES . ' AS p WHERE p.diseaseid = d.id' . ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' : ' AND p.statusid >= ' . STATUS_MARKED) . ') AS phenotypes, ' .
+                                           '(SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' AS i INNER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid) WHERE i2d.diseaseid = d.id' . ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' : ' AND i.statusid >= ' . STATUS_MARKED) . ') AS individuals, ' .
+                                           '(SELECT COUNT(*) FROM ' . TABLE_PHENOTYPES . ' AS p WHERE p.diseaseid = d.id' . ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' : ' AND p.statusid >= ' . STATUS_MARKED) . ') AS phenotypes, ' .
                                            'GROUP_CONCAT(DISTINCT g2d.geneid ORDER BY g2d.geneid SEPARATOR ";") AS _genes, ' .
                                            'uc.name AS created_by_, ' .
                                            'ue.name AS edited_by_';
@@ -173,8 +173,8 @@ class LOVD_Disease extends LOVD_Object
 
         // SQL code for viewing a list of entries.
         $this->aSQLViewList['SELECT']   = 'd.*, d.id AS diseaseid, ' .
-                                          '(SELECT COUNT(DISTINCT i.id) FROM ' . TABLE_IND2DIS . ' AS i2d LEFT OUTER JOIN ' . TABLE_INDIVIDUALS . ' AS i ON (i2d.individualid = i.id' . ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' : ' AND i.statusid >= ' . STATUS_MARKED) . ') WHERE i2d.diseaseid = d.id) AS individuals, ' .
-                                          '(SELECT COUNT(*) FROM ' . TABLE_PHENOTYPES . ' AS p WHERE p.diseaseid = d.id' . ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' : ' AND p.statusid >= ' . STATUS_MARKED) . ') AS phenotypes, ' .
+                                          '(SELECT COUNT(DISTINCT i.id) FROM ' . TABLE_IND2DIS . ' AS i2d LEFT OUTER JOIN ' . TABLE_INDIVIDUALS . ' AS i ON (i2d.individualid = i.id' . ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' : ' AND i.statusid >= ' . STATUS_MARKED) . ') WHERE i2d.diseaseid = d.id) AS individuals, ' .
+                                          '(SELECT COUNT(*) FROM ' . TABLE_PHENOTYPES . ' AS p WHERE p.diseaseid = d.id' . ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' : ' AND p.statusid >= ' . STATUS_MARKED) . ') AS phenotypes, ' .
                                           'COUNT(g2d.geneid) AS gene_count, ' .
                                           'GROUP_CONCAT(DISTINCT g2d.geneid ORDER BY g2d.geneid SEPARATOR ";") AS _genes';
         $this->aSQLViewList['FROM']     = TABLE_DISEASES . ' AS d ' .

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2021-11-10
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -98,7 +98,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
             // Added so that Curators and Collaborators can view the variants for which they have
             // viewing rights in the genomic variant VL.
             // The WHERE condition is set in object_custom.php.
-            ($_AUTH['level'] == LEVEL_SUBMITTER && (count($_AUTH['curates']) || count($_AUTH['collaborates']))?
+            ($_AUTH && $_AUTH['level'] == LEVEL_SUBMITTER && (count($_AUTH['curates']) || count($_AUTH['collaborates']))?
                 'LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vog.id = vot.id) ' .
                 'LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) '
             : '') .
@@ -486,7 +486,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
             // While in principle a variant should only be connected to one patient, due to database model limitations, through several screenings, one could link a variant to more individuals.
             foreach ($zData['individuals'] as $aIndividual) {
                 list($nID, $nStatusID) = $aIndividual;
-                if ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']) {
+                if ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']) {
                     $zData['individualid_'] .= ($zData['individualid_']? ', ' : '') .
                         '<A href="individuals/' . $nID . '">' . $nID . '</A> ' .
                         '<SPAN style="color: #' . $this->getStatusColor($nStatusID) . '">(' . $_SETT['data_status'][$nStatusID] . ')</SPAN>';
@@ -504,7 +504,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
                 // Allow linking to view of all these variants.
                 $sQ = 'SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' WHERE chromosome = ? AND `VariantOnGenome/DBID` = ?';
                 $aArgs = array($zData['chromosome'], $zData['VariantOnGenome/DBID']);
-                if ($_AUTH['level'] < LEVEL_CURATOR) {
+                if (!$_AUTH || $_AUTH['level'] < LEVEL_CURATOR) {
                     $sQ .= ' AND statusid >= ?';
                     $aArgs[] = STATUS_MARKED;
                 }
@@ -547,7 +547,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
                     }
                     $sMappingLinkText = 'Map now';
                 }
-                if ($_AUTH['level'] >= LEVEL_OWNER) {
+                if ($_AUTH && $_AUTH['level'] >= LEVEL_OWNER) {
                     $zData['mapping_flags_'] .= ' <SPAN style="float: right" id="mapOnRequest"><A href="#" onclick="return lovd_mapOnRequest();"' . (!$sMappingLinkTitle? '' : ' title="' . $sMappingLinkTitle . '"') . '>' . $sMappingLinkText . '</A></SPAN>';
                 }
             } else {

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -413,7 +413,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
             //  'not classified', will the form field be shown so that the user
             //  must manually correct the current value.
             $bHideEffectConcluded = false;
-            $nVOGEffectConcluded = intval($zData['effectid'][1]);
+            $nVOGEffectConcluded = (!isset($zData['effectid'])? 0 : intval($zData['effectid'][1]));
             if ($nVOGEffectConcluded === 0) {
                 // Set to "Not classified", we'll fill it in.
                 $bHideEffectConcluded = true;
@@ -442,7 +442,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
             //  'not classified', will the form field be shown so that the user
             //  must manually correct the current value.
             $bHideEffectReported = false;
-            $nVOGEffectReported = intval($zData['effectid'][0]);
+            $nVOGEffectReported = (!isset($zData['effectid'])? 0 : intval($zData['effectid'][0]));
             if ($nVOGEffectReported === 0) {
                 // Set to "Not classified", we'll fill it in.
                 $bHideEffectReported = true;

--- a/src/class/object_phenotypes.php
+++ b/src/class/object_phenotypes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2021-09-27
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -256,7 +256,7 @@ class LOVD_Phenotype extends LOVD_Custom
 
         if ($sView == 'entry') {
             $zData['individualid_'] = '<A href="individuals/' . $zData['individualid'] . '">' . $zData['individualid'] . '</A>';
-            if ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']) {
+            if ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']) {
                 $zData['individualid_'] .= ' <SPAN style="color : #' . $this->getStatusColor($zData['individual_statusid']) . '">(' . $_SETT['data_status'][$zData['individual_statusid']] . ')</SPAN>';
             }
             $zData['disease_'] = '<A href="diseases/' . $zData['diseaseid'] . '">' . $zData['disease'] . '</A>';

--- a/src/class/object_transcripts.php
+++ b/src/class/object_transcripts.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2021-09-27
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -81,7 +81,7 @@ class LOVD_Transcript extends LOVD_Object
                                           'g.chromosome' .
                                           (!$_SETT['customization_settings']['transcripts_VL_show_variant_counts']? '' :
                                               // Speed optimization by skipping variant counts.
-                                              ', COUNT(DISTINCT ' . ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? 'vot.id' : 'vog.id') . ') AS variants');
+                                              ', COUNT(DISTINCT ' . ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? 'vot.id' : 'vog.id') . ') AS variants');
         $this->aSQLViewList['FROM']     = TABLE_TRANSCRIPTS . ' AS t ' .
                                           'LEFT OUTER JOIN ' . TABLE_GENES . ' AS g ON (t.geneid = g.id) ' .
                                           (!$_SETT['customization_settings']['transcripts_VL_show_variant_counts']? '' :
@@ -89,7 +89,7 @@ class LOVD_Transcript extends LOVD_Object
                                               'LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid)' .
                                               // If user is less than a collaborator, only show public variants and
                                               //  variants owned/created by them.
-                                              ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' :
+                                              ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' :
                                                   ' LEFT OUTER JOIN ' . TABLE_VARIANTS . ' AS vog' .
                                                   '   ON (vot.id = vog.id AND (vog.statusid >= ' . STATUS_MARKED .
                                                   (!$_AUTH? '' :

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-09-27
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -195,8 +195,6 @@ class LOVD_User extends LOVD_Object
         $this->sSortDefault = 'level_';
 
         // Because the user information is publicly available, remove some columns for the public.
-        // FIXME; Dit moet eigenlijk per user anders; curatoren mogen deze info wel van submitters zien.
-        // Dus eigenlijk if ($_AUTH['level'] <= $zData['level']) maar we hebben hier geen $zData...
         $this->unsetColsByAuthLevel();
 
         parent::__construct();
@@ -515,7 +513,7 @@ class LOVD_User extends LOVD_Object
                 } else {
                     $zData['auth_token_expires_'] = (!$zData['auth_token']? '' : '- (Never)');
                 }
-                if ($_AUTH['level'] >= LEVEL_MANAGER && lovd_isAuthorized('user', $zData['id'])) {
+                if ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER && lovd_isAuthorized('user', $zData['id'])) {
                     $zData['api_settings'] = '<SPAN style="float:right;">(<A href="#" onclick="$.get(\'ajax/api_settings.php/' . $zData['id'] . '?edit\').fail(function(){alert(\'Error viewing settings, please try again later.\');}); return false;">Change</A>)</SPAN>' .
                         $zData['api_settings'];
                 }

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2022-01-17
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -118,7 +118,7 @@ class LOVD_Object
         // FIXME: This check should be done earlier, not just when running it.
         // Check user authorization needed to perform find and replace action.
         // FIXME: check if authorization level is correctly set for viewlist data.
-        if ($_AUTH['level'] < LEVEL_CURATOR) {
+        if (!$_AUTH || $_AUTH['level'] < LEVEL_CURATOR) {
             $sErr = 'You do not have authorization to perform this action.';
             lovd_displayError('FindAndReplace', $sErr);
             return false;
@@ -1610,7 +1610,7 @@ class LOVD_Object
             // Status coloring will only be done, when we have authorization.
             // Instead of having the logic in separate objects and the custom VL object, put it together here.
             // In LOVD+, we disable the feature of coloring hidden and marked data, since all data is hidden.
-            if (!LOVD_plus && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']) {
+            if (!LOVD_plus && $_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']) {
                 // Loop through possible status fields, always keep the minimum.
                 foreach (array('statusid', 'var_statusid', 'ind_statusid') as $sField) {
                     if (!empty($zData[$sField])) {
@@ -1681,7 +1681,7 @@ class LOVD_Object
                         '<SPAN class="custom_link" onmouseover="lovd_showToolTip(\'' .
                         addslashes(
                             '<TABLE border=0 cellpadding=0 cellspacing=0 width=350 class=S11><TR><TH valign=top>User&nbsp;ID</TH><TD>' .
-                            ($_AUTH['level'] < LEVEL_MANAGER? $nID : '<A href=users/' . $nID . '>' . $nID . '</A>') .
+                            (!$_AUTH || $_AUTH['level'] < LEVEL_MANAGER? $nID : '<A href=users/' . $nID . '>' . $nID . '</A>') .
                             '</TD></TR><TR><TH valign=top>Name</TH><TD>' . htmlspecialchars($sName) .
                             '</TD></TR><TR><TH valign=top>Email&nbsp;address</TH><TD>' . str_replace("\r\n", '<BR>', lovd_hideEmail($sEmail)) .
                             '</TD></TR><TR><TH valign=top>Institute</TH><TD>' . htmlspecialchars($sInstitute) .
@@ -1700,7 +1700,14 @@ class LOVD_Object
             // Analyzer's details like the owner's details.
             if (isset($zData['analysis_by']) && (int) $zData['analysis_by'] && !empty($zData['analyzer'])) {
                 list($nID, $sName, $sEmail, $sInstitute, $sDepartment, $sCountryID) = $zData['analyzer'];
-                $zData['analysis_by_'] = '<SPAN class="custom_link" onmouseover="lovd_showToolTip(\'' . addslashes('<TABLE border=0 cellpadding=0 cellspacing=0 width=350 class=S11><TR><TH valign=top>User&nbsp;ID</TH><TD>' . ($_AUTH['level'] < LEVEL_MANAGER? $nID : '<A href=users/' . $nID . '>' . $nID . '</A>') . '</TD></TR><TR><TH valign=top>Name</TH><TD>' . $sName . '</TD></TR><TR><TH valign=top>Email&nbsp;address</TH><TD>' . str_replace("\r\n", '<BR>', lovd_hideEmail($sEmail)) . '</TD></TR><TR><TH valign=top>Institute</TH><TD>' . $sInstitute . '</TD></TR><TR><TH valign=top>Department</TH><TD>' . $sDepartment . '</TD></TR><TR><TH valign=top>Country</TH><TD>' . $sCountryID . '</TD></TR></TABLE>') . '\', this);">' . $sName . '</SPAN>';
+                $zData['analysis_by_'] = '<SPAN class="custom_link" onmouseover="lovd_showToolTip(\'' .
+                    addslashes('<TABLE border=0 cellpadding=0 cellspacing=0 width=350 class=S11><TR><TH valign=top>User&nbsp;ID</TH><TD>' .
+                        (!$_AUTH || $_AUTH['level'] < LEVEL_MANAGER? $nID : '<A href=users/' . $nID . '>' . $nID . '</A>') . '</TD></TR>' .
+                        '<TR><TH valign=top>Name</TH><TD>' . $sName . '</TD></TR>' .
+                        '<TR><TH valign=top>Email&nbsp;address</TH><TD>' . str_replace("\r\n", '<BR>', lovd_hideEmail($sEmail)) . '</TD></TR>' .
+                        '<TR><TH valign=top>Institute</TH><TD>' . $sInstitute . '</TD></TR>' .
+                        '<TR><TH valign=top>Department</TH><TD>' . $sDepartment . '</TD></TR>' .
+                        '<TR><TH valign=top>Country</TH><TD>' . $sCountryID . '</TD></TR></TABLE>') . '\', this);">' . $sName . '</SPAN>';
             }
         }
 

--- a/src/diseases.php
+++ b/src/diseases.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-07-27
- * Modified    : 2020-08-25
- * For LOVD    : 3.0-25
+ * Modified    : 2022-02-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -72,7 +72,7 @@ if (PATH_COUNT == 1 && !ACTION) {
     }
     $aVLOptions = array(
         'cols_to_skip' => $aColsToHide,
-        'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+        'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER),
     );
     $_DATA->viewList('Diseases', $aVLOptions);
 
@@ -136,7 +136,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         $aVLOptions = array(
             'cols_to_skip' => array('panelid', 'diseaseids'),
             'track_history' => false,
-            'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+            'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER),
             'find_and_replace' => true,
         );
         $_DATA->viewList('Individuals_for_D_VE', $aVLOptions);

--- a/src/download.php
+++ b/src/download.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2021-01-06
- * For LOVD    : 3.0-26
+ * Modified    : 2022-02-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -142,7 +142,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
         $ID = $_PE[3];
         lovd_isAuthorized('gene', $_PE[3]);
 
-        if ($_AUTH['level'] >= LEVEL_CURATOR) {
+        if ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR) {
             $sFilter = 'gene';
         } else {
             $bAllowDownload = $_DB->query('SELECT allow_download FROM ' . TABLE_GENES . ' WHERE id = ?', array($ID))->fetchColumn();

--- a/src/genes.php
+++ b/src/genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2022-01-17
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -139,7 +139,7 @@ if (PATH_COUNT == 1 && !ACTION) {
     // View all entries.
 
     // Managers are allowed to download this list...
-    if ($_AUTH['level'] >= LEVEL_MANAGER) {
+    if ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER) {
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
@@ -150,7 +150,7 @@ if (PATH_COUNT == 1 && !ACTION) {
     require ROOT_PATH . 'class/object_genes.php';
     $_DATA = new LOVD_Gene();
     $aVLOptions = array(
-        'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+        'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER),
     );
     $_DATA->viewList('Genes', $aVLOptions);
 
@@ -1475,7 +1475,7 @@ if (PATH_COUNT == 3 && preg_match('/^[a-z][a-z0-9#@-]*$/i', rawurldecode($_PE[1]
 
     // Load authorization, collaborators and up see statistics about all variants, not just the public ones.
     lovd_isAuthorized('gene', $sID);
-    $bSeeNonPublicVariants = ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']);
+    $bSeeNonPublicVariants = ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']);
 
     // Check if there are variants at all.
     $nVariants = $_DB->query('
@@ -1607,7 +1607,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', $_PE[1]) && in_array
     // Load appropriate user level for this gene.
     lovd_isAuthorized('gene', $sID);
 
-    if (ACTION == 'authorize' && $_AUTH['level'] < LEVEL_MANAGER) {
+    if (ACTION == 'authorize' && (!$_AUTH || $_AUTH['level'] < LEVEL_MANAGER)) {
         header('Location: ' . lovd_getInstallURL() . $_PE[0] . '/' . $sID . '?sortCurators');
         exit;
     }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2335,9 +2335,9 @@ function lovd_isColleagueOfOwner ($sType, $Data, $bMustHaveEditPermission = true
     // Return: True if all of the objects of type $sType with an ID in $Data
     //         are owned or created by a colleague of the current user.
 
-    global $_DB;
+    global $_AUTH, $_DB;
 
-    if (!in_array($sType, array('individual', 'phenotype', 'screening', 'variant'))) {
+    if (!$_AUTH || !in_array($sType, array('individual', 'phenotype', 'screening', 'variant'))) {
         // Unknown data type, return false by default.
         return false;
     }

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2021-09-22
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -63,7 +63,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
     }
 
     // Managers and authorized curators are allowed to download this list...
-    if ($_AUTH['level'] >= LEVEL_CURATOR) {
+    if ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR) {
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
@@ -81,7 +81,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
     $_DATA = new LOVD_Individual();
     $aVLOptions = array(
         'cols_to_skip' => $aColsToHide,
-        'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
+        'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR),
         'find_and_replace' => true,
         'curate_set' => true,
         'merge_set' => true,
@@ -206,7 +206,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
             'cols_to_skip' => array('screeningid', 'individualid', 'created_date', 'edited_date'),
             'track_history' => false,
             'show_navigation' => false,
-            'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
+            'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR),
             'merge_set' => true,
         );
         // This ViewList ID is checked in ajax/viewlist.php. Don't just change it.
@@ -221,7 +221,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         // VOG needs to be first, so it groups by the VOG ID.
         $_DATA = new LOVD_CustomViewList(array('VariantOnGenome', 'Scr2Var', 'VariantOnTranscript'));
         $aVariantVLOptions = array(
-            'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
+            'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR),
         );
         $_DATA->viewList('CustomVL_VOT_for_I_VE', $aVariantVLOptions);
     }

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-23
- * Modified    : 2022-01-17
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -92,7 +92,7 @@ if (PATH_COUNT == 3 && $_PE[1] == 'disease' && ctype_digit($_PE[2]) && !ACTION) 
     $aVLOptions = array(
         'cols_to_skip' => array('diseaseid'),
         // We can't enable curator authorization, as phenotype entries authorize through their individual's variants.
-        'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+        'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER),
         'find_and_replace' => true,
         'curate_set' => true,
     );

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2021-09-22
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -78,7 +78,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
     $_DATA = new LOVD_Screening();
     $aVLOptions = array(
         'cols_to_skip' => $aColsToHide,
-        'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+        'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER),
         'find_and_replace' => true,
     );
     $_DATA->viewList('Screenings', $aVLOptions);
@@ -144,7 +144,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         $_DATA = new LOVD_CustomViewList(array('VariantOnGenome', 'Scr2Var', 'VariantOnTranscript'));
         $aVLOptions = array(
             'cols_to_skip' => array('transcriptid'),
-            'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
+            'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR),
         );
         $_DATA->viewList('CustomVL_VOT_for_S_VE', $aVLOptions);
     }

--- a/src/status.php
+++ b/src/status.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-03
- * Modified    : 2021-10-13
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -54,7 +54,7 @@ if (!$_SETT['customization_settings']['graphs_enable']) {
 
 
 require ROOT_PATH . 'class/graphs.php';
-$bSeeNonPublicVariants = ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']);
+$bSeeNonPublicVariants = ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']);
 $_G = new LOVD_Graphs();
 lovd_includeJS('lib/flot/jquery.flot.min.js');
 lovd_includeJS('lib/flot/jquery.flot.pie.min.js');

--- a/src/transcripts.php
+++ b/src/transcripts.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2022-01-17
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -74,7 +74,7 @@ if (!ACTION && (empty($_PE[1]) || preg_match('/^[a-z][a-z0-9#@-]*$/i', $_PE[1]))
     }
     $aVLOptions = array(
         'cols_to_skip' => ($sGene? array('geneid') : array()),
-        'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
+        'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR),
     );
     $_DATA->viewList('Transcripts', $aVLOptions);
 

--- a/src/users.php
+++ b/src/users.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2022-01-27
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -53,7 +53,7 @@ if (PATH_COUNT == 1 && !ACTION) {
     // View all entries.
 
     // Managers are allowed to download this list...
-    if ($_AUTH['level'] >= LEVEL_MANAGER) {
+    if ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER) {
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
@@ -67,7 +67,7 @@ if (PATH_COUNT == 1 && !ACTION) {
 
     require ROOT_PATH . 'class/object_users.php';
     $_DATA = new LOVD_User();
-    $_DATA->viewList('Users', array('show_options' => ($_AUTH['level'] >= LEVEL_MANAGER)));
+    $_DATA->viewList('Users', array('show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER)));
 
     $_T->printFooter();
     exit;

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2021-11-10
+ * Modified    : 2022-02-10
  * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
@@ -113,7 +113,7 @@ if (!ACTION && (empty($_PE[1])
     // View all variant entries on the genome level, optionally restricted by chromosome or genomic range.
 
     // Managers are allowed to download this list...
-    if ($_AUTH['level'] >= LEVEL_MANAGER) {
+    if ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER) {
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
@@ -152,7 +152,7 @@ if (!ACTION && (empty($_PE[1])
             SELECT c.name, COUNT(vog.id)
             FROM ' . TABLE_CHROMOSOMES . ' AS c
               LEFT OUTER JOIN ' . TABLE_VARIANTS . ' AS vog ON (c.name = vog.chromosome)' .
-            ($_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' :
+            ($_AUTH && $_AUTH['level'] >= $_SETT['user_level_settings']['see_nonpublic_data']? '' :
                 ' WHERE vog.statusid >= ' . STATUS_MARKED) . '
             GROUP BY c.name
             ORDER BY c.sort_id')->fetchAllCombine();
@@ -174,7 +174,7 @@ if (!ACTION && (empty($_PE[1])
 
     $aVLOptions = array(
         'cols_to_skip' => $aColsToHide,
-        'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+        'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER),
         'find_and_replace' => true,
         'curate_set' => true,
     );
@@ -193,7 +193,7 @@ if (PATH_COUNT == 2 && $_PE[1] == 'in_gene' && !ACTION
     // View all entries effecting a transcript.
 
     // Managers are allowed to download this list...
-    if ($_AUTH['level'] >= LEVEL_MANAGER) {
+    if ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER) {
         define('FORMAT_ALLOW_TEXTPLAIN', true);
     }
 
@@ -205,7 +205,7 @@ if (PATH_COUNT == 2 && $_PE[1] == 'in_gene' && !ACTION
     $_DATA = new LOVD_CustomViewList(array('Transcript', 'VariantOnTranscript', 'VariantOnGenome'));
     $aVLOptions = array(
         'cols_to_skip' => array('name', 'id_protein_ncbi'),
-        'show_options' => ($_AUTH['level'] >= LEVEL_MANAGER),
+        'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER),
         'curate_set' => true,
     );
     $_DATA->viewList('CustomVL_IN_GENE', $aVLOptions);
@@ -272,7 +272,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
         lovd_isAuthorized('gene', $sGene); // To show non public entries.
 
         // Curators are allowed to download this list...
-        if ($_AUTH['level'] >= LEVEL_CURATOR) {
+        if ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR) {
             define('FORMAT_ALLOW_TEXTPLAIN', true);
         }
 
@@ -359,7 +359,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
         $_DATA->sSortDefault = 'VariantOnTranscript/DNA';
         $aVLOptions = array(
             'cols_to_skip' => array('chromosome', 'allele_'), // Enforced for unique view in the object.
-            'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
+            'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR),
             'find_and_replace' => !$bUnique,
             'multi_value_filter' => $bUnique,
             'curate_set' => !$bUnique,

--- a/src/view.php
+++ b/src/view.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-12-05
- * Modified    : 2020-08-11
- * For LOVD    : 3.0-25
+ * Modified    : 2022-02-10
+ * For LOVD    : 3.0-28
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -60,7 +60,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
         lovd_isAuthorized('gene', $sGene); // To show non public entries.
 
         // Curators are allowed to download this list...
-        if ($_AUTH['level'] >= LEVEL_CURATOR) {
+        if ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR) {
             define('FORMAT_ALLOW_TEXTPLAIN', true);
         }
 
@@ -135,7 +135,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
         $_DATA = new LOVD_CustomViewList(array('VariantOnTranscript', 'VariantOnGenome', 'Screening', 'Individual'), $sGene);
         $aVLOptions = array(
             'cols_to_skip' => array('chromosome'),
-            'show_options' => ($_AUTH['level'] >= LEVEL_CURATOR),
+            'show_options' => ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR),
             'find_and_replace' => true,
         );
         $_DATA->viewList($sViewListID, $aVLOptions);


### PR DESCRIPTION
Testing LOVD on a newer LOVD version revealed lots of notices. We used to do quick checks on `$_AUTH['level']`, but `$_AUTH` can also be false. Fixing all these checks and others that also started throwing a notice.
- Comparisons with `$_AUTH['level']` when `$_AUTH` was false.
- Retrieval of other `$_AUTH` keys when `$_AUTH` was false.
- Retrieval of `$aData['effectid']` when form hasn't been submitted yet.

Also,
- Let `lovd_isColleagueOfOwner()` just return if `$_AUTH` is false.