### PR TITLE
Add/remove indices when adding/removing GBs

### DIFF
--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -167,7 +167,14 @@ if (PATH_COUNT == 1 && ACTION == 'add') {
                 }
 
                 if ($bToAdd) {
-                    $_DB->query(rtrim($sSQL, ','));
+                    $_DB->query(
+                        ($sTable != TABLE_VARIANTS?
+                            rtrim($sSQL, ',') :
+                            $sSQL .
+                            ' ADD INDEX (chromosome, position_g_start_' . $_POST['column_suffix'] .
+                            ', position_g_end_' . $_POST['column_suffix'] . ')'
+                        )
+                    );
                 }
             }
 

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -167,14 +167,14 @@ if (PATH_COUNT == 1 && ACTION == 'add') {
                 }
 
                 if ($bToAdd) {
-                    $_DB->query(
-                        ($sTable != TABLE_VARIANTS?
-                            rtrim($sSQL, ',') :
-                            $sSQL .
-                            ' ADD INDEX (chromosome, position_g_start_' . $_POST['column_suffix'] .
-                            ', position_g_end_' . $_POST['column_suffix'] . ')'
-                        )
-                    );
+                    if ($sTable == TABLE_VARIANTS) {
+                        // For the variants table, we will add an index
+                        //  to be able to quickly query the positions.
+                        $sSQL .=
+                        ' ADD INDEX (chromosome, position_g_start_' . $_POST['column_suffix'] .
+                        ', position_g_end_' . $_POST['column_suffix'] . ')';
+                    }
+                    $_DB->query(rtrim($sSQL, ','));
                 }
             }
 

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -375,10 +375,10 @@ if (PATH_COUNT == 2 && ACTION == 'remove') {
                     if ($sTable == TABLE_VARIANTS) {
                         // If we are working with the variants table, we must
                         //  additionally remove the indices specific to the GB.
-                        $sKeysAndIndexInfo = $_DB->query('SHOW CREATE TABLE ' . TABLE_VARIANTS)->fetchAllAssoc();
+                        $sKeysAndIndexInfo = $_DB->query('SHOW CREATE TABLE ' . TABLE_VARIANTS)->fetchColumn(1);
                         if (preg_match(
                             '/KEY `(.*)` \(`chromosome`,`position_g_start' . $sSuffixWithUnderscore . '`,`position_g_end' . $sSuffixWithUnderscore . '`\)/',
-                            $sKeysAndIndexInfo[0]['Create Table'], $aRegs)) {
+                            $sKeysAndIndexInfo, $aRegs)) {
                             // We retrieve the name of the index in the list of
                             //  indices as found through the SHOW CREATE TABLE
                             //  query. If we found a matching index, we will

--- a/src/genome_builds.php
+++ b/src/genome_builds.php
@@ -372,6 +372,20 @@ if (PATH_COUNT == 2 && ACTION == 'remove') {
                 }
 
                 if ($bToRemove) {
+                    if ($sTable == TABLE_VARIANTS) {
+                        // If we are working with the variants table, we must
+                        //  additionally remove the indices specific to the GB.
+                        $sKeysAndIndexInfo = $_DB->query('SHOW CREATE TABLE ' . TABLE_VARIANTS)->fetchAllAssoc();
+                        if (preg_match(
+                            '/KEY `(.*)` \(`chromosome`,`position_g_start' . $sSuffixWithUnderscore . '`,`position_g_end' . $sSuffixWithUnderscore . '`\)/',
+                            $sKeysAndIndexInfo[0]['Create Table'], $aRegs)) {
+                            // We retrieve the name of the index in the list of
+                            //  indices as found through the SHOW CREATE TABLE
+                            //  query. If we found a matching index, we will
+                            //  remove this index along with the position fields.
+                            $sSQL .= ' DROP INDEX `' . $aRegs[1] . '`';
+                        }
+                    }
                     $_DB->query(rtrim($sSQL, ','));
                 }
             }


### PR DESCRIPTION
From now on, when a new genome build is added, a new index will be built for the new position fields, and this index will be removed again when the build is removed.

Related to #550.