### PR TITLE
Feat/liftover existing variants

### DIFF
--- a/src/ajax/map_variants.php
+++ b/src/ajax/map_variants.php
@@ -245,7 +245,7 @@ if (count($aActiveGBs) > 1) {
             ' LIMIT ' . (int) $nMaxVariants,
             array($sChr)
         )->fetchAllColumn();
-        $aVariantUpdates = array_merge($aVariantUpdates, $aVariantIDs);
+        $aVariantUpdates = array_fill_keys($aVariantIDs, true);
 
         // These variant are now in progress, which we will indicate by mapping flags.
         $_DB->query(


### PR DESCRIPTION
This code will identify existing variants that are not described on all active GBs, and add missing descriptions wherever possible by performing lift overs using VariantValidator. 

Closes #600, related to #550.
