### PR TITLE
Fix multiple issues.

### DIFF
--- a/src/api.php
+++ b/src/api.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-11-08
- * Modified    : 2022-06-24
- * For LOVD    : 3.0-28
+ * Modified    : 2022-08-29
+ * For LOVD    : 3.0-29
  *
  * Supported URIs:
  *  3.0-26       /api/rest.php/get_frequencies (POST)
@@ -413,7 +413,7 @@ if ($sDataType == 'variants') {
             if (!empty($_GET['search_' . $sField])) {
                 $bSearching = true;
                 if ($sField == 'symbol') {
-                    $sQ .= ' AND g.id = "' . $_DB->quote(GET['search_' . $sField]) . '"';
+                    $sQ .= ' AND g.id = ' . $_DB->quote($_GET['search_' . $sField]);
                 } elseif ($sField == 'position' && preg_match('/^chr([0-9]{1,2}|[MXY])(:[0-9]{1,9}(_[0-9]+)?)?$/', $_GET['search_' . $sField], $aRegs)) {
                     // $aRegs numbering:                             1                2           3
                     @list(, $sChromosome, $sPositionStart, $sPositionEnd) = $aRegs;

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -984,7 +984,7 @@ if (!defined('NOT_INSTALLED')) {
             } else {
                 // Replace with what we have in the database, so we won't run into issues on other pages when CurrDB is used for navigation to other tabs.
                 $_SESSION['currdb'] = $_SETT['currdb']['id'];
-                if (strtoupper($_PE[1]) == strtoupper($_SESSION['currdb'])) {
+                if (!empty($_PE[1]) && strtoupper($_PE[1]) == strtoupper($_SESSION['currdb'])) {
                     // Also update the URL, just in case.
                     $_PE[1] = $_SESSION['currdb'];
                 }

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2022-07-15
- * For LOVD    : 3.0-28
+ * Modified    : 2022-08-29
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -984,6 +984,10 @@ if (!defined('NOT_INSTALLED')) {
             } else {
                 // Replace with what we have in the database, so we won't run into issues on other pages when CurrDB is used for navigation to other tabs.
                 $_SESSION['currdb'] = $_SETT['currdb']['id'];
+                if (strtoupper($_PE[1]) == strtoupper($_SESSION['currdb'])) {
+                    // Also update the URL, just in case.
+                    $_PE[1] = $_SESSION['currdb'];
+                }
             }
         } else {
             $_SESSION['currdb'] = false;

--- a/tests/upload_test_results.sh
+++ b/tests/upload_test_results.sh
@@ -34,7 +34,7 @@ for file in ${GLOB}/test_results/error_screenshots/*; do
     else
         echo $RETURN | jq -r .link;
         echo -n 'Expires in ';
-        echo $RETURN | jq -r .expiry;
+        echo $RETURN | jq -r .expires;
     fi
 
     rm -f "${file}"


### PR DESCRIPTION
Fix multiple issues.
- Complete fix from last year regarding `$_DB->quote()` in the API.
  - This is related to https://github.com/LOVDnl/LOVD3/commit/83ad2c2ca9c2ade66d069f43004245a22e24e517.
  - Unknown why I didn't pick up this remaining `quote()` method call that should get its quotes removed.
  - Also, `$_GET` got changed into `GET`; fixed this as well.
- Fix `$_PE[1]` when it contains a gene symbol in the wrong case.
  - The recent implementation of `lovd_getCurrentID()` and `lovd_getCurrentPageTitle()` has made LOVD sensitive again for incorrectly cased URLs.