### PR TITLE
Improved the HGVS functions and the VV library.

### DIFF
--- a/src/ajax/check_HGVS.php
+++ b/src/ajax/check_HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-09-06
- * Modified    : 2022-09-12
+ * Modified    : 2022-10-20
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -140,10 +140,14 @@ foreach ($aVariants as $sVariant => $aVariant) {
         if (!$aVariant['variant_info']) {
             $aVariant['variant_info'] = array(
                 'errors' => array(
-                    'EFAIL' => 'Failed to recognize a variant description in your input.'
+                    'EFAIL' => 'Failed to recognize a DNA variant description in your input.'
                 ),
                 'warnings' => array(),
             );
+            // Catch r. and p. submissions.
+            if (preg_match('/(^|:)[rp]\./', $sVariant)) {
+                $aVariant['variant_info']['errors']['EFAIL'] .= ' Please note that this service is for DNA variant descriptions only.';
+            }
         }
 
         // We normally don't show non-HGVS compliant suggestions. Exception;

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -945,7 +945,7 @@ class LOVD_VV
         //  using an NC reference sequence.
         if (preg_match('/^N[MR]_.+[0-9]+[+-][0-9]+/', $sVariant)) {
             $aData['warnings']['WINTRONICWITHOUTNC'] = 'Without using a genomic reference sequence, intronic bases can not be verified.' .
-                (!isset($aJSON['genome_context_intronic_sequence']) || !isset($aJSON['submitted_variant'])? ''
+                (empty($aJSON['genome_context_intronic_sequence']) || empty($aJSON['submitted_variant'])? ''
                     : ' Please consider passing the variant as ' .
                     strstr($aJSON['genome_context_intronic_sequence'], ':', true) . strstr($aJSON['submitted_variant'], ':') . '.');
         }

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2022-10-20
+ * Modified    : 2022-10-21
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1040,6 +1040,7 @@ class LOVD_VV
                     // Don't accept VV's change of the description.
                     // VV starts moving coordinates around like it's an algebra equation. We don't like that.
                     $aData['data']['DNA'] = '';
+                    $aJSON['primary_assembly_loci'] = array();
                     unset($aData['warnings']['WCORRECTED']);
                     unset($aData['warnings']['WROLLFORWARD']);
 

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2022-09-15
+ * Modified    : 2022-10-20
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -899,6 +899,7 @@ class LOVD_VV
                             // EINCONSISTENTLENGTH error.
                             $aData['errors']['EINCONSISTENTLENGTH'] = $sError;
                         } elseif (strpos($sError, 'coordinates do not agree with the intron/exon boundaries') !== false) {
+                            // Not sure if we still catch it here, its flag is "gene_variant" nowadays?
                             // EINVALIDBOUNDARY error.
                             $aData['errors']['EINVALIDBOUNDARY'] = $sError;
                         } elseif (strpos($sError, ' variant position that lies outside of the reference sequence') !== false
@@ -1031,6 +1032,16 @@ class LOVD_VV
                     || $sWarning == 'RefSeqGene record not available') {
                     // We don't care about this - we started with an NM anyway.
                     unset($aJSON['validation_warnings'][$nKey]);
+
+                } elseif (strpos($sWarning, 'coordinates do not agree with the intron/exon boundaries') !== false) {
+                    // EINVALIDBOUNDARY error. This used to throw a flag "warning", but no more, so catch it here.
+                    $aData['errors']['EINVALIDBOUNDARY'] = $sWarning;
+                    unset($aJSON['validation_warnings'][$nKey]);
+                    // Don't accept VV's change of the description.
+                    // VV starts moving coordinates around like it's an algebra equation. We don't like that.
+                    $aData['data']['DNA'] = '';
+                    unset($aData['warnings']['WCORRECTED']);
+                    unset($aData['warnings']['WROLLFORWARD']);
 
                 } elseif (preg_match(
                     '/^A more recent version of the selected reference sequence (.+) is available \((.+)\):/',

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1998,6 +1998,11 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     'Too many positions are given; a substitution is used to only indicate single-base changes and therefore should have only one position.';
             }
         }
+        if (isset($aResponse['messages']['IPOSITIONRANGE'])) {
+            // VV won't support this... although we'll allow c.(100_101)A>G.
+            $aResponse['warnings']['WNOTSUPPORTED'] =
+                'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.';
+        }
 
     } elseif ($aResponse['type'] == 'repeat' && $aVariant['prefix'] == 'c') {
         foreach(explode('[', $aVariant['type']) as $sRepeat) {

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1314,6 +1314,12 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     'NCBI reference sequence IDs allow no more than six or nine digits.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . $aRegs[3] . '.' . $aRegs[4] . '".';
 
+            } elseif (preg_match('/([NX][MR])_(0+)([0-9]{9})\.([0-9]+)/', $sReferenceSequence, $aRegs)) {
+                // The user is using too many digits.
+                $aResponse['warnings']['WREFERENCEFORMAT'] =
+                    'NCBI transcript reference sequence IDs allow no more than nine digits.' .
+                    ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . $aRegs[3] . '.' . $aRegs[4] . '".';
+
             } else {
                 $aResponse['errors']['EREFERENCEFORMAT'] =
                     'The reference sequence could not be recognised.' .

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2011,7 +2011,8 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 return false;
             }
             $aResponse['warnings']['WWRONGTYPE'] =
-                'A substitution should be a change of one base to one base. Did you mean to describe an unchanged position?';
+                'A substitution should be a change of one base to one base. Did you mean to describe an unchanged ' .
+                ($aResponse['range']? 'range' : 'position') . '?';
 
         } elseif ($aSubstitution[1] == '.') {
             if ($bCheckHGVS) {

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2022-10-21
+ * Modified    : 2022-10-24
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1300,6 +1300,12 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 $aResponse['warnings']['WREFERENCEFORMAT'] =
                     'NCBI reference sequence IDs require an underscore between the prefix and the numeric ID.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . $aRegs[2] . '".';
+
+            } elseif (preg_match('/([NX][CGMRTW])_([0-9]{1,5})\.([0-9]+)/', $sReferenceSequence, $aRegs)) {
+                // The user is using too few digits.
+                $aResponse['warnings']['WREFERENCEFORMAT'] =
+                    'NCBI reference sequence IDs require at least six digits.' .
+                    ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . str_pad($aRegs[2], 6, '0', STR_PAD_LEFT) . '.' . $aRegs[3] . '".';
 
             } else {
                 $aResponse['errors']['EREFERENCEFORMAT'] =

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1320,6 +1320,12 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     'NCBI transcript reference sequence IDs allow no more than nine digits.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . $aRegs[3] . '.' . $aRegs[4] . '".';
 
+            } elseif (preg_match('/(LRG)([0-9]+)/', $sReferenceSequence, $aRegs)) {
+                // LRGs require underscores.
+                $aResponse['warnings']['WREFERENCEFORMAT'] =
+                    'LRG reference sequence IDs require an underscore between the prefix and the numeric ID.' .
+                    ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . $aRegs[2] . '".';
+
             } else {
                 $aResponse['errors']['EREFERENCEFORMAT'] =
                     'The reference sequence could not be recognised.' .

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1307,6 +1307,13 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     'NCBI reference sequence IDs require at least six digits.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . str_pad($aRegs[2], 6, '0', STR_PAD_LEFT) . '.' . $aRegs[3] . '".';
 
+            } elseif (preg_match('/([NX][CGMRTW])_(0+)([0-9]{6})\.([0-9]+)/', $sReferenceSequence, $aRegs)) {
+                // The user is using too many digits.
+                // (in principle, this would also match NM_[0-9]{9}, but that is correct and wouldn't get here)
+                $aResponse['warnings']['WREFERENCEFORMAT'] =
+                    'NCBI reference sequence IDs allow no more than six or nine digits.' .
+                    ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . $aRegs[3] . '.' . $aRegs[4] . '".';
+
             } else {
                 $aResponse['errors']['EREFERENCEFORMAT'] =
                     'The reference sequence could not be recognised.' .

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2022-10-24
+ * Modified    : 2022-10-25
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1325,6 +1325,12 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 $aResponse['warnings']['WREFERENCEFORMAT'] =
                     'LRG reference sequence IDs require an underscore between the prefix and the numeric ID.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . $aRegs[2] . '".';
+
+            } elseif (preg_match('/(ENS[GT])[_-]([0-9]+)/', $sReferenceSequence, $aRegs)) {
+                // Ensembl IDs disallow underscores.
+                $aResponse['warnings']['WREFERENCEFORMAT'] =
+                    'Ensembl reference sequence IDs don\'t allow a divider between the prefix and the numeric ID.' .
+                    ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . $aRegs[2] . '".';
 
             } else {
                 $aResponse['errors']['EREFERENCEFORMAT'] =

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2022-09-15
+ * Modified    : 2022-10-21
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2038,10 +2038,13 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
     //  is formatted as it should.
     if (!$aVariant['suffix']
         && (in_array($aVariant['type'], array('ins', 'delins'))
-            || isset($aResponse['messages']['IPOSITIONRANGE']))) {
+            || isset($aResponse['messages']['IPOSITIONRANGE']))
+        && $aResponse['type'] != 'subst') {
         // Variants of type ins and delins need a suffix showing what has been
         //  inserted and variants which took place within a range need a suffix
         //  showing the length of the variant.
+        // This is not required for substitutions with an IPOSITIONRANGE,
+        //  as their length is always 1.
         if ($bCheckHGVS) {
             return false;
         }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -36,7 +36,7 @@
 $_LIBRARIES = array(
     'regex_patterns' => array(
         'refseq' => array(
-            'basic' => '/^[A-Z_.t0-9()]+$/',
+            'basic' => '/^[A-Z_.t0-9()-]+$/',
             'strict'  =>
                 '/^([NX][CGMRTW]_[0-9]{6}\.[0-9]+' .
                 '|[NX][MR]_[0-9]{9}\.[0-9]+' .
@@ -1295,8 +1295,8 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     'The genomic and transcript reference sequence IDs have been swapped.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[2] . '(' . $aRegs[1] . ')".';
 
-            } elseif (preg_match('/^([NX][CGMRTW])([0-9]+)/', $sReferenceSequence, $aRegs)) {
-                // The user forgot the underscore.
+            } elseif (preg_match('/([NX][CGMRTW])-?([0-9]+)/', $sReferenceSequence, $aRegs)) {
+                // The user forgot the underscore or used a hyphen.
                 $aResponse['warnings']['WREFERENCEFORMAT'] =
                     'NCBI reference sequence IDs require an underscore between the prefix and the numeric ID.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . $aRegs[2] . '".';

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2022-10-25
+ * Modified    : 2022-10-26
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2005,6 +2005,13 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
             }
             $aResponse['errors']['EWRONGTYPE'] =
                 'A substitution should be a change of one base to one base. Did you mean to describe an insertion?';
+
+        } elseif ($aSubstitution[0] == $aSubstitution[1]) {
+            if ($bCheckHGVS) {
+                return false;
+            }
+            $aResponse['warnings']['WWRONGTYPE'] =
+                'A substitution should be a change of one base to one base. Did you mean to describe an unchanged position?';
 
         } elseif ($aSubstitution[1] == '.') {
             if ($bCheckHGVS) {

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1332,6 +1332,12 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     'Ensembl reference sequence IDs don\'t allow a divider between the prefix and the numeric ID.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . $aRegs[2] . '".';
 
+            } elseif (preg_match('/(ENS[GT])([0-9]{1,10})\.([0-9]+)/', $sReferenceSequence, $aRegs)) {
+                // The user is using too few digits.
+                $aResponse['warnings']['WREFERENCEFORMAT'] =
+                    'Ensembl reference sequence IDs require 11 digits.' .
+                    ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . str_pad($aRegs[2], 11, '0', STR_PAD_LEFT) . '.' . $aRegs[3] . '".';
+
             } else {
                 $aResponse['errors']['EREFERENCEFORMAT'] =
                     'The reference sequence could not be recognised.' .

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1287,18 +1287,18 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
             if (lovd_isValidRefSeq(preg_replace('/([0-9]{6})([()]|$)/', '$1.1$2', $sReferenceSequence))) {
                 // OK, adding a .1 helped. So, version is missing.
                 $aResponse['errors']['EREFERENCEFORMAT'] =
-                    'The reference sequence is missing the required version number.' .
+                    'The reference sequence ID is missing the required version number.' .
                     ' NCBI RefSeq and Ensembl IDs require version numbers when used in variant descriptions.';
 
             } elseif (preg_match('/^([NX][MR]_[0-9]{6,9}\.[0-9]+)\((N[CGTW]_[0-9]{6}\.[0-9]+)\)$/', $sReferenceSequence, $aRegs)) {
                 $aResponse['warnings']['WREFERENCEFORMAT'] =
-                    'The genomic and transcript reference sequences have been swapped.' .
+                    'The genomic and transcript reference sequence IDs have been swapped.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[2] . '(' . $aRegs[1] . ')".';
 
             } elseif (preg_match('/^([NX][CGMRTW])([0-9]+)/', $sReferenceSequence, $aRegs)) {
                 // The user forgot the underscore.
                 $aResponse['warnings']['WREFERENCEFORMAT'] =
-                    'NCBI reference sequences require an underscore between the prefix and the numeric ID.' .
+                    'NCBI reference sequence IDs require an underscore between the prefix and the numeric ID.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '_' . $aRegs[2] . '".';
 
             } else {

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2022-09-16
+ * Modified    : 2022-10-21
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -189,6 +189,14 @@ function lovd_fixHGVS ($sVariant, $sType = '')
             // c.((1_5))insA or c.100_500del((10))
             return lovd_fixHGVS($sReference . str_replace(array('((', '))'), array('(', ')'), $sVariant), $sType);
         }
+
+    } elseif ($nOpening == 1 && preg_match('/^' . $sType . '\.\([0-9]+\)/', $sVariant)) {
+        // The variant recognition pattern is quite complex. An opening parenthesis is accepted without any problems,
+        //  but a closing parenthesis after a position is only allowed when using ranges.
+        // The closing parenthesis in variants like c.(100del) just ends up in the suffix, so is also accepted.
+        // However, variants like c.(100)del are then not matched, even though it's clear what's meant.
+        // Try without the parentheses. c.(100)del to c.100del.
+        return lovd_fixHGVS($sReference . str_replace(array('(', ')'), '', $sVariant), $sType);
     }
 
     // Add prefix in case it is missing.

--- a/tests/selenium_tests/shared_tests/check_HGVS_interface.php
+++ b/tests/selenium_tests/shared_tests/check_HGVS_interface.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2022-09-06
- * Modified    : 2022-09-14
+ * Modified    : 2022-10-21
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -273,6 +273,7 @@ class CheckHGVSInterfaceTest extends LOVDSeleniumWebdriverBaseTestCase
 c.100delA
 c.100del
 c.100
+r.100del
 c.1ATG[2]
 g.qter_cendel
 NM_004006.3:100del
@@ -284,7 +285,7 @@ NM_004006.3:c.100del');
         $sXPathAlert = '//div[@id="multipleVariantsResponse"]/div[contains(@class, "alert")]';
         $this->waitForElement(WebDriverBy::xpath($sXPathAlert));
         $this->assertEquals(
-            '7 variants received. 1 variant validated successfully. 1 variant is not supported. 3 variants can be fixed. 2 variants failed to validate.',
+            '8 variants received. 1 variant validated successfully. 1 variant is not supported. 3 variants can be fixed. 3 variants failed to validate.',
             str_replace("\n", ' ', $this->driver->findElement(WebDriverBy::xpath($sXPathAlert))->getText())
         );
 
@@ -344,7 +345,24 @@ NM_004006.3:c.100del');
                         array(
                             'class' => 'list-group-item-danger',
                             'icon' => 'bi-exclamation-circle-fill',
-                            'value' => 'Failed to recognize a variant description in your input.',
+                            'value' => 'Failed to recognize a DNA variant description in your input.',
+                        ),
+                        array(
+                            'class' => 'list-group-item-danger',
+                            'icon' => 'bi-dash-circle-fill',
+                            'value' => 'Please first correct the variant description to run VariantValidator.',
+                        ),
+                    ),
+                ),
+                array(
+                    'class' => 'bg-danger',
+                    'icon' => 'bi-exclamation-circle-fill',
+                    'variant' => 'r.100del',
+                    'items' => array(
+                        array(
+                            'class' => 'list-group-item-danger',
+                            'icon' => 'bi-exclamation-circle-fill',
+                            'value' => 'Failed to recognize a DNA variant description in your input. Please note that this service is for DNA variant descriptions only.',
                         ),
                         array(
                             'class' => 'list-group-item-danger',
@@ -392,7 +410,7 @@ NM_004006.3:c.100del');
                         array(
                             'class' => 'list-group-item-danger',
                             'icon' => 'bi-exclamation-circle-fill',
-                            'value' => 'Failed to recognize a variant description in your input.',
+                            'value' => 'Failed to recognize a DNA variant description in your input.',
                         ),
                         array(
                             'class' => 'list-group-item-danger',
@@ -429,7 +447,7 @@ NM_004006.3:c.100del');
         // The alert should have changed now because we have variants to fix; check.
         $sXPathAlert = '//div[@id="multipleVariantsResponse"]/div[contains(@class, "alert")]';
         $this->assertEquals(
-            '7 variants received. 3 variants validated successfully. 1 variant is not supported. 3 variants failed to validate.',
+            '8 variants received. 3 variants validated successfully. 1 variant is not supported. 4 variants failed to validate.',
             str_replace("\n", ' ', $this->driver->findElement(WebDriverBy::xpath($sXPathAlert))->getText())
         );
     }

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2022-10-21
+ * Modified    : 2022-10-25
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -262,8 +262,17 @@ class FixHGVSTest extends PHPUnit_Framework_TestCase
             array('NC_123456.10:(123delA)', 'NC_123456.10:g.(123del)'),
             array('NC_123456.10:g.123_234conaaa', 'NC_123456.10:g.123_234delinsAAA'),
 
-            // Swapping reference sequences.
+            // Issues with reference sequences.
+            array('NC_12345.1:g.1del', 'NC_012345.1:g.1del'),
             array('NM_123456.1(NC_123456.1):c.100del', 'NC_123456.1(NM_123456.1):c.100del'),
+            array('NM123456.1:c.100del', 'NM_123456.1:c.100del'),
+            array('NM-123456.1:c.100del', 'NM_123456.1:c.100del'),
+            array('NM_00123456.1:c.100del', 'NM_123456.1:c.100del'),
+            array('NM_00123456789.1:c.100del', 'NM_123456789.1:c.100del'),
+            array('LRG123t1:c.100del', 'LRG_123t1:c.100del'),
+            array('LRG123t1:c.100del', 'LRG_123t1:c.100del'),
+            array('ENSG_12345678911.1:g.1del', 'ENSG12345678911.1:g.1del'),
+            array('ENSG1234567890.1:g.1del', 'ENSG01234567890.1:g.1del'),
 
             // Where we can still improve
             //  (still results in an invalid description - more work needed,

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2022-10-25
+ * Modified    : 2022-10-26
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -120,6 +120,7 @@ class FixHGVSTest extends PHPUnit_Framework_TestCase
             // Variant types should be something else.
             array('g.100_200con400_500', 'g.100_200delins400_500'),
             array('g.123conNC_000001.10:100_200', 'g.123delins[NC_000001.10:g.100_200]'),
+            array('g.123A>A', 'g.123='),
             array('g.123A>GC', 'g.123delinsGC'),
             array('g.123A>AA', 'g.123dup'),
             array('g.123AA>G', 'g.123_124delinsG'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2022-09-16
+ * Modified    : 2022-10-21
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -166,6 +166,7 @@ class FixHGVSTest extends PHPUnit_Framework_TestCase
             array('c.(1_2)insA', 'c.1_2insA'),
             array('c.(123+10_123+11)insA', 'c.123+10_123+11insA'),
             array('c.(1_2)inv', 'c.1_2inv'),
+            array('c.(100)A>G', 'c.100A>G'),
 
             // Superfluous suffixes.
             array('c.123delA', 'c.123del'),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2281,6 +2281,18 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('LRG123t1:c.100del', array(
+                'position_start' => 100,
+                'position_end' => 100,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'LRG reference sequence IDs require an underscore between the prefix and the numeric ID. Please rewrite "LRG123" to "LRG_123".',
+                ),
+                'errors' => array(),
+            )),
 
             // Other errors or problems.
             array('G.123dup', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2277,7 +2277,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => false,
                 'warnings' => array(
-                    'WREFERENCEFORMAT' => 'NCBI reference sequence IDs allow no more than nine digits. Please rewrite "NM_0012345678.1" to "NM_12345678.1".',
+                    'WREFERENCEFORMAT' => 'NCBI transcript reference sequence IDs allow no more than nine digits. Please rewrite "NM_00123456789.1" to "NM_123456789.1".',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2022-10-21
+ * Modified    : 2022-10-24
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2196,10 +2196,10 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'position_end' => 1,
                 'type' => 'del',
                 'range' => false,
-                'warnings' => array(),
-                'errors' => array(
-                    'EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.',
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'NCBI reference sequence IDs require at least six digits. Please rewrite "NC_12345.1" to "NC_012345.1".',
                 ),
+                'errors' => array(),
             )),
             array('NC_123456:g.1del', array(
                 'position_start' => 1,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2269,6 +2269,18 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('NM_00123456789.1:c.100del', array(
+                'position_start' => 100,
+                'position_end' => 100,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'NCBI reference sequence IDs allow no more than nine digits. Please rewrite "NM_0012345678.1" to "NM_12345678.1".',
+                ),
+                'errors' => array(),
+            )),
 
             // Other errors or problems.
             array('G.123dup', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -261,6 +261,18 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.123_124AA>AA', array(
+                'position_start' => 123,
+                'position_end' => 124,
+                'type' => 'subst',
+                'range' => true,
+                'warnings' => array(
+                    'WWRONGTYPE' => 'A substitution should be a change of one base to one base. Did you mean to describe an unchanged range?',
+                ),
+                'errors' => array(
+                    'ETOOMANYPOSITIONS' => 'Too many positions are given; a substitution is used to only indicate single-base changes and therefore should have only one position.'
+                ),
+            )),
             array('g.123_124AA>GC', array(
                 'position_start' => 123,
                 'position_end' => 124,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2315,6 +2315,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('ENSG1234567890.1:g.1del', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'Ensembl reference sequence IDs require 11 digits. Please rewrite "ENSG1234567890.1" to "ENSG01234567890.1".',
+                ),
+                'errors' => array(),
+            )),
 
             // Other errors or problems.
             array('G.123dup', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2022-10-25
+ * Modified    : 2022-10-26
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -196,6 +196,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'errors' => array(
                     'EWRONGTYPE' => 'This substitution does not seem to contain any data. Please provide bases that were replaced.',
                 ),
+            )),
+            array('g.123A>A', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(
+                    'WWRONGTYPE' => 'A substitution should be a change of one base to one base. Did you mean to describe an unchanged position?',
+                ),
+                'errors' => array(),
             )),
             array('g.123_124A>C', array(
                 'position_start' => 123,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2257,6 +2257,18 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('NM_00123456.1:c.100del', array(
+                'position_start' => 100,
+                'position_end' => 100,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'NCBI reference sequence IDs allow no more than six or nine digits. Please rewrite "NM_00123456.1" to "NM_123456.1".',
+                ),
+                'errors' => array(),
+            )),
 
             // Other errors or problems.
             array('G.123dup', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2022-10-24
+ * Modified    : 2022-10-25
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2290,6 +2290,28 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'range' => false,
                 'warnings' => array(
                     'WREFERENCEFORMAT' => 'LRG reference sequence IDs require an underscore between the prefix and the numeric ID. Please rewrite "LRG123" to "LRG_123".',
+                ),
+                'errors' => array(),
+            )),
+            array('LRG123t1:c.100del', array(
+                'position_start' => 100,
+                'position_end' => 100,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'LRG reference sequence IDs require an underscore between the prefix and the numeric ID. Please rewrite "LRG123" to "LRG_123".',
+                ),
+                'errors' => array(),
+            )),
+            array('ENSG_12345678911.1:g.1del', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'Ensembl reference sequence IDs don\'t allow a divider between the prefix and the numeric ID. Please rewrite "ENSG_12345678911" to "ENSG12345678911".',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2208,7 +2208,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'range' => false,
                 'warnings' => array(),
                 'errors' => array(
-                    'EREFERENCEFORMAT' => 'The reference sequence is missing the required version number. NCBI RefSeq and Ensembl IDs require version numbers when used in variant descriptions.',
+                    'EREFERENCEFORMAT' => 'The reference sequence ID is missing the required version number. NCBI RefSeq and Ensembl IDs require version numbers when used in variant descriptions.',
                 ),
             )),
             array('LRG:g.1del', array(
@@ -2229,7 +2229,19 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => false,
                 'warnings' => array(
-                    'WREFERENCEFORMAT' => 'The genomic and transcript reference sequences have been swapped. Please rewrite "NM_123456.1(NC_123456.1)" to "NC_123456.1(NM_123456.1)".',
+                    'WREFERENCEFORMAT' => 'The genomic and transcript reference sequence IDs have been swapped. Please rewrite "NM_123456.1(NC_123456.1)" to "NC_123456.1(NM_123456.1)".',
+                ),
+                'errors' => array(),
+            )),
+            array('NM123456.1:c.100del', array(
+                'position_start' => 100,
+                'position_end' => 100,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'NCBI reference sequence IDs require an underscore between the prefix and the numeric ID. Please rewrite "NM123456" to "NM_123456".',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2245,6 +2245,18 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('NM-123456.1:c.100del', array(
+                'position_start' => 100,
+                'position_end' => 100,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'NCBI reference sequence IDs require an underscore between the prefix and the numeric ID. Please rewrite "NM-123456" to "NM_123456".',
+                ),
+                'errors' => array(),
+            )),
 
             // Other errors or problems.
             array('G.123dup', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2022-09-16
+ * Modified    : 2022-10-21
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -55,7 +55,8 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
     {
         // Test lovd_getVariantInfo() with data from
         // dataProviderGetVariantInfo(), but only as an HGVS check.
-        if (empty($aOutput['errors'])
+        if ($aOutput
+            && empty($aOutput['errors'])
             && (empty($aOutput['warnings'])
                 || empty(array_diff(
                         array_keys($aOutput['warnings']),
@@ -1852,6 +1853,23 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
             )),
 
             // Descriptions that are currently unsupported.
+            array('c.(100)A>G', false),
+            array('c.(100_101)A>G', array(
+                'position_start' => 100,
+                'position_end' => 101,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'subst',
+                'range' => true,
+                'warnings' => array(
+                    'WNOTSUPPORTED' =>
+                        'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                ),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
             array('g.123^124A>C', array(
                 'position_start' => 123,
                 'position_end' => 123,


### PR DESCRIPTION
Improved the HGVS functions:
- Clarify that we're just for DNA variants, in case we see `r.` or `p.`.
- Stop variants like `c.(101_102)G>A` to throw an `ESUFFIXMISSING`. Since `IPOSITIONRANGE` is active for those variants, our library requires a suffix to determine the length of the variant. However, substitutions always have a length of one, so no suffix is needed.
- Add a `WUNSUPPORTED` to variants like `c.(101_102)G>A`. VV doesn't support them, so we shouldn't send them.
- Let `lovd_fixHGVS()` deal with variants like `c.(100)del`.
  - The variant recognition pattern is quite complex. An opening parenthesis is accepted without any problems, but a closing parenthesis after a position is only allowed when using ranges.
  - The closing parenthesis in variants like `c.(100del)` just ends up in the suffix, so is also accepted.
  - However, variants like `c.(100)del` are then not matched even though it's clear what's meant.
  - When `lovd_fixHGVS()` finds two balanced parentheses, and they are around the first number, remove them. This changes `c.(100)del` to `c.100del`.
- Update tests for the newly supported variant descriptions. Also, update the `lovd_getVariantInfo()` test to also allow a simple false as a return value. We just can't support `c.(100)A>G` in any way, so it returns false, but I want to add it to the test.
- Add `r.100del` as a test for the HGVS checker interface test.
- Improved error messages for errors in reference sequences. Also, updated the tests.
- Allow for more issues with refseqs to be recognized and corrected, and add tests for these issues for both `lovd_getVariantInfo()` as well as `lovd_fixHGVS()`.
  - NCBI refseqs with hyphens.
  - NCBI refseqs with too few digits.
  - NCBI refseqs with 7-8 digits. These refseqs can have 6 of 9 digits.
  - NCBI refseqs with more than 9 digits. These refseqs can not have more than 9 digits.
  - LRG refseqs without an underscore.
  - Ensembl refseq IDs with a divider before the number.
  - Ensembl refseqs with too few digits.
- Support the recognition and correction of `A>A` substitutions. Actually, `lovd_fixHGVS()` already contained the required code, but it required a `WWRONGTYPE` to be thrown, and it wasn't yet. Now we throw a warning, and `lovd_fixHGVS()` automatically picks it up. Also added tests.
- Improve warning for unchanged ranges, and added the `lovd_getVariantInfo()` test. The `lovd_fixHGVS()` test was already present, which responded to the `WWRONGTYPE` thrown because substitutions should not be ranges.

Also, improved the VV library:
- Fix VV library; properly throw an `EINVALIDBOUNDARY`.
- When throwing a proper `EINVALIDBOUNDARY`, delete the given mappings.
- Throw a proper `WINTRONICWITHOUTNC`, also without genomic context.
  - When we only pass an NM to `verifyVariant()`, our library should complain with a `WINTRONICWITHOUTNC`. It relies on the NC in the `genome_context_intronic_sequence` field for reporting. This field is, however, apparently sometimes empty but set. So change the `isset()` to `!empty()` to check for it.
