### PR TITLE
Feat/force validation

### DIFF
--- a/src/ajax/check_hgvs_dialogue.php
+++ b/src/ajax/check_hgvs_dialogue.php
@@ -247,7 +247,7 @@ if ($_REQUEST['action'] == 'check') {
             'oButtonOKCouldBeValid'
         );
         // Adding the variant to $_SESSION to mark it as validated.
-        $_SESSION['VV']['validated_variants'][($sType == 'VOG'? $sGenomeBuildID : $sReferenceSequence)] = $_REQUEST['var'];
+        $_SESSION['VV']['validated_variants'][($sType == 'VOG'? $sGenomeBuildID : $sReferenceSequence)][$_REQUEST['var']] = true;
         exit;
     }
 
@@ -315,7 +315,7 @@ if ($_REQUEST['action'] == 'check') {
             'oButtonOKCouldBeValid'
         );
         // Adding the variant to $_SESSION to mark it as validated.
-        $_SESSION['VV']['validated_variants'][($sType == 'VOG'? $sGenomeBuildID : $sReferenceSequence)] = $_REQUEST['var'];
+        $_SESSION['VV']['validated_variants'][($sType == 'VOG'? $sGenomeBuildID : $sReferenceSequence)][$_REQUEST['var']] = true;
         exit;
     }
 
@@ -425,7 +425,7 @@ if ($_REQUEST['action'] == 'map') {
             'oButtonOKCouldBeValid'
         );
         // Adding the variant to $_SESSION to mark it as validated.
-        $_SESSION['VV']['validated_variants'][($sType == 'VOG'? $sGenomeBuildID : $sReferenceSequence)] = $_REQUEST['var'];
+        $_SESSION['VV']['validated_variants'][($sType == 'VOG'? $sGenomeBuildID : $sReferenceSequence)][$_REQUEST['var']] = true;
         exit;
     }
 
@@ -546,7 +546,7 @@ if ($_REQUEST['action'] == 'map') {
         }');
 
         // Adding this variant to the array of validated variants to mark it as validated.
-        $_SESSION['VV']['validated_variants'][$sTranscript] = $aTranscriptData['DNA'];
+        $_SESSION['VV']['validated_variants'][$sTranscript][$aTranscriptData['DNA']] = true;
     }
 
     // Returning the mapping for genomic variants.
@@ -591,7 +591,7 @@ if ($_REQUEST['action'] == 'map') {
         ');
 
         // Adding the variant to the array of validated variants to mark it as validated.
-        $_SESSION['VV']['validated_variants'][$sGBID] = $sMappedGenomicVariant;
+        $_SESSION['VV']['validated_variants'][$sGBID][$sMappedGenomicVariant] = true;
     }
 
 

--- a/src/ajax/check_hgvs_dialogue.php
+++ b/src/ajax/check_hgvs_dialogue.php
@@ -425,7 +425,8 @@ if ($_REQUEST['action'] == 'map') {
             'oButtonOKCouldBeValid'
         );
         // Adding the variant to $_SESSION to mark it as validated.
-        $_SESSION['VV']['validated_variants'][($sType == 'VOG'? $sGenomeBuildID : $sReferenceSequence)][$_REQUEST['var']] = true;
+        $_SESSION['VV']['validated_variants'][($sType == 'VOG'? $sGenomeBuildID : $sReferenceSequence)][
+            substr(strstr($_REQUEST['var'], ':'), 1)] = true;
         exit;
     }
 

--- a/src/ajax/check_hgvs_dialogue.php
+++ b/src/ajax/check_hgvs_dialogue.php
@@ -227,7 +227,7 @@ if ($_REQUEST['action'] == 'check') {
     // This array will be used later on in the checkFields() function after
     //  the submission has been posted, to ensure that the variants were really
     //  actually validated.
-    if (!isset(['VV']['validated_variants'])) {
+    if (!isset($_SESSION['VV']['validated_variants'])) {
         $_SESSION['VV']['validated_variants'] = array();
     }
 

--- a/src/ajax/check_hgvs_dialogue.php
+++ b/src/ajax/check_hgvs_dialogue.php
@@ -82,38 +82,6 @@ if (strpos($_REQUEST['refSeqInfo'], '-') === false) {
 
 
 
-if ($bRefSeqIsSupportedByVV) {
-    // We want to reset all values if a variant input was changed,
-    //  because we want to keep all validated variants coherent.
-    // We only do this if the variants can be fully checked by
-    //  VariantValidator, because we can only map those. For variants
-    //  that we cannot map, we can also not automatically create a
-    //  coherent set of variants, and must thus allow the user to
-    //  create this set themselves.
-    print('
-    // Resetting all values.
-    if ($(\'#variantForm input[name*="VariantOn"]\').hasClass("accept")) {
-        // If any input in the form is of the class accept(ed), this means
-        //  that these input fields were filled in after full mapping and
-        //  validation of VariantValidator. If then, the script is called
-        //  again, we want to RESET these values, since we do not want to
-        //  risk having incoherent variants in the form simultaneously,
-        //  especially not those we have mapped and validated ourselves.
-        // Resetting the transcript fields.        
-        var oTranscriptFields = $(\'#variantForm input[name$="VariantOnTranscript/DNA"]\');
-        oTranscriptFields.val("").removeClass();
-        oTranscriptFields.siblings("img").attr({src: "gfx/trans.png"});
-        $(\'#variantForm input[name$="VariantOnTranscript/RNA"]\').val("").removeClass();
-        $(\'#variantForm input[name$="VariantOnTranscript/Protein"]\').val("").removeClass();
-        
-        // Resetting the genomic fields.
-        var oGenomicVariants = $(\'#variantForm input[name^="VariantOnGenome/DNA"]\');
-        oGenomicVariants.val("").removeClass();
-        oGenomicVariants.siblings("img").attr({src: "gfx/trans.png"});
-    }
-    ');
-}
-
 
 
 // Preparing the JS for the buttons.

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -275,7 +275,8 @@ class LOVD_GenomeVariant extends LOVD_Custom
                     $sReference = $_DB->query(
                         'SELECT id FROM ' . TABLE_GENOME_BUILDS . ' WHERE column_suffix = ?',
                         // Get the column suffix from the field name.
-                        array((!substr($sField, strlen('VariantOnGenome/DNA'))?
+                        array((
+                            !substr($sField, strlen('VariantOnGenome/DNA'))?
                             '' :
                             substr($sField, strlen('VariantOnGenome/DNA/'))
                         ))

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -267,12 +267,14 @@ class LOVD_GenomeVariant extends LOVD_Custom
                     // VOT.
                     $sReference = $_DB->query(
                         'SELECT id_ncbi FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ?',
+                        // Get the transcript ID from the field name.
                         strstr($sField, '_', true)
                     )->fetchColumn();
                 } else {
                     // VOG.
                     $sReference = $_DB->query(
                         'SELECT id FROM ' . TABLE_GENOME_BUILDS . ' WHERE column_suffix = ?',
+                        // Get the column suffix from the field name.
                         (!substr($sField, strlen('VariantOnGenome/DNA'))?
                             '' :
                             substr($sField, strlen('VariantOnGenome/DNA/'))

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -268,17 +268,17 @@ class LOVD_GenomeVariant extends LOVD_Custom
                     $sReference = $_DB->query(
                         'SELECT id_ncbi FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ?',
                         // Get the transcript ID from the field name.
-                        strstr($sField, '_', true)
+                        array(strstr($sField, '_', true))
                     )->fetchColumn();
                 } else {
                     // VOG.
                     $sReference = $_DB->query(
                         'SELECT id FROM ' . TABLE_GENOME_BUILDS . ' WHERE column_suffix = ?',
                         // Get the column suffix from the field name.
-                        (!substr($sField, strlen('VariantOnGenome/DNA'))?
+                        array((!substr($sField, strlen('VariantOnGenome/DNA'))?
                             '' :
                             substr($sField, strlen('VariantOnGenome/DNA/'))
-                        )
+                        ))
                     )->fetchColumn();
                 }
                 // We have the key, so now let's see if the variant has been added.

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -266,13 +266,13 @@ class LOVD_GenomeVariant extends LOVD_Custom
                 if (strpos($sField, 'Transcript') !== false) {
                     // VOT.
                     $sReference = $_DB->query(
-                        'SELECT id_ncbi FROM ' . TABLE_TRANSCRIPTS . ' WHERE ID = ?',
+                        'SELECT id_ncbi FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ?',
                         strstr($sField, '_', true)
                     )->fetchColumn();
                 } else {
                     // VOG.
                     $sReference = $_DB->query(
-                        'SELECT id FROM ' . TABLE_GENOME_BUILDS . ' WHERE ID = ?',
+                        'SELECT id FROM ' . TABLE_GENOME_BUILDS . ' WHERE column_suffix = ?',
                         (!substr($sField, strlen('VariantOnGenome/DNA'))?
                             '' :
                             substr($sField, strlen('VariantOnGenome/DNA/'))


### PR DESCRIPTION
In this branch, the `$_SESSION['VV']['validated_variants']` array is added and used to store all validated variants from the submission dialogue. This array is then used in `checkFields()` at `POST` to ensure that all variants in the submission form were indeed validated. 

Related to #588