### PR TITLE
Fix issues with PHP8.1.

### DIFF
--- a/src/ajax/api_settings.php
+++ b/src/ajax/api_settings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-09-22
- * Modified    : 2021-02-25
- * For LOVD    : 3.0-27
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -47,7 +47,7 @@ if (!$_AUTH || $_AUTH['level'] < LEVEL_MANAGER || !lovd_isAuthorized('user', $_P
 
 // Let's download the user's data.
 $nID = lovd_getCurrentID();
-$zUser = $_DB->query('SELECT id, username, api_settings FROM ' . TABLE_USERS . ' WHERE id > 0 AND id = ?', array($nID))->fetchAssoc();
+$zUser = $_DB->q('SELECT id, username, api_settings FROM ' . TABLE_USERS . ' WHERE id > 0 AND id = ?', array($nID))->fetchAssoc();
 $zUser['api_settings'] = @json_decode($zUser['api_settings'], true);
 if (!$zUser) {
     // FIXME: Should we log this?
@@ -155,7 +155,7 @@ if (ACTION == 'edit' && POST) {
     }
 
     // Update!
-    if (!$_DB->query('UPDATE ' . TABLE_USERS . ' SET api_settings = ? WHERE id = ?',
+    if (!$_DB->q('UPDATE ' . TABLE_USERS . ' SET api_settings = ? WHERE id = ?',
         array($sSettings, $nID), false)) {
         die('alert("Failed to edit settings.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }

--- a/src/ajax/auth_token.php
+++ b/src/ajax/auth_token.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-11-17
- * Modified    : 2021-02-25
- * For LOVD    : 3.0-27
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -49,7 +49,7 @@ if (!$_AUTH || !lovd_isAuthorized('user', $_PE[2])) {
 
 // Let's download the user's data.
 $nID = lovd_getCurrentID();
-$zUser = $_DB->query('SELECT id, username, auth_token, auth_token_expires FROM ' . TABLE_USERS . ' WHERE id > 0 AND id = ?', array($nID))->fetchAssoc();
+$zUser = $_DB->q('SELECT id, username, auth_token, auth_token_expires FROM ' . TABLE_USERS . ' WHERE id > 0 AND id = ?', array($nID))->fetchAssoc();
 if (!$zUser) {
     // FIXME: Should we log this?
     die('alert("Data not found.");');
@@ -150,7 +150,7 @@ if (ACTION == 'create' && POST) {
     $sToken = md5($zUser['username'] . microtime(true) . bin2hex(openssl_random_pseudo_bytes(10)));
 
     // Update!
-    if (!$_DB->query('UPDATE ' . TABLE_USERS . ' SET auth_token = ?, auth_token_expires = ? WHERE id = ?', array($sToken, $sAuthTokenExpires, $nID), false)) {
+    if (!$_DB->q('UPDATE ' . TABLE_USERS . ' SET auth_token = ?, auth_token_expires = ? WHERE id = ?', array($sToken, $sAuthTokenExpires, $nID), false)) {
         die('alert("Failed to create new token.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }
     // If we get here, the token has been created and stored successfully!
@@ -202,7 +202,7 @@ if (ACTION == 'revoke' && POST) {
     }
 
     // Update!
-    if (!$_DB->query('UPDATE ' . TABLE_USERS . ' SET auth_token = NULL, auth_token_expires = NULL WHERE id = ?', array($nID), false)) {
+    if (!$_DB->q('UPDATE ' . TABLE_USERS . ' SET auth_token = NULL, auth_token_expires = NULL WHERE id = ?', array($nID), false)) {
         die('alert("Failed to revoke token.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }
     // If we get here, the token has been revoked successfully!

--- a/src/ajax/check_seattleseq_columns.php
+++ b/src/ajax/check_seattleseq_columns.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-01
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
@@ -47,20 +47,20 @@ $aVOTCols = array('VariantOnTranscript/Distance_to_splice_site',
                   'VariantOnTranscript/Position');
 
 // We also need to get a list of standard VariantOnTranscript columns.
-$aColsStandard = $_DB->query('SELECT id FROM ' . TABLE_COLS . ' WHERE standard = 1 AND id IN ("' . implode('", "', $aVOTCols) . '")')->fetchAllColumn();
+$aColsStandard = $_DB->q('SELECT id FROM ' . TABLE_COLS . ' WHERE standard = 1 AND id IN ("' . implode('", "', $aVOTCols) . '")')->fetchAllColumn();
 
 
 
 
 $sColumnMessage = '';
-if (!$_DB->query('SELECT colid FROM ' . TABLE_ACTIVE_COLS . ' WHERE colid = "VariantOnGenome/Conservation_score/GERP"')->fetchColumn()) {
+if (!$_DB->q('SELECT colid FROM ' . TABLE_ACTIVE_COLS . ' WHERE colid = "VariantOnGenome/Conservation_score/GERP"')->fetchColumn()) {
     // Check whether the GERP column is enabled.
     $sColumnMessage = '<BR>VariantOnGenome/Conservation_score/GERP: currently not enabled (<A href="#" onclick="lovd_openWindow(\'' . lovd_getInstallURL() . 'columns/VariantOnGenome/Conservation_score/GERP?add&amp;in_window=true\', \'col\', 800, 300); return false;">enable</A>)';
 }
 
 // Check if all VariantOnTranscript columns are activated for all genes and whether they are standard.
-$nGenes = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_GENES)->fetchColumn();
-$aColCounts = $_DB->query('SELECT colid, COUNT(*) AS count FROM ' . TABLE_SHARED_COLS . ' WHERE colid IN ("' . implode('", "', $aVOTCols) . '") GROUP BY colid')->fetchAllCombine();
+$nGenes = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_GENES)->fetchColumn();
+$aColCounts = $_DB->q('SELECT colid, COUNT(*) AS count FROM ' . TABLE_SHARED_COLS . ' WHERE colid IN ("' . implode('", "', $aVOTCols) . '") GROUP BY colid')->fetchAllCombine();
 foreach ($aVOTCols as $sCol) {
     $b = true;
     if ((!isset($aColCounts[$sCol]) && $nGenes) || (isset($aColCounts[$sCol]) && $aColCounts[$sCol] != $nGenes)) {

--- a/src/ajax/curate_set.php
+++ b/src/ajax/curate_set.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-04
- * Modified    : 2022-05-27
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -128,7 +128,7 @@ if (ACTION == 'bySubmission' && GET && !empty($_GET['id'])) {
     // URL: /ajax/curate_set.php?bySubmission&id=00000001
     // Fetch object types and object IDs of this submission, and call the curation process.
 
-    $zData = $_DB->query('
+    $zData = $_DB->q('
         SELECT i.id AS individuals, GROUP_CONCAT(DISTINCT p.id SEPARATOR ";") AS phenotypes, GROUP_CONCAT(DISTINCT s2v.variantid SEPARATOR ";") AS variants
         FROM ' . TABLE_INDIVIDUALS . ' AS i
           LEFT OUTER JOIN ' . TABLE_PHENOTYPES . ' AS p ON (i.id = p.individualid)
@@ -251,7 +251,7 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
                     // We didn't receive a disease ID, so we'll need to fetch it.
                     // Each phenotype entry can have a different disease ID.
                     if (!isset($aJob['diseaseids'])) {
-                        $aJob['diseaseids'] = $_DB->query('SELECT id, diseaseid FROM ' . TABLE_PHENOTYPES . ' WHERE id IN (?' . str_repeat(', ?', count($aObjects)-1) . ')', $aObjects)->fetchAllCombine();
+                        $aJob['diseaseids'] = $_DB->q('SELECT id, diseaseid FROM ' . TABLE_PHENOTYPES . ' WHERE id IN (?' . str_repeat(', ?', count($aObjects)-1) . ')', $aObjects)->fetchAllCombine();
                         // Get first disease ID and store that for creation of the object.
                         $nDiseaseID = current($aJob['diseaseids']);
                     }
@@ -301,7 +301,7 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
                 case 'individuals':
                 case 'phenotypes':
                     if ($sObjectType == 'individuals') {
-                        $aGenes = $_DB->query('
+                        $aGenes = $_DB->q('
                             SELECT DISTINCT t.geneid
                             FROM ' . TABLE_TRANSCRIPTS . ' AS t
                               LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid)
@@ -310,7 +310,7 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
                               LEFT OUTER JOIN ' . TABLE_SCREENINGS . ' AS s ON (s2v.screeningid = s.id)
                             WHERE s.individualid = ? AND vog.statusid >= ?', array($nObjectID, STATUS_MARKED))->fetchAllColumn();
                     } elseif ($sObjectType == 'phenotypes') {
-                        $aGenes = $_DB->query('
+                        $aGenes = $_DB->q('
                             SELECT DISTINCT t.geneid
                             FROM ' . TABLE_TRANSCRIPTS . ' AS t
                               LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid)
@@ -347,7 +347,7 @@ if (ACTION == 'process' && !empty($_GET['workid']) && GET) {
 
                     // FIXME: The following ~20 lines are just repeated from other code. It would be good to have a method for this in the VOG object.
                     // Load gene-related data.
-                    $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE vot.id = ?', array($nObjectID))->fetchAllColumn();
+                    $aGenes = $_DB->q('SELECT DISTINCT t.geneid FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE vot.id = ?', array($nObjectID))->fetchAllColumn();
 
                     if ($aGenes) {
                         foreach ($aGenes as $sGene) {

--- a/src/ajax/delete_log.php
+++ b/src/ajax/delete_log.php
@@ -4,11 +4,11 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-02-01
- * Modified    : 2012-05-07
- * For LOVD    : 3.0-beta-05
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2012 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -49,7 +49,7 @@ if (!empty($_GET['id'])) {
     foreach ($aIDs as $key => $sID) {
         $aDel = explode(',', $sID);
         if (count($aDel) == 3) {
-            $q = $_DB->query('DELETE FROM ' . TABLE_LOGS . ' WHERE name = ? AND date = ? AND mtime = ?', $aDel, false);
+            $q = $_DB->q('DELETE FROM ' . TABLE_LOGS . ' WHERE name = ? AND date = ? AND mtime = ?', $aDel, false);
             if ($q && $q->rowCount()) {
                 $nDeleted ++;
                 if ($_GET['id'] == 'selected') {

--- a/src/ajax/edit_column.php
+++ b/src/ajax/edit_column.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-01
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
@@ -34,7 +34,7 @@ require_once ROOT_PATH . 'inc-init.php';
 
 if (!$_AUTH || $_AUTH['level'] < LEVEL_MANAGER) {
     exit(AJAX_NO_AUTH);
-} elseif (ACTION == 'set_standard' && !empty($_POST['colid']) && $_DB->query('UPDATE ' . TABLE_COLS . ' SET standard = 1, edited_by = ?, edited_date = NOW() WHERE id = ?', array($_AUTH['id'], $_POST['colid']))->rowCount()) {
+} elseif (ACTION == 'set_standard' && !empty($_POST['colid']) && $_DB->q('UPDATE ' . TABLE_COLS . ' SET standard = 1, edited_by = ?, edited_date = NOW() WHERE id = ?', array($_AUTH['id'], $_POST['colid']))->rowCount()) {
     exit(AJAX_TRUE);
 } else {
     exit(AJAX_FALSE);

--- a/src/ajax/get_gene_switcher.php
+++ b/src/ajax/get_gene_switcher.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-11-27
- * Modified    : 2016-02-02
- * For LOVD    : 3.0-15
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2015 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Msc. Daan Asscheman <D.Asscheman@LUMC.nl>
  *
  *
@@ -33,7 +33,7 @@ require ROOT_PATH . 'inc-init.php';
 session_write_close();
 $nMaxDropDown = 10;
 
-$qGenes = $_DB->query('SELECT id AS value, CONCAT(id, " (", name, ")") AS label FROM ' . TABLE_GENES . ' ORDER BY id');
+$qGenes = $_DB->q('SELECT id AS value, CONCAT(id, " (", name, ")") AS label FROM ' . TABLE_GENES . ' ORDER BY id');
 $zGenes = $qGenes->fetchAllAssoc();
 
 if (empty($zGenes)) {

--- a/src/ajax/import_scheduler.php
+++ b/src/ajax/import_scheduler.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-11-16
- * Modified    : 2020-02-24
- * For LOVD    : 3.0-24
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -45,7 +45,7 @@ if (!$_AUTH || $_AUTH['level'] < LEVEL_MANAGER) {
 
 // Check info currently in the scheduler.
 $sFile = $_PE[2];
-$zFile = $_DB->query('SELECT * FROM ' . TABLE_SCHEDULED_IMPORTS . ' WHERE filename = ?', array($sFile))->fetchAssoc();
+$zFile = $_DB->q('SELECT * FROM ' . TABLE_SCHEDULED_IMPORTS . ' WHERE filename = ?', array($sFile))->fetchAssoc();
 
 if (!$zFile) {
     // FIXME: Should we log this?
@@ -142,7 +142,7 @@ if (ACTION == 'unschedule' && POST) {
     }
 
     // Delete!
-    if (!$_DB->query('DELETE FROM ' . TABLE_SCHEDULED_IMPORTS . ' WHERE filename = ?', array($sFile), false)) {
+    if (!$_DB->q('DELETE FROM ' . TABLE_SCHEDULED_IMPORTS . ' WHERE filename = ?', array($sFile), false)) {
         die('alert("Failed to unschedule file.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }
     // If we get here, the file has been successfully unscheduled!
@@ -197,7 +197,7 @@ if (ACTION == 'set_priority' && POST) {
     }
 
     // Update!
-    if (!$_DB->query('UPDATE ' . TABLE_SCHEDULED_IMPORTS . ' SET priority = ? WHERE filename = ?', array($_POST['priority'], $sFile), false)) {
+    if (!$_DB->q('UPDATE ' . TABLE_SCHEDULED_IMPORTS . ' SET priority = ? WHERE filename = ?', array($_POST['priority'], $sFile), false)) {
         die('alert("Failed to set priority.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }
     // If we get here, the token has been created and stored successfully!
@@ -248,7 +248,7 @@ if (ACTION == 'reschedule' && POST) {
     }
 
     // Update!
-    if (!$_DB->query('UPDATE ' . TABLE_SCHEDULED_IMPORTS . ' SET in_progress = 0, scheduled_by = ?, scheduled_date = NOW(), process_errors = NULL, processed_by = NULL, processed_date = NULL WHERE filename = ?', array($_AUTH['id'], $sFile), false)) {
+    if (!$_DB->q('UPDATE ' . TABLE_SCHEDULED_IMPORTS . ' SET in_progress = 0, scheduled_by = ?, scheduled_date = NOW(), process_errors = NULL, processed_by = NULL, processed_date = NULL WHERE filename = ?', array($_AUTH['id'], $sFile), false)) {
         die('alert("Failed to reschedule file.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }
     // If we get here, the file has been successfully rescheduled!
@@ -334,7 +334,7 @@ if (ACTION == 'new_screening' && POST) {
     }
 
     // Find original Individual.
-    $zIndividual = $_DB->query('
+    $zIndividual = $_DB->q('
         SELECT i.*, GROUP_CONCAT(i2d.diseaseid SEPARATOR ";") AS _diseases
         FROM ' . TABLE_INDIVIDUALS . ' AS i LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid)
         WHERE `Individual/Lab_ID` = ?
@@ -421,7 +421,7 @@ if (ACTION == 'new_screening' && POST) {
     lovd_writeLog('Event', 'ImportReschedule', 'Successfully edited ' . $sFile . ' to be imported as a new Screening');
 
     // Also, reschedule the file.
-    if (!$_DB->query('UPDATE ' . TABLE_SCHEDULED_IMPORTS . ' SET in_progress = 0, scheduled_by = ?, scheduled_date = NOW(), process_errors = NULL, processed_by = NULL, processed_date = NULL WHERE filename = ?', array($_AUTH['id'], $sFile), false)) {
+    if (!$_DB->q('UPDATE ' . TABLE_SCHEDULED_IMPORTS . ' SET in_progress = 0, scheduled_by = ?, scheduled_date = NOW(), process_errors = NULL, processed_by = NULL, processed_date = NULL WHERE filename = ?', array($_AUTH['id'], $sFile), false)) {
         die('alert("Successfully edited the file to be imported as a new Screening, but failed to reschedule.\n' . htmlspecialchars($_DB->formatError()) . '");');
     }
     // If we get here, the file has been successfully rescheduled!

--- a/src/ajax/licenses.php
+++ b/src/ajax/licenses.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-02-25
- * Modified    : 2021-08-11
- * For LOVD    : 3.0-27
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -54,13 +54,13 @@ if (ACTION != 'view' && (!$_AUTH || !lovd_isAuthorized($_PE[2], $_PE[3]))) {
 $nID = lovd_getCurrentID();
 $sObject = $_PE[2];
 if ($sObject == 'individual') {
-    $rObject = $_DB->query('
+    $rObject = $_DB->q('
         SELECT CONCAT("individual #", i.id), IFNULL(NULLIF(i.license, ""), uc.default_license), uc.name
         FROM ' . TABLE_INDIVIDUALS . ' AS i
           INNER JOIN ' . TABLE_USERS . ' AS uc ON (i.created_by = uc.id)
         WHERE i.id = ?', array($nID))->fetchRow();
 } elseif ($sObject == 'user') {
-    $rObject = $_DB->query('SELECT username, default_license, name FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchRow();
+    $rObject = $_DB->q('SELECT username, default_license, name FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchRow();
     if ((int) $nID === 0) {
         $rObject[0] = 'LOVD (license applied to data without a specific creator)';
     }
@@ -207,7 +207,7 @@ if ($sObject == 'individual') {
     unset($aFields['overwrite']);
 } else {
     // Determine whether there are submissions manually set at all.
-    $n = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' WHERE created_by = ? AND NULLIF(license, "") IS NOT NULL',
+    $n = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' WHERE created_by = ? AND NULLIF(license, "") IS NOT NULL',
         array($nID))->fetchColumn();
     if (!$n) {
         unset($aFields['overwrite']);
@@ -363,20 +363,20 @@ if (ACTION == 'edit' && POST) {
 
     // Update!
     if ($sObject == 'individual') {
-        if (!$_DB->query('UPDATE ' . TABLE_INDIVIDUALS . ' SET license = ? WHERE id = ?',
+        if (!$_DB->q('UPDATE ' . TABLE_INDIVIDUALS . ' SET license = ? WHERE id = ?',
             array($sLicense, $nID), false)) {
             die('alert("Failed to save settings.\n' . htmlspecialchars($_DB->formatError()) . '");');
         }
         // If we get here, the changes have been saved successfully!
         lovd_writeLog('Event', 'IndividualLicenseEdit', 'Successfully set license to ' . $sLicenseText . ' for individual #' . $nID);
     } elseif ($sObject == 'user') {
-        if (!$_DB->query('UPDATE ' . TABLE_USERS . ' SET default_license = ? WHERE id = ?',
+        if (!$_DB->q('UPDATE ' . TABLE_USERS . ' SET default_license = ? WHERE id = ?',
             array($sLicense, $nID), false)) {
             die('alert("Failed to save settings.\n' . htmlspecialchars($_DB->formatError()) . '");');
         }
         // Reset manually set licenses, if requested.
         if (!empty($_POST['overwrite'])) {
-            $_DB->query('UPDATE ' . TABLE_INDIVIDUALS . ' SET license = NULL WHERE created_by = ?',
+            $_DB->q('UPDATE ' . TABLE_INDIVIDUALS . ' SET license = NULL WHERE created_by = ?',
                 array($nID), false);
         }
         // If we get here, the changes have been saved successfully!

--- a/src/ajax/mobidetails.php
+++ b/src/ajax/mobidetails.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-10-01
- * Modified    : 2020-10-20
- * For LOVD    : 3.0-25
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -48,7 +48,7 @@ $nID = sprintf('%0' . $_SETT['objectid_length']['variants'] . 'd', $_PE[2]);
 // lovd_isAuthorized() can produce false, 0 or 1. Accept 0 or 1.
 $bIsAuthorized = (lovd_isAuthorized('variant', $nID, false) !== false);
 list($sVOG, $nHGNCID) =
-    $_DB->query('
+    $_DB->q('
         SELECT CONCAT(c.`' . $_CONF['refseq_build'] . '_id_ncbi`, ":", vog.`VariantOnGenome/DNA`) AS VOG_DNA,
             g.id_hgnc AS HGNC
         FROM ' . TABLE_VARIANTS . ' AS vog

--- a/src/ajax/viewentry.php
+++ b/src/ajax/viewentry.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-11-09
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -98,7 +98,7 @@ if (!file_exists($sFile)) {
 if (in_array($sObject, array('Phenotype', 'Transcript_Variant', 'Custom_ViewList', 'ScreeningPLUS'))) {
     // Exception for VOT viewEntry, we need to isolate the gene from the ID to correctly pass this to the data object.
     if ($sObject == 'Transcript_Variant') {
-        $sObjectID = $_DB->query('SELECT geneid FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ?', array($nTranscriptID))->fetchColumn();
+        $sObjectID = $_DB->q('SELECT geneid FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ?', array($nTranscriptID))->fetchColumn();
     }
 }
 require $sFile;

--- a/src/ajax/viewlist.php
+++ b/src/ajax/viewlist.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-02-18
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -124,7 +124,7 @@ if ($_AUTH && $_AUTH['level'] < LEVEL_MANAGER && (!empty($_AUTH['curates']) || !
                         'VariantOnTranscriptUnique,VariantOnGenome',
                         'VariantOnTranscript,VariantOnGenome,Screening,Individual'
                     )) && (!isset($_REQUEST['search_transcriptid'])
-                    || !$_DB->query('SELECT COUNT(*) FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ? AND geneid = ?', array($_REQUEST['search_transcriptid'], $_REQUEST['id']))->fetchColumn())) {
+                    || !$_DB->q('SELECT COUNT(*) FROM ' . TABLE_TRANSCRIPTS . ' WHERE id = ? AND geneid = ?', array($_REQUEST['search_transcriptid'], $_REQUEST['id']))->fetchColumn())) {
                 die(AJAX_NO_AUTH);
             }
             lovd_isAuthorized('gene', $nID); // Authorize for the gene currently loaded.
@@ -138,7 +138,7 @@ if ($_AUTH && $_AUTH['level'] < LEVEL_MANAGER && (!empty($_AUTH['curates']) || !
             // Check if we have multiple screening IDs. If so, make sure they belong together.
             $aScreeningIDs = explode('|', $_REQUEST['search_screeningid']);
             if (count($aScreeningIDs) > 1) {
-                $nIndividuals = $_DB->query('SELECT COUNT(DISTINCT individualid) FROM ' . TABLE_SCREENINGS . ' WHERE id IN (?' . str_repeat(', ?', count($aScreeningIDs) - 1) . ')',
+                $nIndividuals = $_DB->q('SELECT COUNT(DISTINCT individualid) FROM ' . TABLE_SCREENINGS . ' WHERE id IN (?' . str_repeat(', ?', count($aScreeningIDs) - 1) . ')',
                     $aScreeningIDs)->fetchColumn();
                 if ($nIndividuals > 1) {
                     // This custom VL is only loaded for authorization on Screenings, and there's no reason to have multiple Individuals.

--- a/src/class/PDO.php
+++ b/src/class/PDO.php
@@ -44,28 +44,11 @@ class LOVD_PDO extends PDO
     // FIXME; lovd_queryDB() provided a $bDebug argument. How to implement that now?
     private $aLastError = array();
 
-    function __construct ($sBackend, $sDSN, $sUsername = '', $sPassword = '')
+    function __construct ($sDSN, $sUsername = '', $sPassword = '', $aOptions = array())
     {
         // Initiate database connection.
-
-        $sDSN = $sBackend . ':' . $sDSN;
-        $aOptions = array();
-        if ($sBackend == 'mysql') {
-            // This method for setting the charset works also before 5.3.6, when "charset" was introduced in the DSN.
-            // Fix #4; Implement fix for PHP 5.3.0 on Windows, where PDO::MYSQL_ATTR_INIT_COMMAND by accident is not available.
-            // https://bugs.php.net/bug.php?id=47224                  (other constants were also lost, but we don't use them)
-            // Can't define a class' constant, so I'll have to use this one. This can be removed (and MYSQL_ATTR_INIT_COMMAND
-            // below restored to PDO::MYSQL_ATTR_INIT_COMMAND) once we're sure they're no other 5.3.0 users left.
-            if (!defined('MYSQL_ATTR_INIT_COMMAND')) {
-                // Still needs check though, in case two PDO connections are opened.
-                define('MYSQL_ATTR_INIT_COMMAND', 1002);
-            }
-            $aOptions = array(
-                // ONLY_FULL_GROUP_BY is causing issues; even if we try to play nice,
-                //  the totally unnecessary MIN() and MAX() calls slow down queries a lot. See #386.
-                MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8, SQL_MODE = REPLACE(REPLACE(@@SQL_MODE, "NO_ZERO_DATE", ""), "ONLY_FULL_GROUP_BY", "")',
-                PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => TRUE,
-            );
+        if (!is_array($aOptions)) {
+            $aOptions = array();
         }
         try {
             parent::__construct($sDSN, $sUsername, $sPassword, $aOptions);

--- a/src/class/PDO.php
+++ b/src/class/PDO.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-17
- * Modified    : 2022-11-22
+ * Modified    : 2022-11-23
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -127,7 +127,7 @@ class LOVD_PDO extends PDO
 
 
 
-    function prepare ($sSQL, $bHalt = true, $aOptions = array())
+    function prepare ($sSQL, $aOptions = array(), $bHalt = true)
     {
         // Wrapper around PDO::prepare().
 
@@ -161,7 +161,7 @@ class LOVD_PDO extends PDO
 
         if ($aSQL === (array) $aSQL) { // Believe it or not, faster than is_array().
             // We'll do an prepare() and execute(), not a query()!
-            $q = $this->prepare($sSQL, $bHalt); // Error handling by our own PDO class.
+            $q = $this->prepare($sSQL, array(), $bHalt); // Error handling by our own PDO class.
             if ($q) {
                 $b = $q->execute($aSQL, $bHalt, $bTrim); // Error handling by our own PDOStatement class.
                 if (!$b) {

--- a/src/class/PDO.php
+++ b/src/class/PDO.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-17
- * Modified    : 2019-08-01
- * For LOVD    : 3.0-22
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -153,7 +153,7 @@ class LOVD_PDO extends PDO
 
 
 
-    function query ($sSQL, $aSQL = '', $bHalt = true, $bTrim = false)
+    function q ($sSQL, $aSQL = '', $bHalt = true, $bTrim = false)
     {
         // Wrapper around PDO::query() or PDO::prepare()->execute(), if arguments are passed.
         // THIS WRAPPER DOES NOT SUPPORT ANY OF THE MODES!

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2021-11-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -383,7 +383,7 @@ class LOVD_API_GA4GH
         static $aGenes = array();
 
         if (!isset($aGenes[$sSymbol])) {
-            $aGenes[$sSymbol] = $_DB->query('
+            $aGenes[$sSymbol] = $_DB->q('
                 SELECT id_hgnc, id_omim FROM ' . TABLE_GENES . ' WHERE id = ?',
                 array($sSymbol))->fetchAssoc();
         }
@@ -788,7 +788,7 @@ class LOVD_API_GA4GH
         // Select columns only if they're *globally* set to public.
         // Note that this means, for VOT and Phenotype columns, the gene- and
         //  disease-specific settings are ignored.
-        $aCols = $_DB->query('
+        $aCols = $_DB->q('
             SELECT colid
             FROM ' . TABLE_ACTIVE_COLS . ' AS ac
               INNER JOIN ' . TABLE_COLS . ' AS c ON (ac.colid = c.id)
@@ -838,7 +838,7 @@ class LOVD_API_GA4GH
         $aLicensesSummaryData = array_keys(array_diff($aLicenses, array(1)));
 
         // We'll need lots of space for GROUP_CONCAT().
-        $_DB->query('SET group_concat_max_len = 1000000');
+        $_DB->q('SET group_concat_max_len = 1000000');
 
         // Fetch data. We do this in two steps; first the basic variant
         //  information and after that the full submission data.
@@ -930,7 +930,7 @@ class LOVD_API_GA4GH
         $sQ .= '
                ORDER BY vog.chromosome, vog.position_g_start, vog.position_g_end, vog.`VariantOnGenome/DNA`
                LIMIT ' . $nLimit;
-        $zData = $_DB->query($sQ, $aQ)->fetchAllAssoc();
+        $zData = $_DB->q($sQ, $aQ)->fetchAllAssoc();
         $n = count($zData);
 
 
@@ -1261,7 +1261,7 @@ class LOVD_API_GA4GH
             }
 
             if ($aSubmissions) {
-                $aSubmissions = $_DB->query('
+                $aSubmissions = $_DB->q('
                     SELECT i.id, i.panel_size' .
                     (!$bIndGender? '' : ',
                       i.`Individual/Gender` AS gender') . ',

--- a/src/class/feeds.php
+++ b/src/class/feeds.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-11-09
- * Modified    : 2022-05-26
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -109,10 +109,10 @@ class Feed
             // Let the date of last update depend on the type of feed.
             if (preg_match('/\/variants\/(.+)$/', $sFeedURL, $aRegs)) {
                 // Variants of a specific gene.
-                $sDateUpdated = $_DB->query('SELECT MAX(updated_date) FROM ' . TABLE_GENES . ' WHERE id = ?', array($aRegs[1]))->fetchColumn();
+                $sDateUpdated = $_DB->q('SELECT MAX(updated_date) FROM ' . TABLE_GENES . ' WHERE id = ?', array($aRegs[1]))->fetchColumn();
             } else {
                 // Find date of last update for all genes.
-                $sDateUpdated = $_DB->query('SELECT MAX(updated_date) FROM ' . TABLE_GENES)->fetchColumn();
+                $sDateUpdated = $_DB->q('SELECT MAX(updated_date) FROM ' . TABLE_GENES)->fetchColumn();
             }
             $this->sAtomFeed = str_replace('{{ FEED_DATE_UPDATED }}', $this->formatDate($sDateUpdated), $this->sAtomFeed);
 

--- a/src/class/graphs.php
+++ b/src/class/graphs.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-11
- * Modified    : 2019-08-06
- * For LOVD    : 3.0-22
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               David Baux <david.baux@inserm.fr>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -130,10 +130,10 @@ class LOVD_Graphs
 
         // Retricting to a certain set of genes, or full database ($Data == '*', although we actually don't check the value of $Data).
         if (!is_array($Data)) {
-            $qData = $_DB->query('SELECT g.id, COUNT(g2d.diseaseid) FROM ' . TABLE_GENES . ' AS g LEFT OUTER JOIN ' . TABLE_GEN2DIS . ' AS g2d ON (g.id = g2d.geneid) GROUP BY g.id');
+            $qData = $_DB->q('SELECT g.id, COUNT(g2d.diseaseid) FROM ' . TABLE_GENES . ' AS g LEFT OUTER JOIN ' . TABLE_GEN2DIS . ' AS g2d ON (g.id = g2d.geneid) GROUP BY g.id');
         } elseif (count($Data)) {
             // Using list of gene IDs.
-            $qData = $_DB->query('SELECT g.id, COUNT(g2d.diseaseid) FROM ' . TABLE_GENES . ' AS g LEFT OUTER JOIN ' . TABLE_GEN2DIS . ' AS g2d ON (g.id = g2d.geneid) WHERE geneid IN (?' . str_repeat(',?', count($Data)-1) . ') GROUP BY g.id', array($Data));
+            $qData = $_DB->q('SELECT g.id, COUNT(g2d.diseaseid) FROM ' . TABLE_GENES . ' AS g LEFT OUTER JOIN ' . TABLE_GEN2DIS . ' AS g2d ON (g.id = g2d.geneid) WHERE geneid IN (?' . str_repeat(',?', count($Data)-1) . ') GROUP BY g.id', array($Data));
         }
 
         // Fetch and group data.
@@ -229,14 +229,14 @@ class LOVD_Graphs
 
         // Retricting to a certain set of genes, or full database ($Data == '*', although we actually don't check the value of $Data).
         if (!is_array($Data)) {
-            $qData = $_DB->query('SELECT t.geneid, COUNT(DISTINCT vot.id) FROM ' .
+            $qData = $_DB->q('SELECT t.geneid, COUNT(DISTINCT vot.id) FROM ' .
                 (!$bNonPublic? TABLE_VARIANTS . ' AS vog INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING (id) ' : TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ') .
                 'INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id)' .
                 ($bNonPublic? '' : ' WHERE statusid >= ' . STATUS_MARKED) .
                 ' GROUP BY t.geneid');
         } elseif (count($Data)) {
             // Using list of gene IDs.
-            $qData = $_DB->query('SELECT t.geneid, COUNT(DISTINCT vot.id) FROM ' .
+            $qData = $_DB->q('SELECT t.geneid, COUNT(DISTINCT vot.id) FROM ' .
                 ($bNonPublic? '' : TABLE_VARIANTS . ' AS vog INNER JOIN ') .
                 TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING (id) INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE t.geneid IN (?' . str_repeat(',?', count($Data)-1) . ')' .
                 ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) .
@@ -354,15 +354,15 @@ class LOVD_Graphs
             //   I guess this should be called "exonic", also removing both UTR regions, but I will leave this for some other time, if ever.
             if ($bUnique) {
                 if ($Data == '*') {
-                    $qPositions = $_DB->query('SELECT position_c_cds_end, position_c_start, position_c_start_intron, position_c_end, position_c_end_intron, 1 FROM ' . TABLE_TRANSCRIPTS . ' AS t INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id) WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`');
+                    $qPositions = $_DB->q('SELECT position_c_cds_end, position_c_start, position_c_start_intron, position_c_end, position_c_end_intron, 1 FROM ' . TABLE_TRANSCRIPTS . ' AS t INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id) WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`');
                 } else {
-                    $qPositions = $_DB->query('SELECT position_c_cds_end, position_c_start, position_c_start_intron, position_c_end, position_c_end_intron, 1 FROM ' . TABLE_TRANSCRIPTS . ' AS t INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id) WHERE t.geneid = ?' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`', array($Data));
+                    $qPositions = $_DB->q('SELECT position_c_cds_end, position_c_start, position_c_start_intron, position_c_end, position_c_end_intron, 1 FROM ' . TABLE_TRANSCRIPTS . ' AS t INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id) WHERE t.geneid = ?' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`', array($Data));
                 }
             } else {
                 if ($Data == '*') {
-                    $qPositions = $_DB->query('SELECT position_c_cds_end, position_c_start, position_c_start_intron, position_c_end, position_c_end_intron, COUNT(*) FROM ' . TABLE_TRANSCRIPTS . ' AS t INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id) WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`');
+                    $qPositions = $_DB->q('SELECT position_c_cds_end, position_c_start, position_c_start_intron, position_c_end, position_c_end_intron, COUNT(*) FROM ' . TABLE_TRANSCRIPTS . ' AS t INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id) WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`');
                 } else {
-                    $qPositions = $_DB->query('SELECT position_c_cds_end, position_c_start, position_c_start_intron, position_c_end, position_c_end_intron, COUNT(*) FROM ' . TABLE_TRANSCRIPTS . ' AS t INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id) WHERE t.geneid = ?' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`', array($Data));
+                    $qPositions = $_DB->q('SELECT position_c_cds_end, position_c_start, position_c_start_intron, position_c_end, position_c_end_intron, COUNT(*) FROM ' . TABLE_TRANSCRIPTS . ' AS t INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id) WHERE t.geneid = ?' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`', array($Data));
                 }
             }
         } else {
@@ -483,9 +483,9 @@ class LOVD_Graphs
             // Restricting to a certain gene, or full database ($Data == '*').
             if ($bUnique) {
                 if ($Data == '*') {
-                    $qData = $_DB->query('SELECT type, COUNT(DISTINCT type) FROM ' . TABLE_VARIANTS . ' AS vog WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`');
+                    $qData = $_DB->q('SELECT type, COUNT(DISTINCT type) FROM ' . TABLE_VARIANTS . ' AS vog WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`');
                 } else {
-                    $qData = $_DB->query('SELECT type, COUNT(DISTINCT type) FROM ' . TABLE_VARIANTS . ' AS vog INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING (id) INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE t.geneid = ?' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`', array($Data));
+                    $qData = $_DB->q('SELECT type, COUNT(DISTINCT type) FROM ' . TABLE_VARIANTS . ' AS vog INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING (id) INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE t.geneid = ?' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY `VariantOnGenome/DBID`', array($Data));
                 }
                 $aData = array();
                 while (list($sType, $nCount) = $qData->fetchRow()) {
@@ -500,9 +500,9 @@ class LOVD_Graphs
                 }
             } else {
                 if ($Data == '*') {
-                    $aData = $_DB->query('SELECT type, COUNT(*) FROM ' . TABLE_VARIANTS . ' AS vog WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY type')->fetchAllCombine();
+                    $aData = $_DB->q('SELECT type, COUNT(*) FROM ' . TABLE_VARIANTS . ' AS vog WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY type')->fetchAllCombine();
                 } else {
-                    $aData = $_DB->query('SELECT type, COUNT(*) FROM ' . TABLE_VARIANTS . ' AS vog WHERE vog.id IN (SELECT DISTINCT vot.id FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE t.geneid = ?)' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY type', array($Data))->fetchAllCombine();
+                    $aData = $_DB->q('SELECT type, COUNT(*) FROM ' . TABLE_VARIANTS . ' AS vog WHERE vog.id IN (SELECT DISTINCT vot.id FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE t.geneid = ?)' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vog.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY type', array($Data))->fetchAllCombine();
                 }
             }
         } else {
@@ -597,15 +597,15 @@ class LOVD_Graphs
             if ($bUnique) {
                 // FIXME: This is not really correct. When grouping on VOT/Protein, we might in theory be grouping variants over multiple transcripts that are not one variant on DNA level, but just happen to have the same description on protein level. Vice versa, we're counting one variant twice if it has different descriptions on different transcripts.
                 if ($Data == '*') {
-                    $qProteinDescriptions = $_DB->query('SELECT DISTINCT IFNULL(REPLACE(`VariantOnTranscript/Protein`, " ", ""), "") AS protein, 1 FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_VARIANTS . ' AS vog USING (id) WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')'));
+                    $qProteinDescriptions = $_DB->q('SELECT DISTINCT IFNULL(REPLACE(`VariantOnTranscript/Protein`, " ", ""), "") AS protein, 1 FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_VARIANTS . ' AS vog USING (id) WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')'));
                 } else {
-                    $qProteinDescriptions = $_DB->query('SELECT DISTINCT IFNULL(REPLACE(`VariantOnTranscript/Protein`, " ", ""), "") AS protein, 1 FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_VARIANTS . ' AS vog USING (id) INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE t.geneid = ?' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')'), array($Data));
+                    $qProteinDescriptions = $_DB->q('SELECT DISTINCT IFNULL(REPLACE(`VariantOnTranscript/Protein`, " ", ""), "") AS protein, 1 FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_VARIANTS . ' AS vog USING (id) INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE t.geneid = ?' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')'), array($Data));
                 }
             } else {
                 if ($Data == '*') {
-                    $qProteinDescriptions = $_DB->query('SELECT IFNULL(REPLACE(`VariantOnTranscript/Protein`, " ", ""), "") AS protein, COUNT(*) FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_VARIANTS . ' AS vog USING (id) WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY protein');
+                    $qProteinDescriptions = $_DB->q('SELECT IFNULL(REPLACE(`VariantOnTranscript/Protein`, " ", ""), "") AS protein, COUNT(*) FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_VARIANTS . ' AS vog USING (id) WHERE 1=1' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY protein');
                 } else {
-                    $qProteinDescriptions = $_DB->query('SELECT IFNULL(REPLACE(`VariantOnTranscript/Protein`, " ", ""), "") AS protein, COUNT(*) FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_VARIANTS . ' AS vog USING (id) INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE t.geneid = ?' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY protein', array($Data));
+                    $qProteinDescriptions = $_DB->q('SELECT IFNULL(REPLACE(`VariantOnTranscript/Protein`, " ", ""), "") AS protein, COUNT(*) FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot INNER JOIN ' . TABLE_VARIANTS . ' AS vog USING (id) INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE t.geneid = ?' . ($bNonPublic? '' : ' AND statusid >= ' . STATUS_MARKED) . (!$bPathogenicOnly? '' : ' AND (LEFT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ' OR RIGHT(vot.effectid, 1) >= ' . $nPathogenicThreshold . ')') . ' GROUP BY protein', array($Data));
                 }
             }
         } else {

--- a/src/class/object_columns.php
+++ b/src/class/object_columns.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-03-04
- * Modified    : 2020-10-23
- * For LOVD    : 3.0-26
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -214,7 +214,7 @@ class LOVD_Column extends LOVD_Object
         if (lovd_getProjectFile() != '/import.php') {
             // ColID must not exist in the database.
             if (!empty($aData['category']) && !empty($aData['colid'])) {
-                if ($_DB->query('SELECT COUNT(*) FROM ' . TABLE_COLS . ' WHERE id = ?', array($aData['category'] . '/' . $aData['colid']))->fetchColumn()) {
+                if ($_DB->q('SELECT COUNT(*) FROM ' . TABLE_COLS . ' WHERE id = ?', array($aData['category'] . '/' . $aData['colid']))->fetchColumn()) {
                     lovd_errorAdd('colid', 'There is already a ' . $aData['category'] . ' column with this column ID. Please verify that you\'re not trying to create a column that already exists!');
                 }
             }
@@ -262,7 +262,7 @@ class LOVD_Column extends LOVD_Object
         global $_PE, $_DB;
 
         // Get links list, to connect column to link.
-        $aLinks = $_DB->query('SELECT id, name FROM ' . TABLE_LINKS . ' ORDER BY name')->fetchAllCombine();
+        $aLinks = $_DB->q('SELECT id, name FROM ' . TABLE_LINKS . ' ORDER BY name')->fetchAllCombine();
         $nLinkSize = count($aLinks);
         $nLinkSize = ($nLinkSize < 10? $nLinkSize : 10);
 

--- a/src/class/object_custom.php
+++ b/src/class/object_custom.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-17
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -121,7 +121,7 @@ class LOVD_Custom extends LOVD_Object
                         'ORDER BY c.col_order';
             }
         }
-        $q = $_DB->query($sSQL, $aArgs);
+        $q = $_DB->q($sSQL, $aArgs);
         while ($z = $q->fetchAssoc()) {
             $z['custom_links'] = array();
             $z['form_type'] = explode('|', $z['form_type']);
@@ -139,7 +139,7 @@ class LOVD_Custom extends LOVD_Object
         // Gather the custom link information.
         // 2015-01-23; 3.0-13; But not when importing, then we don't need this at all.
         if (lovd_getProjectFile() != '/import.php') {
-            $aLinks = $_DB->query('SELECT l.*, GROUP_CONCAT(c2l.colid SEPARATOR ";") AS colids FROM ' . TABLE_LINKS . ' AS l INNER JOIN ' . TABLE_COLS2LINKS . ' AS c2l ON (l.id = c2l.linkid) WHERE c2l.colid LIKE ? GROUP BY l.id',
+            $aLinks = $_DB->q('SELECT l.*, GROUP_CONCAT(c2l.colid SEPARATOR ";") AS colids FROM ' . TABLE_LINKS . ' AS l INNER JOIN ' . TABLE_COLS2LINKS . ' AS c2l ON (l.id = c2l.linkid) WHERE c2l.colid LIKE ? GROUP BY l.id',
                 array($this->sCategory . '/%'))->fetchAllAssoc();
             foreach ($aLinks as $aLink) {
                 $aLink['regexp_pattern'] = '/' . str_replace(array('{', '}'), array('\{', '\}'), preg_replace('/\[\d\]/', '([^:]*)', $aLink['pattern_text'])) . '/';

--- a/src/class/object_custom_viewlists.php
+++ b/src/class/object_custom_viewlists.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-15
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -113,8 +113,8 @@ class LOVD_CustomViewList extends LOVD_Object
         }
 
         // Increase the max GROUP_CONCAT() length, so that lists of many many genes still have all genes mentioned here (22.000 genes take 193.940 bytes here).
-        $_DB->query('SET group_concat_max_len = 200000');
-        $q = $_DB->query($sSQL, $aSQL);
+        $_DB->q('SET group_concat_max_len = 200000');
+        $q = $_DB->q($sSQL, $aSQL);
         while ($z = $q->fetchAssoc()) {
             $z['custom_links'] = array();
             $z['form_type'] = explode('|', $z['form_type']);
@@ -158,7 +158,7 @@ class LOVD_CustomViewList extends LOVD_Object
                     if (!$aSQL['FROM']) {
                         // First data table in query.
                         $aSQL['FROM'] = TABLE_GENES . ' AS g';
-                        $this->bEntryExists = (bool) $_DB->query('
+                        $this->bEntryExists = (bool) $_DB->q('
                             SELECT 1 FROM ' . TABLE_GENES . ' LIMIT 1')->fetchColumn();
                     }
                     break;
@@ -173,7 +173,7 @@ class LOVD_CustomViewList extends LOVD_Object
                     if (!$aSQL['FROM']) {
                         // First data table in query.
                         $aSQL['FROM'] = TABLE_TRANSCRIPTS . ' AS t';
-                        $this->bEntryExists = (bool) $_DB->query('
+                        $this->bEntryExists = (bool) $_DB->q('
                             SELECT 1 FROM ' . TABLE_TRANSCRIPTS . ' LIMIT 1')->fetchColumn();
                     } else {
                         $aSQL['FROM'] .= ' INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (';
@@ -197,7 +197,7 @@ class LOVD_CustomViewList extends LOVD_Object
                     if ($nKeyT !== false && $nKeyT < $nKey && $this->nOtherID) {
                         // Earlier, Transcript was used, join to that.
                         // First, retrieve information of variant.
-                        list($nPosStart, $nPosEnd) = $_DB->query('SELECT position_g_start, position_g_end FROM ' . TABLE_VARIANTS . ' WHERE id = ?', array($this->nOtherID))->fetchRow();
+                        list($nPosStart, $nPosEnd) = $_DB->q('SELECT position_g_start, position_g_end FROM ' . TABLE_VARIANTS . ' WHERE id = ?', array($this->nOtherID))->fetchRow();
                         // Specific modifications for this overview; distance between variant and transcript in question.
                         if ($nPosStart && $nPosEnd) {
                             // 2014-08-11; 3.0-12; Transcripts on the reverse strand did not display the correctly calculated distance.
@@ -230,7 +230,7 @@ class LOVD_CustomViewList extends LOVD_Object
                     if (!$aSQL['FROM']) {
                         // First data table in query.
                         $aSQL['FROM'] = TABLE_VARIANTS . ' AS vog';
-                        $this->bEntryExists = (bool) $_DB->query('
+                        $this->bEntryExists = (bool) $_DB->q('
                             SELECT 1 FROM ' . TABLE_VARIANTS . ' LIMIT 1')->fetchColumn();
                         $aSQL['GROUP_BY'] = 'vog.id'; // Necessary for GROUP_CONCAT(), such as in Screening.
                         $aSQL['ORDER_BY'] = 'vog.chromosome ASC, vog.position_g_start';
@@ -298,7 +298,7 @@ class LOVD_CustomViewList extends LOVD_Object
                     if (!$aSQL['FROM']) {
                         // First data table in query.
                         $aSQL['FROM'] = TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot';
-                        $this->bEntryExists = (bool) $_DB->query('
+                        $this->bEntryExists = (bool) $_DB->q('
                             SELECT 1 FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' LIMIT 1')->fetchColumn();
                         $aSQL['GROUP_BY'] = 'vot.id'; // Necessary for GROUP_CONCAT(), such as in Screening.
                     } elseif ($nKeyVOG !== false && $nKeyVOG < $nKey) {
@@ -363,7 +363,7 @@ class LOVD_CustomViewList extends LOVD_Object
                     }
                     $aSQL['FROM'] = TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot';
 
-                    $this->bEntryExists = (bool) $_DB->query('
+                    $this->bEntryExists = (bool) $_DB->q('
                         SELECT 1 FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' LIMIT 1')->fetchColumn();
 
                     $aSQL['GROUP_BY'] = '`position_c_start`, `position_c_start_intron`, `position_c_end`, `position_c_end_intron`, vot_clean_dna_change'; // Necessary for GROUP_CONCAT(), such as in Screening.
@@ -387,7 +387,7 @@ class LOVD_CustomViewList extends LOVD_Object
                         // First data table in query.
                         $aSQL['SELECT'] .= (!$aSQL['SELECT']? '' : ', ') . 's.id AS sid';
                         $aSQL['FROM'] = TABLE_SCREENINGS . ' AS s';
-                        $this->bEntryExists = (bool) $_DB->query('
+                        $this->bEntryExists = (bool) $_DB->q('
                             SELECT 1 FROM ' . TABLE_SCREENINGS . ' LIMIT 1')->fetchColumn();
                         $aSQL['ORDER_BY'] = 's.id';
                     } else {
@@ -455,7 +455,7 @@ class LOVD_CustomViewList extends LOVD_Object
                     if (!$aSQL['FROM']) {
                         // First data table in query.
                         $aSQL['FROM'] = TABLE_INDIVIDUALS . ' AS i';
-                        $this->bEntryExists = (bool) $_DB->query('
+                        $this->bEntryExists = (bool) $_DB->q('
                             SELECT 1 FROM ' . TABLE_INDIVIDUALS . ' LIMIT 1')->fetchColumn();
                         $aSQL['ORDER_BY'] = 'i.id';
                         // If no manager, hide lines with hidden individuals (not specific to a gene)!
@@ -837,7 +837,7 @@ class LOVD_CustomViewList extends LOVD_Object
 
 
         // Gather the custom link information. It's just easier to load all custom links, instead of writing code that checks for the appropriate objects.
-        $aLinks = $_DB->query('SELECT l.*, GROUP_CONCAT(c2l.colid SEPARATOR ";") AS colids FROM ' . TABLE_LINKS . ' AS l INNER JOIN ' . TABLE_COLS2LINKS . ' AS c2l ON (l.id = c2l.linkid) GROUP BY l.id')->fetchAllAssoc();
+        $aLinks = $_DB->q('SELECT l.*, GROUP_CONCAT(c2l.colid SEPARATOR ";") AS colids FROM ' . TABLE_LINKS . ' AS l INNER JOIN ' . TABLE_COLS2LINKS . ' AS c2l ON (l.id = c2l.linkid) GROUP BY l.id')->fetchAllAssoc();
         foreach ($aLinks as $aLink) {
             $aLink['regexp_pattern'] = '/' . str_replace(array('{', '}'), array('\{', '\}'), preg_replace('/\[\d\]/', '([^:]*)', $aLink['pattern_text'])) . '/';
             $aLink['replace_text'] = preg_replace('/\[(\d)\]/', '\$$1', $aLink['replace_text']);

--- a/src/class/object_diseases.php
+++ b/src/class/object_diseases.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-07-28
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -278,7 +278,7 @@ class LOVD_Disease extends LOVD_Object
         }
         // Two diseases with the same OMIM ID are not allowed.
         if (!empty($aData['id_omim']) && ($bCreate || $aData['id_omim'] != $zData['id_omim'])) {
-            $bExists = $_DB->query('SELECT id FROM ' . TABLE_DISEASES . ' WHERE id_omim = ?', array($aData['id_omim']))->fetchColumn();
+            $bExists = $_DB->q('SELECT id FROM ' . TABLE_DISEASES . ' WHERE id_omim = ?', array($aData['id_omim']))->fetchColumn();
             if ($bExists) {
                 // IMPORTANT: when you change this message, also change the array_search argument in import.php in the Disease section.
                 lovd_errorAdd('id_omim', 'Another disease already exists with this OMIM ID!');
@@ -286,7 +286,7 @@ class LOVD_Disease extends LOVD_Object
         }
         // We don't like two diseases with the exact same name, either.
         if (!empty($aData['name']) && ($bCreate || $aData['name'] != $zData['name'])) {
-            $bExists = $_DB->query('SELECT id FROM ' . TABLE_DISEASES . ' WHERE name = ?', array($aData['name']))->fetchColumn();
+            $bExists = $_DB->q('SELECT id FROM ' . TABLE_DISEASES . ' WHERE name = ?', array($aData['name']))->fetchColumn();
             if ($bExists && ($bCreate || $zData['id'] != $bExists)) {
                 // IMPORTANT: when you change this message, also change the array_search argument in import.php in the Disease section.
                 lovd_errorAdd('name', 'Another disease already exists with the same name!');
@@ -344,9 +344,9 @@ class LOVD_Disease extends LOVD_Object
                 // 2016-09-08; 3.0-17; Don't forget to run array_values() since a missing key results in a query error... :|
                 $aGenes = array_values(array_unique(array_merge($aGenes, $zData['genes'])));
             }
-            $aGenesForm = $_DB->query('SELECT id, name FROM ' . TABLE_GENES . ' WHERE id IN (?' . str_repeat(', ?', count($aGenes) - 1) . ') ORDER BY id', $aGenes)->fetchAllCombine();
+            $aGenesForm = $_DB->q('SELECT id, name FROM ' . TABLE_GENES . ' WHERE id IN (?' . str_repeat(', ?', count($aGenes) - 1) . ') ORDER BY id', $aGenes)->fetchAllCombine();
         } else {
-            $aGenesForm = $_DB->query('SELECT id, name FROM ' . TABLE_GENES . ' ORDER BY id')->fetchAllCombine();
+            $aGenesForm = $_DB->q('SELECT id, name FROM ' . TABLE_GENES . ' ORDER BY id')->fetchAllCombine();
         }
         $nData = count($aGenesForm);
         foreach ($aGenesForm as $sID => $sGene) {

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -307,7 +307,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
             return parent::getForm();
         }
 
-        $aSelectAllele = $_DB->query('SELECT id, name FROM ' . TABLE_ALLELES . ' ORDER BY display_order')->fetchAllCombine();
+        $aSelectAllele = $_DB->q('SELECT id, name FROM ' . TABLE_ALLELES . ' ORDER BY display_order')->fetchAllCombine();
 
         if (!empty($_GET['geneid'])) {
             $aFormChromosome = array('Chromosome', '', 'print', $_POST['chromosome']);
@@ -320,7 +320,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
         }
 
         if ($_AUTH['level'] >= LEVEL_CURATOR) {
-            $aSelectOwner = $_DB->query('SELECT id, CONCAT(name, " (#", id, ")") as name_id FROM ' . TABLE_USERS .
+            $aSelectOwner = $_DB->q('SELECT id, CONCAT(name, " (#", id, ")") as name_id FROM ' . TABLE_USERS .
                 ' ORDER BY name')->fetchAllCombine();
             $aFormOwner = array('Owner of this data', '', 'select', 'owned_by', 1, $aSelectOwner, false, false, false);
             $aSelectStatus = $_SETT['data_status'];
@@ -508,7 +508,7 @@ class LOVD_GenomeVariant extends LOVD_Custom
                     $sQ .= ' AND statusid >= ?';
                     $aArgs[] = STATUS_MARKED;
                 }
-                $n = $_DB->query($sQ, $aArgs)->fetchColumn();
+                $n = $_DB->q($sQ, $aArgs)->fetchColumn();
                 if ($n > 1 && (!LOVD_plus || !lovd_verifyInstance('mgha', false))) {
                     list($sPrefix,) = explode('_', $zData['VariantOnGenome/DBID'], 2);
                     $sLink = '<A href="' . (substr($sPrefix, 0, 3) == 'chr'? 'variants' : 'view/' . $sPrefix) . '?search_VariantOnGenome%2FDBID=%3D%22' . $zData['VariantOnGenome/DBID'] . '%22">See all ' . $n . ' reported entries</A>';

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2022-05-24
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -228,7 +228,7 @@ class LOVD_Individual extends LOVD_Custom
         // Simplest is to check for ourselves, so we don't need to initiate any object.
         // FIXME: Should this be replaced by a CustomVL, with Ind joined to Phenotypes to create this?
         // FIXME: This Ind VL has more than that Ind VL, though.
-        if ($_DB->query('SELECT COUNT(*) FROM ' . TABLE_ACTIVE_COLS . ' WHERE colid = ?', array('Phenotype/Additional'))->fetchColumn()) {
+        if ($_DB->q('SELECT COUNT(*) FROM ' . TABLE_ACTIVE_COLS . ' WHERE colid = ?', array('Phenotype/Additional'))->fetchColumn()) {
             // Column is active, include in SELECT, JOIN and the column list.
             $this->aSQLViewList['SELECT'] .= ', GROUP_CONCAT(DISTINCT p.`Phenotype/Additional` ORDER BY p.`Phenotype/Additional` SEPARATOR ", ") AS phenotypes_';
 
@@ -280,7 +280,7 @@ class LOVD_Individual extends LOVD_Custom
             if (isset($aData[$sParentalField]) && ctype_digit($aData[$sParentalField]) && !$bImport) {
                 // FIXME: Also check gender!!! Check if field is available, download value (or '' if not available), then check possible conflicts.
                 // Partially, the code is already written below.
-                $nParentID = $_DB->query('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($aData[$sParentalField]))->fetchColumn();
+                $nParentID = $_DB->q('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($aData[$sParentalField]))->fetchColumn();
                 if (empty($nParentID)) {
                     // FIXME: Once we have this on the form, replace with form description.
                     lovd_errorAdd($sParentalField, 'No individual found with this \'' . $sParentalField . '\'.');
@@ -296,7 +296,7 @@ class LOVD_Individual extends LOVD_Custom
 
         // Changes in these checks should also be implemented in import.php in section "Individuals"
         if (isset($aData['panelid']) && ctype_digit($aData['panelid']) && !$bImport) {
-            $nPanel = $_DB->query('SELECT panel_size FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($aData['panelid']))->fetchColumn();
+            $nPanel = $_DB->q('SELECT panel_size FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($aData['panelid']))->fetchColumn();
             if (empty($nPanel)) {
                 lovd_errorAdd('panelid', 'No Panel found with this \'Panel ID\'.');
             } elseif ($nPanel == 1) {
@@ -325,12 +325,12 @@ class LOVD_Individual extends LOVD_Custom
         // Can't enforce this in the table, because it's a custom column, so I'll just do it like this.
         if (LOVD_plus && !empty($aData['Individual/Lab_ID'])) {
             if ($zData && isset($zData['id'])) {
-                $r = $_DB->query('SELECT id, created_date
+                $r = $_DB->q('SELECT id, created_date
                                   FROM ' . TABLE_INDIVIDUALS . '
                                   WHERE `Individual/Lab_ID` = ? AND id != ?',
                         array($aData['Individual/Lab_ID'], $zData['id']))->fetchRow();
             } else {
-                $r = $_DB->query('SELECT id, created_date
+                $r = $_DB->q('SELECT id, created_date
                                   FROM ' . TABLE_INDIVIDUALS . '
                                   WHERE `Individual/Lab_ID` = ?',
                         array($aData['Individual/Lab_ID']))->fetchRow();
@@ -362,7 +362,7 @@ class LOVD_Individual extends LOVD_Custom
         global $_AUTH, $_DB, $_SETT;
 
         // Get list of diseases.
-        $aDiseasesForm = $_DB->query('SELECT id, IF(CASE symbol WHEN "-" THEN "" ELSE symbol END = "", name, CONCAT(symbol, " (", name, ")")) FROM ' . TABLE_DISEASES . ' ORDER BY (id > 0), (symbol != "" AND symbol != "-") DESC, symbol, name')->fetchAllCombine();
+        $aDiseasesForm = $_DB->q('SELECT id, IF(CASE symbol WHEN "-" THEN "" ELSE symbol END = "", name, CONCAT(symbol, " (", name, ")")) FROM ' . TABLE_DISEASES . ' ORDER BY (id > 0), (symbol != "" AND symbol != "-") DESC, symbol, name')->fetchAllCombine();
         $nDiseases = count($aDiseasesForm);
         foreach ($aDiseasesForm as $nID => $sDisease) {
             $aDiseasesForm[$nID] = lovd_shortenString($sDisease, 75);
@@ -374,7 +374,7 @@ class LOVD_Individual extends LOVD_Custom
         }
 
         if ($_AUTH['level'] >= LEVEL_CURATOR) {
-            $aSelectOwner = $_DB->query('SELECT id, CONCAT(name, " (#", id, ")") as name_id FROM ' . TABLE_USERS .
+            $aSelectOwner = $_DB->q('SELECT id, CONCAT(name, " (#", id, ")") as name_id FROM ' . TABLE_USERS .
                 ' ORDER BY name')->fetchAllCombine();
             $aFormOwner = array('Owner of this data', '', 'select', 'owned_by', 1, $aSelectOwner, false, false, false);
             $aSelectStatus = $_SETT['data_status'];

--- a/src/class/object_links.php
+++ b/src/class/object_links.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-04-19
- * Modified    : 2020-03-30
- * For LOVD    : 3.0-24
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -136,7 +136,7 @@ class LOVD_Link extends LOVD_Object
                 $sSQL .= ' AND id != ?';
                 $aSQL[] = $zData['id'];
             }
-            if ($_DB->query($sSQL, $aSQL)->fetchColumn()) {
+            if ($_DB->q($sSQL, $aSQL)->fetchColumn()) {
                 lovd_errorAdd('name', 'There is already a custom link with this link name. Please choose another one.');
             }
         }
@@ -145,7 +145,7 @@ class LOVD_Link extends LOVD_Object
             $_POST['active_columns'] = array();
         } elseif (!empty($aData['active_columns'])) {
             // Check if columns are text columns, since others cannot even hold the custom link's pattern text.
-            $aColumns = $_DB->query('SELECT id FROM ' . TABLE_COLS . ' WHERE mysql_type LIKE \'VARCHAR%\' OR mysql_type LIKE \'TEXT%\'')->fetchAllColumn();
+            $aColumns = $_DB->q('SELECT id FROM ' . TABLE_COLS . ' WHERE mysql_type LIKE \'VARCHAR%\' OR mysql_type LIKE \'TEXT%\'')->fetchAllColumn();
             foreach($aData['active_columns'] as $sCol) {
                 if (substr_count($sCol, '/') && !in_array($sCol, $aColumns)) {
                     // Columns without slashes are the category headers, that could be selected.
@@ -164,7 +164,7 @@ class LOVD_Link extends LOVD_Object
                 $sSQL .= ' AND id != ?';
                 $aSQL[] = $zData['id'];
             }
-            if ($_DB->query($sSQL, $aSQL)->fetchColumn()) {
+            if ($_DB->q($sSQL, $aSQL)->fetchColumn()) {
                 lovd_errorAdd('pattern_text', 'There is already a custom link with this pattern. Please choose another one.');
 
             } else {
@@ -243,7 +243,7 @@ class LOVD_Link extends LOVD_Object
         // Get column list, to connect link to column.
         $aData = array();
         $sLastCategory = '';
-        $zData = $_DB->query('SELECT id, CONCAT(id, " (", head_column, ")") FROM ' . TABLE_COLS . ' WHERE mysql_type LIKE \'VARCHAR%\' OR mysql_type LIKE \'TEXT%\' ORDER BY id')->fetchAllCombine();
+        $zData = $_DB->q('SELECT id, CONCAT(id, " (", head_column, ")") FROM ' . TABLE_COLS . ' WHERE mysql_type LIKE \'VARCHAR%\' OR mysql_type LIKE \'TEXT%\' ORDER BY id')->fetchAllCombine();
         $nData = count($zData);
         $nFieldSize = ($nData < 20? $nData : 20);
 

--- a/src/class/object_phenotypes.php
+++ b/src/class/object_phenotypes.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -183,13 +183,13 @@ class LOVD_Phenotype extends LOVD_Custom
         }
 
         if (!empty($_POST['diseaseid'])) {
-            $sDisease = $_DB->query('SELECT name FROM ' . TABLE_DISEASES . ' WHERE id = ?', array($_POST['diseaseid']))->fetchColumn();
+            $sDisease = $_DB->q('SELECT name FROM ' . TABLE_DISEASES . ' WHERE id = ?', array($_POST['diseaseid']))->fetchColumn();
         } else {
             $sDisease = 'all diseases';
         }
 
         if ($_AUTH['level'] >= LEVEL_CURATOR) {
-            $aSelectOwner = $_DB->query('SELECT id, CONCAT(name, " (#", id, ")") as name_id FROM ' . TABLE_USERS .
+            $aSelectOwner = $_DB->q('SELECT id, CONCAT(name, " (#", id, ")") as name_id FROM ' . TABLE_USERS .
                 ' ORDER BY name')->fetchAllCombine();
             $aFormOwner = array('Owner of this data', '', 'select', 'owned_by', 1, $aSelectOwner, false, false, false);
             $aSelectStatus = $_SETT['data_status'];

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -206,7 +206,7 @@ class LOVD_Screening extends LOVD_Custom
         global $_AUTH, $_DB, $nID;
 
         if ($_AUTH['level'] >= LEVEL_CURATOR) {
-            $aSelectOwner = $_DB->query('SELECT id, CONCAT(name, " (#", id, ")") as name_id FROM ' . TABLE_USERS .
+            $aSelectOwner = $_DB->q('SELECT id, CONCAT(name, " (#", id, ")") as name_id FROM ' . TABLE_USERS .
                 ' ORDER BY name')->fetchAllCombine();
             $aFormOwner = array('Owner of this data', '', 'select', 'owned_by', 1, $aSelectOwner, false, false, false);
         } else {
@@ -214,7 +214,7 @@ class LOVD_Screening extends LOVD_Custom
         }
 
         // Get list of genes.
-        $aGenesForm = $_DB->query('SELECT id, name FROM ' . TABLE_GENES . ' ORDER BY id')->fetchAllCombine();
+        $aGenesForm = $_DB->q('SELECT id, name FROM ' . TABLE_GENES . ' ORDER BY id')->fetchAllCombine();
         $nData = count($aGenesForm);
         foreach ($aGenesForm as $sID => $sGene) {
             $aGenesForm[$sID] = $sID . ' (' . lovd_shortenString($sGene, 50) . ')';
@@ -252,7 +252,7 @@ class LOVD_Screening extends LOVD_Custom
             // When creating, or when publishing without any changes, unset the authorization.
             unset($this->aFormData['authorization']);
         } elseif (lovd_getProjectFile() != '/import.php') {
-            if ($_DB->query('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn()) {
+            if ($_DB->q('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn()) {
                 unset($this->aFormData['variants_found']);
             };
         }

--- a/src/class/object_shared_columns.php
+++ b/src/class/object_shared_columns.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-05-02
- * Modified    : 2020-11-24
- * For LOVD    : 3.0-26
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -213,7 +213,7 @@ class LOVD_SharedColumn extends LOVD_Object
         global $_DB;
 
         if ($sID) {
-            $bEntryExists = $_DB->query('
+            $bEntryExists = $_DB->q('
                 SELECT 1
                 FROM ' . constant($this->sTable) . '
                 WHERE ' . $this->aTableInfo['unit'] . 'id = ? AND colid = ? LIMIT 1',
@@ -223,7 +223,7 @@ class LOVD_SharedColumn extends LOVD_Object
             if (isset($this->bEntryExists)) {
                 return $this->bEntryExists;
             }
-            $bEntryExists = $_DB->query('
+            $bEntryExists = $_DB->q('
                 SELECT 1
                 FROM ' . constant($this->sTable) . '
                 WHERE ' . $this->aTableInfo['unit'] . 'id = ? LIMIT 1',
@@ -359,7 +359,7 @@ class LOVD_SharedColumn extends LOVD_Object
         if (!defined('LOG_EVENT')) {
             define('LOG_EVENT', $this->sObject . '::updateEntry()');
         }
-        $q = $_DB->query($sSQL, $aSQL, true, true);
+        $q = $_DB->q($sSQL, $aSQL, true, true);
 
         return $q->rowCount();
     }

--- a/src/class/object_transcript_variants.php
+++ b/src/class/object_transcript_variants.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-12
- * Modified    : 2021-11-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -172,14 +172,14 @@ class LOVD_TranscriptVariant extends LOVD_Custom
 
         if (!empty($this->nID)) {
             // Known variant ID, load all transcripts for existing variant.
-            $aTranscripts = $_DB->query('SELECT t.id, t.id_ncbi, t.geneid, t.id_mutalyzer FROM ' .
+            $aTranscripts = $_DB->q('SELECT t.id, t.id_ncbi, t.geneid, t.id_mutalyzer FROM ' .
                 TABLE_TRANSCRIPTS . ' AS t LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS .
                 ' AS vot ON (t.id = vot.transcriptid) WHERE vot.id = ? ORDER BY t.geneid, ' .
                 't.id_ncbi', array($this->nID))->fetchAllRow();
         } else {
             // Unknown variant, but then we must have a gene symbol ($sObjectID).
             // Get list of transcript(s) available for this gene for getForm(), checkFields(), etc...
-            $aTranscripts = $_DB->query('SELECT id, id_ncbi, geneid, id_mutalyzer FROM ' .
+            $aTranscripts = $_DB->q('SELECT id, id_ncbi, geneid, id_mutalyzer FROM ' .
                 TABLE_TRANSCRIPTS . ' WHERE geneid IN (?' .
                 str_repeat(', ?', substr_count($sObjectID, ',')) . ') ' .
                 (!$bLoadAllTranscripts? 'LIMIT 1' : 'ORDER BY id_ncbi'),
@@ -363,7 +363,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
             lovd_displayError('LOVD-Lib', 'Objects::(' . $this->sObject . ')::loadEntry() - Method didn\'t receive ID');
         }
 
-        $q = $_DB->query($this->sSQLLoadEntry, array_merge(
+        $q = $_DB->q($this->sSQLLoadEntry, array_merge(
             array($nID),
             (!$this->sObjectID? array() : array($this->sObjectID))), false);
         if ($q) {
@@ -494,7 +494,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
         if (!defined('LOG_EVENT')) {
             define('LOG_EVENT', $this->sObject . '::updateEntry()');
         }
-        $q = $_DB->query($sSQL, $aSQL, true, true);
+        $q = $_DB->q($sSQL, $aSQL, true, true);
 
         return $q->rowCount();
     }
@@ -568,7 +568,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
                 define('LOG_EVENT', $this->sObject . '::updateEntry()');
             }
 
-            $q = $_DB->query($sSQL, $aSQL, true, true);
+            $q = $_DB->q($sSQL, $aSQL, true, true);
             $nAffected += $q->rowCount();
         }
         return $nAffected;
@@ -587,7 +587,7 @@ class LOVD_TranscriptVariant extends LOVD_Custom
         // Before passing this on to parent::viewEntry(), perform a standard count() check on the transcript ID,
         // to make sure that we won't get a query error when the combination of VariantID/TranscriptID does not yield
         // any results. Easiest is then to fake a wrong $nID such that parent::viewEntry() will complain.
-        if (!$_DB->query('SELECT COUNT(*) FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' WHERE id = ? AND transcriptid = ?', array($nID, $nTranscriptID))->fetchColumn()) {
+        if (!$_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' WHERE id = ? AND transcriptid = ?', array($nID, $nTranscriptID))->fetchColumn()) {
             $nID = -1;
         }
         parent::viewEntry($nID);

--- a/src/class/object_transcripts.php
+++ b/src/class/object_transcripts.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -276,7 +276,7 @@ class LOVD_Transcript extends LOVD_Object
         );
 
         $sAliasSymbol = $sSymbol;
-        $aTranscripts['added'] = $_DB->query('SELECT id_ncbi FROM ' . TABLE_TRANSCRIPTS . ' WHERE geneid = ? ORDER BY id_ncbi', array($sSymbol))->fetchAllColumn();
+        $aTranscripts['added'] = $_DB->q('SELECT id_ncbi FROM ' . TABLE_TRANSCRIPTS . ' WHERE geneid = ? ORDER BY id_ncbi', array($sSymbol))->fetchAllColumn();
         if (isset($_SETT['mito_genes_aliases'][$sSymbol])) {
             // For mitochondrial genes, an alias must be used to get the transcripts and info.
             // List of aliases are hard-coded in inc-init.php.
@@ -359,7 +359,7 @@ class LOVD_Transcript extends LOVD_Object
     {
         global $_DB;
 
-        $q = $_DB->query('UPDATE ' . TABLE_VARIANTS . '
+        $q = $_DB->q('UPDATE ' . TABLE_VARIANTS . '
                          SET mapping_flags = mapping_flags & ~' . MAPPING_DONE . '
                          WHERE chromosome = ? AND (
                            (position_g_start BETWEEN ? AND ?) OR

--- a/src/class/object_users.php
+++ b/src/class/object_users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2022-05-25
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -248,7 +248,7 @@ class LOVD_User extends LOVD_Object
         if (in_array(ACTION, array('create', 'register'))) {
             // Does the username exist already?
             if ($aData['username']) {
-                if ($_DB->query('SELECT COUNT(*) FROM ' . TABLE_USERS . ' WHERE username = ?', array($aData['username']))->fetchColumn()) {
+                if ($_DB->q('SELECT COUNT(*) FROM ' . TABLE_USERS . ' WHERE username = ?', array($aData['username']))->fetchColumn()) {
                     lovd_errorAdd('username', 'There is already a user with this username. Please choose another one.');
                 }
             }
@@ -341,7 +341,7 @@ class LOVD_User extends LOVD_Object
 
         } else {
             // "Normal" user form; create user, edit user.
-            $aCountryList = $_DB->query('SELECT id, name FROM ' . TABLE_COUNTRIES . ' ORDER BY name')->fetchAllCombine();
+            $aCountryList = $_DB->q('SELECT id, name FROM ' . TABLE_COUNTRIES . ' ORDER BY name')->fetchAllCombine();
 
             if ($_AUTH) {
                 // Remove user levels that are higher than or equal to the current user's level IF you are logged in.
@@ -522,7 +522,7 @@ class LOVD_User extends LOVD_Object
                 foreach (array('owned_by', 'created_by') as $sField) {
                     $aStats = array(0, '');
                     foreach (array('individuals', 'screenings', 'variants', 'phenotypes') as $sDataType) {
-                        $nCount = $_DB->query('SELECT COUNT(*) FROM ' .
+                        $nCount = $_DB->q('SELECT COUNT(*) FROM ' .
                             constant('TABLE_' . strtoupper($sDataType)) . ' WHERE ' . $sField .
                             ' = ?', array($zData['id']))->fetchColumn();
                         $sTitle = $nCount . ' ' . ($nCount == 1? substr($sDataType, 0, -1) :

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2022-08-26
+ * Modified    : 2022-11-22
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -226,7 +226,7 @@ class LOVD_Object
         $aArgs[] = $_AUTH['id'];
         $aArgs[] = date('Y-m-d H:i:s');
 
-        $q = $_DB->query($sUpdateSQL, $aArgs);
+        $q = $_DB->q($sUpdateSQL, $aArgs);
         $bSuccess = (bool) $q;
         if ($bSuccess) {
             // Create a log entry, too.
@@ -314,7 +314,7 @@ class LOVD_Object
                 ' AND tab.transcriptid = subq.transcriptid) WHERE ' .
                 $sFRSearchCondition;
         }
-        $oResult = $_DB->query($oQuery, $aArgs);
+        $oResult = $_DB->q($oQuery, $aArgs);
         require_once ROOT_PATH . 'inc-lib-form.php';
 
         // Determine LOVD object to which F&R column belongs.
@@ -652,7 +652,7 @@ class LOVD_Object
         if (!defined('LOG_EVENT')) {
             define('LOG_EVENT', $this->sObject . '::deleteEntry()');
         }
-        $q = $_DB->query($sSQL, array_values($aIDs));
+        $q = $_DB->q($sSQL, array_values($aIDs));
 
         // Setup and run the revision table SQL.
         if ($bRev) {
@@ -660,7 +660,7 @@ class LOVD_Object
             // Update the existing revision record.
             // We could just check for a valid_to of 9999-12-31, but this
             //  is more flexible if we choose a different format.
-            $qRevisionUpdate = $_DB->query(
+            $qRevisionUpdate = $_DB->q(
                 'UPDATE ' . constant($this->sTable . '_REV') . '
                  SET valid_to = NOW(), deleted = 1, deleted_by = ?, reason = CONCAT(reason, "\r\n", ?)
                  WHERE ' . implode(' = ? AND ', array_keys($aIDs)) . ' = ? AND valid_to >= NOW()
@@ -740,7 +740,7 @@ class LOVD_Object
                 $aIDs = array($sIDColumn => $ID);
             }
 
-            $bEntryExists = (bool) $_DB->query('
+            $bEntryExists = (bool) $_DB->q('
                 SELECT 1
                 FROM ' . constant($this->sTable) . '
                 WHERE ' . implode(' = ? AND ', array_keys($aIDs)) . ' = ? LIMIT 1',
@@ -750,7 +750,7 @@ class LOVD_Object
             if (isset($this->bEntryExists)) {
                 return $this->bEntryExists;
             }
-            $bEntryExists = (bool) $_DB->query('
+            $bEntryExists = (bool) $_DB->q('
                 SELECT 1
                 FROM ' . constant($this->sTable) . ' LIMIT 1')->fetchColumn();
             $this->bEntryExists = $bEntryExists;
@@ -1354,7 +1354,7 @@ class LOVD_Object
         // Run the query, fetch the result and return.
         // We'll return false when we failed.
         $nCount = false;
-        $qCount = $_DB->query($sSQLOut, $aArgs, false);
+        $qCount = $_DB->q($sSQLOut, $aArgs, false);
         if ($qCount !== false) {
             $nCount = $qCount->fetchColumn();
         }
@@ -1369,11 +1369,11 @@ class LOVD_Object
             if ($_INI['database']['driver'] == 'mysql') {
                 $this->aSQLViewList['SELECT'] = 'SQL_CALC_FOUND_ROWS ' . $this->aSQLViewList['SELECT'];
                 $this->aSQLViewList['LIMIT'] = '0';
-                $_DB->query($this->buildSQL($this->aSQLViewList), $aArgs);
-                $nCount = $_DB->query('SELECT FOUND_ROWS()')->fetchColumn();
+                $_DB->q($this->buildSQL($this->aSQLViewList), $aArgs);
+                $nCount = $_DB->q('SELECT FOUND_ROWS()')->fetchColumn();
             } else {
                 // Super inefficient, only for low-volume (sqlite) databases!
-                $nCount = count($_DB->query($this->buildSQL($this->aSQLViewList), $aArgs)->fetchAllColumn());
+                $nCount = count($_DB->q($this->buildSQL($this->aSQLViewList), $aArgs)->fetchAllColumn());
             }
         }
 
@@ -1443,7 +1443,7 @@ class LOVD_Object
         if (!defined('LOG_EVENT')) {
             define('LOG_EVENT', $this->sObject . '::insertEntry()');
         }
-        $q = $_DB->query($sSQL, $aSQL, $bHalt, true);
+        $q = $_DB->q($sSQL, $aSQL, $bHalt, true);
         if (!$bHalt && $q === false) {
             return false;
         }
@@ -1474,7 +1474,7 @@ class LOVD_Object
             // Use the reason, if provided in the $aData array.
             $aSQL[] = 'Record created' . (empty($aData['reason'])? '' : ': ' . $aData['reason']);
             $sRevSQL .= ') VALUES (?' . str_repeat(', ?', count($aSQL) - 1) . ')';
-            $qRevisionInsert = $_DB->query($sRevSQL, $aSQL, true, true);
+            $qRevisionInsert = $_DB->q($sRevSQL, $aSQL, true, true);
 
             // If any of the queries fail, then rollback and return false. Otherwise, commit.
             if (!$q || !$qRevisionInsert) {
@@ -1508,7 +1508,7 @@ class LOVD_Object
 
         if ($this->sSQLPreLoadEntry !== '') {
             // $sSQLPreLoadEntry is defined, execute it.
-            $_DB->query($this->sSQLPreLoadEntry);
+            $_DB->q($this->sSQLPreLoadEntry);
         }
 
         // Prepare ID variable, to always be in the array('id' => 1) format.
@@ -1525,7 +1525,7 @@ class LOVD_Object
         } else {
             $sSQL = 'SELECT * FROM ' . constant($this->sTable) . ' WHERE ' . implode(' = ? AND ', array_keys($aIDs)) . ' = ?';
         }
-        $q = $_DB->query($sSQL, array_values($aIDs), false);
+        $q = $_DB->q($sSQL, array_values($aIDs), false);
         if ($q) {
             $zData = $q->fetchAssoc();
         }
@@ -2103,7 +2103,7 @@ class LOVD_Object
             }
             // Read in the existing record from the revision table to be used to compare against the changes.
             // TODO What if we do not find any records in the revision table? Currently it will crasy with an error.
-            $aDataOld = $_DB->query('SELECT * FROM ' . constant($this->sTable) . ' WHERE ' . implode(' = ? AND ', array_keys($aIDs)) . ' = ?',
+            $aDataOld = $_DB->q('SELECT * FROM ' . constant($this->sTable) . ' WHERE ' . implode(' = ? AND ', array_keys($aIDs)) . ' = ?',
                 array_values($aIDs))->fetchAssoc();
         }
 
@@ -2150,7 +2150,7 @@ class LOVD_Object
         if (!defined('LOG_EVENT')) {
             define('LOG_EVENT', $this->sObject . '::updateEntry()');
         }
-        $q = $_DB->query($sSQL, array_values($aSQL), true, true);
+        $q = $_DB->q($sSQL, array_values($aSQL), true, true);
 
         // Setup and run the revision table SQL.
         if ($bRev) {
@@ -2174,7 +2174,7 @@ class LOVD_Object
             // Update the existing revision record.
             // We could just check for a valid_to of 9999-12-31, but this
             //  is more flexible if we choose a different format.
-            $qRevisionUpdate = $_DB->query('
+            $qRevisionUpdate = $_DB->q('
                 UPDATE ' . constant($this->sTable . '_REV') . '
                 SET valid_to = ?
                 WHERE ' . implode(' = ? AND ', array_keys($aIDs)) . ' = ? AND valid_to >= NOW()
@@ -2183,7 +2183,7 @@ class LOVD_Object
 
             // Create the SQL for inserting a new revision record.
             $sRevSQL = 'INSERT INTO ' . constant($this->sTable . '_REV') . ' (`' . implode('`, `', array_keys($aSQLTotal)) . '`) VALUES (?' . str_repeat(', ?', count($aSQLTotal) - 1) . ')';
-            $qRevisionInsert = $_DB->query($sRevSQL, array_values($aSQLTotal), true, true);
+            $qRevisionInsert = $_DB->q($sRevSQL, array_values($aSQLTotal), true, true);
 
             // If any of the queries fail, then rollback and return false. Otherwise, commit.
             if (!$q || !$qRevisionInsert || !$qRevisionUpdate) {
@@ -2230,7 +2230,7 @@ class LOVD_Object
         }
 
         if ($this->sSQLPreViewEntry !== '') {
-            $_DB->query($this->sSQLPreViewEntry);
+            $_DB->q($this->sSQLPreViewEntry);
         }
 
         // Because a ViewEntry query often contains many tables, find out the table's alias, if used.
@@ -2269,7 +2269,7 @@ class LOVD_Object
                ' GROUP BY ' . $this->aSQLViewEntry['GROUP_BY']);
 
         // Run the actual query.
-        $zData = $_DB->query($sSQL, array_values($aIDs))->fetchAssoc();
+        $zData = $_DB->q($sSQL, array_values($aIDs))->fetchAssoc();
         // If the user has no rights based on the statusid column, we don't have a $zData.
         if (!$zData) {
             // Don't give away information about the ID: just pretend the entry does not exist.
@@ -2613,7 +2613,7 @@ class LOVD_Object
                             'GROUP_BY' => $this->aSQLViewList['GROUP_BY'],
                             'HAVING' => $this->aSQLViewList['HAVING'],
                         ));
-                        $q = $_DB->query($sSQL, $aArgs);
+                        $q = $_DB->q($sSQL, $aArgs);
                         while ($zData = $q->fetchAssoc()) {
                             $zData = $this->generateRowID($zData);
                             // We only need the row_id here for knowing which ones we need to check.
@@ -2681,12 +2681,12 @@ class LOVD_Object
 
             // Run the viewList query.
             // FIXME; what if using AJAX? Probably we should generate a number here, if this query fails, telling the system to try once more. If that fails also, the JS should throw a general error, maybe.
-            $q = $_DB->query($sSQL, $aArgs);
+            $q = $_DB->q($sSQL, $aArgs);
 
             // Now, get the total number of hits as if no LIMIT was used (when we have used the proper SELECT syntax). Note that $nTotal gets overwritten here.
             if ($bSQLCALCFOUNDROWS) {
                 // FIXME: 't' needs to be recalculated as well!
-                $nTotal = $_DB->query('SELECT FOUND_ROWS()')->fetchColumn();
+                $nTotal = $_DB->q('SELECT FOUND_ROWS()')->fetchColumn();
                 $aSessionViewList['counts'][$sFilterMD5]['n'] = $nTotal;
                 $aSessionViewList['counts'][$sFilterMD5]['d'] = time();
                 $bTrueCount = true;

--- a/src/class/pedigree.php
+++ b/src/class/pedigree.php
@@ -4,11 +4,11 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-12-22
- * Modified    : 2013-03-29
- * For LOVD    : 3.0-04
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
- * Programmer  : Ing. Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
  * This file is part of LOVD.
@@ -69,7 +69,7 @@ class Pedigree
         }
 
         // Make sure the individual actually exists.
-        if (!$_DB->query('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($nID))->fetchColumn()) {
+        if (!$_DB->q('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($nID))->fetchColumn()) {
             lovd_displayError('ObjectError', 'Pedigree::__construct() called with non-existing Individual ID ' . $nID . '.');
         }
 
@@ -81,7 +81,7 @@ class Pedigree
         do {
             // I don't think I can do a prepared statement, because the IN () range can change over time.
             $sFROM = 'AS parent FROM ' . TABLE_INDIVIDUALS . ' WHERE id IN (?' . str_repeat(', ?', count($aParentIDs)-1) . ') HAVING parent IS NOT NULL';
-            $q = $_DB->query('SELECT DISTINCT `fatherid` ' . $sFROM . ' UNION ' .
+            $q = $_DB->q('SELECT DISTINCT `fatherid` ' . $sFROM . ' UNION ' .
                              'SELECT DISTINCT `motherid` ' . $sFROM, array_merge($aParentIDs, $aParentIDs));
             $aIDs = $q->fetchAllColumn();
             if ($aIDs) {
@@ -119,7 +119,7 @@ class Pedigree
             // Try and find a spouse.
             $nID = $aIDs[0];
             // Unfortunately, we don't know the gender yet!
-            $aSpouseIDs = array_unique($_DB->query('SELECT DISTINCT `fatherid` FROM ' . TABLE_INDIVIDUALS . ' WHERE `motherid` = ? UNION
+            $aSpouseIDs = array_unique($_DB->q('SELECT DISTINCT `fatherid` FROM ' . TABLE_INDIVIDUALS . ' WHERE `motherid` = ? UNION
                                                     SELECT DISTINCT `motherid` FROM ' . TABLE_INDIVIDUALS . ' WHERE `fatherid` = ?', array($nID, $nID))->fetchAllColumn());
             // Because this is a fake column, I need to str_pad the IDs.
             foreach ($aSpouseIDs as $key => $val) {
@@ -134,7 +134,7 @@ class Pedigree
         }
 
         // Get information about the individual(s) itself.
-        $q = $_DB->query('SELECT i.id, i.`Individual/Name` AS name, i.`Individual/Gender` AS gender, i.`fatherid` AS father, i.`motherid` AS mother, GROUP_CONCAT(i2d.diseaseid SEPARATOR ";") AS _diseases FROM ' . TABLE_INDIVIDUALS . ' AS i LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid) WHERE i.id IN (?' . str_repeat(', ?', count($aIDs)-1) . ') GROUP BY i.id', $aIDs);
+        $q = $_DB->q('SELECT i.id, i.`Individual/Name` AS name, i.`Individual/Gender` AS gender, i.`fatherid` AS father, i.`motherid` AS mother, GROUP_CONCAT(i2d.diseaseid SEPARATOR ";") AS _diseases FROM ' . TABLE_INDIVIDUALS . ' AS i LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid) WHERE i.id IN (?' . str_repeat(', ?', count($aIDs)-1) . ') GROUP BY i.id', $aIDs);
         while ($z = $q->fetchAssoc()) {
             $this->individuals[$z['id']] =
                  array(
@@ -157,7 +157,7 @@ class Pedigree
             $sSQLChildren .= ($nKey? ' AND' : '') . ' `' . ($this->individuals[$nID]['gender'] == 'm'? 'father' : 'mother') . 'id` = ?';
         }
         $sSQLChildren .= ' ORDER BY (`Individual/Date_of_birth` IS NOT NULL) DESC, `Individual/Date_of_birth`, id';
-        $aChildren = $_DB->query($sSQLChildren, $aIDs)->fetchAllColumn();
+        $aChildren = $_DB->q($sSQLChildren, $aIDs)->fetchAllColumn();
         $aChildrenTree = array();
         if ($aChildren) {
             foreach ($aChildren as $nChildID) {

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-27
- * Modified    : 2022-06-27
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -653,7 +653,7 @@ function lovd_mapVariants ()
 <DIV id="stickyheader" style="position : fixed; z-index : 10; width : 100%">
 <?php
 // Check for announcements. Ignore errors, in case the table doesn't exist yet.
-$qAnnouncements = @$_DB->query('SELECT id, type, announcement FROM ' . TABLE_ANNOUNCEMENTS . ' WHERE start_date <= NOW() AND end_date >= NOW()', array(), false);
+$qAnnouncements = @$_DB->q('SELECT id, type, announcement FROM ' . TABLE_ANNOUNCEMENTS . ' WHERE start_date <= NOW() AND end_date >= NOW()', array(), false);
 if ($qAnnouncements) {
     $zAnnouncements = $qAnnouncements->fetchAllAssoc();
 } else {
@@ -725,7 +725,7 @@ foreach ($zAnnouncements as $zAnnouncement) {
         // Add curator info to header.
         if ($sCurrSymbol && $sCurrGene) {
             $sCurators = '';
-            $aCurators = $_DB->query('
+            $aCurators = $_DB->q('
                 SELECT u.name, u.email
                 FROM ' . TABLE_USERS . ' AS u LEFT JOIN ' . TABLE_CURATES . ' AS u2g ON (u.id = u2g.userid)
                 WHERE u2g.geneid = ? AND u2g.allow_edit = 1 AND u2g.show_order != 0

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2022-10-21
+ * Modified    : 2022-11-22
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -792,7 +792,7 @@ class LOVD_VV
                 // Check for intronic and positions outside of the mRNA.
 
                 // Fetch transcript positions from the database.
-                $aTranscript = $_DB->query('
+                $aTranscript = $_DB->q('
                     SELECT position_c_mrna_start, position_c_mrna_end
                     FROM ' . TABLE_TRANSCRIPTS . ' WHERE id_ncbi = ?',
                     array($sRefSeqNM))->fetchAssoc();

--- a/src/configuration.php
+++ b/src/configuration.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-07-11
- * Modified    : 2022-05-27
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -79,9 +79,9 @@ if (!(PATH_COUNT <= 2 && $_SESSION['currdb'] && lovd_isAuthorized('gene', $_SESS
 
     // Print LOVD2-style type of selection list with genes this person is curator of (if LEVEL_CURATOR). If only one gene exists, select that gene inmediately.
     if ($_AUTH['level'] == LEVEL_CURATOR) {
-        $qGenes = $_DB->query('SELECT g.id, CONCAT(g.id, " (", g.name, ")") AS name FROM ' . TABLE_CURATES . ' AS c INNER JOIN ' . TABLE_GENES . ' AS g ON (c.geneid = g.id) WHERE c.userid = ? AND c.allow_edit = 1 ORDER BY g.id', array($_AUTH['id']));
+        $qGenes = $_DB->q('SELECT g.id, CONCAT(g.id, " (", g.name, ")") AS name FROM ' . TABLE_CURATES . ' AS c INNER JOIN ' . TABLE_GENES . ' AS g ON (c.geneid = g.id) WHERE c.userid = ? AND c.allow_edit = 1 ORDER BY g.id', array($_AUTH['id']));
     } else {
-        $qGenes = $_DB->query('SELECT g.id, CONCAT(g.id, " (", g.name, ")") AS name FROM ' . TABLE_GENES . ' AS g ORDER BY g.id', array());
+        $qGenes = $_DB->q('SELECT g.id, CONCAT(g.id, " (", g.name, ")") AS name FROM ' . TABLE_GENES . ' AS g ORDER BY g.id', array());
     }
     $aGenes = $qGenes->fetchAllRow();
     $nGenes = count($aGenes);
@@ -132,7 +132,7 @@ $_T->printTitle();
 
 // Some info & statistics.
 $aVarStatuses = array_combine(array_keys($_SETT['data_status']), array_fill(0, count($_SETT['data_status']), 0));
-$aVarCounts = $_DB->query('SELECT vog.statusid, COUNT(DISTINCT vog.id) FROM ' . TABLE_TRANSCRIPTS . ' AS t INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id) WHERE t.geneid = ? GROUP BY vog.statusid ORDER BY statusid', array($_SESSION['currdb']))->fetchAllCombine()
+$aVarCounts = $_DB->q('SELECT vog.statusid, COUNT(DISTINCT vog.id) FROM ' . TABLE_TRANSCRIPTS . ' AS t INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid) INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vot.id = vog.id) WHERE t.geneid = ? GROUP BY vog.statusid ORDER BY statusid', array($_SESSION['currdb']))->fetchAllCombine()
     + $aVarStatuses;
 ksort($aVarCounts);
 // In progress would just confuse users, so remove if it's not present.
@@ -178,7 +178,7 @@ print('</TD></TR></TABLE><BR>' . "\n\n");
 
 // Do some basic checks to try and trigger curator's actions.
 // It is important to have at least one transcript.
-$nTranscript = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_TRANSCRIPTS . ' WHERE geneid = ?', array($_SESSION['currdb']))->fetchColumn();
+$nTranscript = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_TRANSCRIPTS . ' WHERE geneid = ?', array($_SESSION['currdb']))->fetchColumn();
 if (!$nTranscript) {
     lovd_showInfoTable('<SPAN class="S11">You currently do not have a transcript configured for the ' . $_SESSION['currdb'] . ' gene database. Without a transcript added, you can only store genomic variants, and thus you will not have any gene-specific variant overviews.<BR>Please <A href="transcripts?create&amp;target=' . $_SESSION['currdb'] . '">add a transcript to your gene</A>.</SPAN>', 'warning');
 }
@@ -186,7 +186,7 @@ if (!$nTranscript) {
 
 
 // Curators do not have access to the Users tab. But if needed, they should be able to contact the manager, when available.
-$aManagers = $_DB->query('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ? ORDER BY name', array(LEVEL_MANAGER))->fetchAllAssoc();
+$aManagers = $_DB->q('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ? ORDER BY name', array(LEVEL_MANAGER))->fetchAllAssoc();
 if (!$aManagers) {
     $aManagers = array($_SETT['admin']);
 }

--- a/src/diseases.php
+++ b/src/diseases.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-07-27
- * Modified    : 2022-07-01
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -93,7 +93,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     //  starts with a digit of at least 1 but no higher than 6, check first if
     //  we know this integer as an OMIM ID.
     if (strlen($_PE[1]) == 6 && $_PE[1][0] && (int) $_PE[1][0] < 7) {
-        $nDisease = $_DB->query(
+        $nDisease = $_DB->q(
             'SELECT id FROM ' . TABLE_DISEASES . ' WHERE id_omim = ?',
             array($_PE[1]))->fetchColumn();
         if ($nDisease) {
@@ -169,7 +169,7 @@ if (PATH_COUNT == 2 && !ctype_digit($_PE[1]) && !ACTION) {
     // Try to find a disease by its abbreviation and forward.
     // When we have multiple hits, refer to listView.
 
-    $aDiseases = $_DB->query('SELECT id FROM ' . TABLE_DISEASES . ' WHERE symbol = ?', array($_PE[1]))->fetchAllColumn();
+    $aDiseases = $_DB->q('SELECT id FROM ' . TABLE_DISEASES . ' WHERE symbol = ?', array($_PE[1]))->fetchAllColumn();
     $n = count($aDiseases);
     if (!$n) {
         define('PAGE_TITLE', lovd_getCurrentPageTitle());
@@ -236,7 +236,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                 foreach ($_POST['genes'] as $sGene) {
                     // Add gene to disease.
                     // FIXME; Nu dat PDO beschikbaar is, doe dit in een prepared statement met multiple executes.
-                    $q = $_DB->query('INSERT INTO ' . TABLE_GEN2DIS . ' VALUES (?, ?)', array($sGene, $nID), false);
+                    $q = $_DB->q('INSERT INTO ' . TABLE_GEN2DIS . ' VALUES (?, ?)', array($sGene, $nID), false);
                     if (!$q) {
                         // Silent error.
                         lovd_writeLog('Error', LOG_EVENT, 'Disease information entry ' . $nID . ' - ' . $_POST['symbol'] . ' - could not be added to gene ' . $sGene);
@@ -368,7 +368,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
                 }
             }
             if ($aToRemove) {
-                $q = $_DB->query('DELETE FROM ' . TABLE_GEN2DIS . ' WHERE diseaseid = ? AND geneid IN (?' . str_repeat(', ?', count($aToRemove) - 1) . ')', array_merge(array($nID), $aToRemove), false);
+                $q = $_DB->q('DELETE FROM ' . TABLE_GEN2DIS . ' WHERE diseaseid = ? AND geneid IN (?' . str_repeat(', ?', count($aToRemove) - 1) . ')', array_merge(array($nID), $aToRemove), false);
                 if (!$q) {
                     // Silent error.
                     // FIXME; deze log entries zijn precies andersom dan bij create (wat wordt aan wat toegevoegd/verwijderd). Dat moeten we standaardiseren, maar wellicht even overleggen over LOVD-breed.
@@ -542,7 +542,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
         'not be deleted, but remain in the database.', 'warning');
 
     if ($bValidPassword) {
-        $nCount = $_DB->query('SELECT count(DISTINCT p.id)
+        $nCount = $_DB->q('SELECT count(DISTINCT p.id)
                                FROM ' . TABLE_DISEASES . ' AS d
                                 LEFT OUTER JOIN ' . TABLE_PHENOTYPES . ' AS p ON (d.id = p.diseaseid)
                                WHERE d.id = ?', array($nID))->fetchColumn();
@@ -773,7 +773,7 @@ if (PATH_COUNT == 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && ACTION ==
         $_DB->beginTransaction();
         foreach ($_POST['columns'] as $nOrder => $sColID) {
             $nOrder ++; // Since 0 is the first key in the array.
-            $_DB->query('UPDATE ' . TABLE_SHARED_COLS . ' SET col_order = ? WHERE ' . $sUnit . 'id = ? AND colid = ?', array($nOrder, $nID, $sCategory . '/' . $sColID));
+            $_DB->q('UPDATE ' . TABLE_SHARED_COLS . ' SET col_order = ? WHERE ' . $sUnit . 'id = ? AND colid = ?', array($nOrder, $nID, $sCategory . '/' . $sColID));
         }
         $_DB->commit();
 
@@ -800,7 +800,7 @@ if (PATH_COUNT == 3 && ctype_digit($_PE[1]) && $_PE[2] == 'columns' && ACTION ==
     $_T->printTitle();
 
     // Retrieve column IDs in current order.
-    $aColumns = $_DB->query('SELECT SUBSTRING(colid, LOCATE("/", colid)+1) FROM ' . TABLE_SHARED_COLS . ' WHERE ' . $sUnit . 'id = ? ORDER BY col_order ASC', array($nID))->fetchAllColumn();
+    $aColumns = $_DB->q('SELECT SUBSTRING(colid, LOCATE("/", colid)+1) FROM ' . TABLE_SHARED_COLS . ' WHERE ' . $sUnit . 'id = ? ORDER BY col_order ASC', array($nID))->fetchAllColumn();
 
     if (!count($aColumns)) {
         lovd_showInfoTable('No columns found!', 'stop');

--- a/src/download.php
+++ b/src/download.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -145,7 +145,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
         if ($_AUTH && $_AUTH['level'] >= LEVEL_CURATOR) {
             $sFilter = 'gene';
         } else {
-            $bAllowDownload = $_DB->query('SELECT allow_download FROM ' . TABLE_GENES . ' WHERE id = ?', array($ID))->fetchColumn();
+            $bAllowDownload = $_DB->q('SELECT allow_download FROM ' . TABLE_GENES . ' WHERE id = ?', array($ID))->fetchColumn();
             if ($bAllowDownload) {
                 $sFilter = 'gene_public';
             } else {
@@ -434,7 +434,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
                     'Screening' => 'Screenings');
                 $qHiddenCols = 'SELECT id, SUBSTRING_INDEX(id, "/", 1) AS category FROM ' .
                                TABLE_COLS . ' WHERE public_view = ?';
-                $aHiddenCols = $_DB->query($qHiddenCols, array('0'))->fetchAllAssoc();
+                $aHiddenCols = $_DB->q($qHiddenCols, array('0'))->fetchAllAssoc();
                 foreach($aHiddenCols as $aHiddenCol) {
                     $sObject = $aObjectTranslations[$aHiddenCol['category']];
                     $aObjects[$sObject]['hide_columns'][] = $aHiddenCol['id'];
@@ -592,7 +592,7 @@ foreach ($aObjectsToBeFiltered as $sObject) {
     //  I could also fetch the IDs in VOT from my own VOGs, then get all
     //   transcript IDs from all VOT IDs, then get all gene IDs.
     if ($aSettings['prefetch'] || count($aSettings['filter_other'])) {
-        $aObjects[$sObject]['data'] = $_DB->query($aObjects[$sObject]['query'], $aObjects[$sObject]['args'])->fetchAllAssoc();
+        $aObjects[$sObject]['data'] = $_DB->q($aObjects[$sObject]['query'], $aObjects[$sObject]['args'])->fetchAllAssoc();
 
         // Check if we, now that we have the data fetched, need to apply other filters,
         foreach ($aSettings['filter_other'] as $sObjectToFilter => $aFiltersToRun) {
@@ -674,7 +674,7 @@ foreach (
             array($aObjects[$sObject]['filters']['id']) : array_values($aObjects[$sObject]['filters']['id']));
         sort($aIDs); // Makes the reporting prettier.
         $sObjectColumn = strtolower(preg_replace('/s$/', 'id', $sObject));
-        $aInactiveColumns = $_DB->query('
+        $aInactiveColumns = $_DB->q('
             SELECT DISTINCT colid 
             FROM ' . TABLE_SHARED_COLS . '
             WHERE colid NOT IN (
@@ -706,7 +706,7 @@ foreach ($aObjects as $sObject => $aSettings) {
     // So saving two queries, and it's easier code, at the cost of additional memory usage.
     // FIXME: Perhaps, if we have a 'hide_columns' setting, modify the query to not select these? May save a lot of memory.
     if (empty($aSettings['data'])) {
-        $aSettings['data'] = $_DB->query($aObjects[$sObject]['query'], $aObjects[$sObject]['args'])->fetchAllAssoc();
+        $aSettings['data'] = $_DB->q($aObjects[$sObject]['query'], $aObjects[$sObject]['args'])->fetchAllAssoc();
     }
 
     // Print comments.
@@ -738,7 +738,7 @@ foreach ($aObjects as $sObject => $aSettings) {
     if ($sObject == 'Variants_On_Transcripts') {
         // Since we joined to the VOG table to enable filtering, we've got all those columns, too.
         // Just for VOT, do a describe to find out which columns are VOT.
-        $aColumns = $_DB->query('DESCRIBE ' . TABLE_VARIANTS_ON_TRANSCRIPTS)->fetchAllColumn();
+        $aColumns = $_DB->q('DESCRIBE ' . TABLE_VARIANTS_ON_TRANSCRIPTS)->fetchAllColumn();
     } else {
         $aColumns = array_keys($aSettings['data'][0]);
     }

--- a/src/inc-auth.php
+++ b/src/inc-auth.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-23
- * Modified    : 2021-11-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -39,7 +39,7 @@ if (!defined('ROOT_PATH')) {
 $_AUTH = false;
 
 if (isset($_SESSION['auth']) && is_array($_SESSION['auth'])) {
-    $_SESSION['auth'] = @$_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE username = ? AND password = ? AND login_attempts < 3', array($_SESSION['auth']['username'], $_SESSION['auth']['password']), false)->fetchAssoc();
+    $_SESSION['auth'] = @$_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE username = ? AND password = ? AND login_attempts < 3', array($_SESSION['auth']['username'], $_SESSION['auth']['password']), false)->fetchAssoc();
     if (is_array($_SESSION['auth'])) {
         $_AUTH = & $_SESSION['auth'];
 
@@ -47,7 +47,7 @@ if (isset($_SESSION['auth']) && is_array($_SESSION['auth'])) {
         $_AUTH['curates']      = array();
         $_AUTH['collaborates'] = array();
         if ($_AUTH['level'] < LEVEL_MANAGER) {
-            $q = $_DB->query('SELECT geneid, allow_edit FROM ' . TABLE_CURATES . ' WHERE userid = ?', array($_AUTH['id']));
+            $q = $_DB->q('SELECT geneid, allow_edit FROM ' . TABLE_CURATES . ' WHERE userid = ?', array($_AUTH['id']));
             while ($r = $q->fetchRow()) {
                 if ($r[1]) {
                     $_AUTH['curates'][] = $r[0];
@@ -62,7 +62,7 @@ if (isset($_SESSION['auth']) && is_array($_SESSION['auth'])) {
         $_AUTH['saved_work'] = (!empty($_AUTH['saved_work'])? ($_AUTH['saved_work'][0] == 'a'? unserialize($_AUTH['saved_work']) : json_decode($_AUTH['saved_work'])) : array());
 
         // Get an array of IDs of users that share their permissions with current user.
-        $q = $_DB->query('SELECT userid_from, allow_edit FROM ' . TABLE_COLLEAGUES .
+        $q = $_DB->q('SELECT userid_from, allow_edit FROM ' . TABLE_COLLEAGUES .
                         ' WHERE userid_to = ?', array($_AUTH['id']), false);
         if ($q === false) {
             // Query to TABLE_COLLEAGUES failed (note: this table was introduced in 3.0-14e).

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2022-11-22
+ * Modified    : 2022-11-23
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -696,10 +696,30 @@ if (!class_exists('PDO')) {
 // Initiate Database Connection.
 require ROOT_PATH . 'class/PDO.php';
 if ($_INI['database']['driver'] == 'mysql') {
-    $_DB = new LOVD_PDO($_INI['database']['driver'], 'host=' . $_INI['database']['hostname'] . ';dbname=' . $_INI['database']['database'], $_INI['database']['username'], $_INI['database']['password']);
+    // This method for setting the charset works also before 5.3.6, when "charset" was introduced in the DSN.
+    // Fix #4; Implement fix for PHP 5.3.0 on Windows, where PDO::MYSQL_ATTR_INIT_COMMAND by accident is not available.
+    // https://bugs.php.net/bug.php?id=47224                  (other constants were also lost, but we don't use them)
+    // Can't define a class' constant, so I'll have to use this one. This can be removed (and MYSQL_ATTR_INIT_COMMAND
+    // below restored to PDO::MYSQL_ATTR_INIT_COMMAND) once we're sure they're no other 5.3.0 users left.
+    if (!defined('MYSQL_ATTR_INIT_COMMAND')) {
+        // Still needs check though, in case two PDO connections are opened.
+        define('MYSQL_ATTR_INIT_COMMAND', 1002);
+    }
+    $aOptions = array(
+        // ONLY_FULL_GROUP_BY is causing issues; even if we try to play nice,
+        //  the totally unnecessary MIN() and MAX() calls slow down queries a lot. See #386.
+        MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8, SQL_MODE = REPLACE(REPLACE(@@SQL_MODE, "NO_ZERO_DATE", ""), "ONLY_FULL_GROUP_BY", "")',
+        PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => TRUE,
+    );
+    $_DB = new LOVD_PDO(
+        $_INI['database']['driver'] . ':host=' . $_INI['database']['hostname'] . ';dbname=' . $_INI['database']['database'],
+        $_INI['database']['username'],
+        $_INI['database']['password'],
+        $aOptions
+    );
 } elseif ($_INI['database']['driver'] == 'sqlite') {
     // SQLite.
-    $_DB = new LOVD_PDO($_INI['database']['driver'], $_INI['database']['database']);
+    $_DB = new LOVD_PDO($_INI['database']['driver'] . ':' . $_INI['database']['database']);
 } else {
     // Can't happen.
     exit;

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2022-08-29
+ * Modified    : 2022-11-22
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -717,13 +717,13 @@ if (function_exists('mb_internal_encoding')) {
 @ini_set('session.cookie_httponly', 1); // Available from 5.2.0.
 
 // Read system-wide configuration from the database.
-if ($_CONF = $_DB->query('SELECT * FROM ' . TABLE_CONFIG, false, false)) {
+if ($_CONF = $_DB->q('SELECT * FROM ' . TABLE_CONFIG, false, false)) {
     // Must be two-step, since $_CONF can be false and therefore does not have ->fetchAssoc().
     $_CONF = $_CONF->fetchAssoc();
     if ($_CONF) {
         // See if the database is read-only at the moment, due to an announcement with the configuration.
         // Ignore errors, in case the table doesn't exist yet.
-        $qAnnouncements = @$_DB->query('SELECT COUNT(*) FROM ' . TABLE_ANNOUNCEMENTS . ' WHERE start_date <= NOW() AND end_date >= NOW() AND lovd_read_only = 1', array(), false);
+        $qAnnouncements = @$_DB->q('SELECT COUNT(*) FROM ' . TABLE_ANNOUNCEMENTS . ' WHERE start_date <= NOW() AND end_date >= NOW() AND lovd_read_only = 1', array(), false);
         $_CONF['lovd_read_only'] = ($qAnnouncements && $qAnnouncements->fetchColumn());
     }
 }
@@ -739,7 +739,7 @@ if (!$_CONF) {
 }
 
 // Read LOVD status from the database.
-if ($_STAT = $_DB->query('SELECT * FROM ' . TABLE_STATUS, false, false)) {
+if ($_STAT = $_DB->q('SELECT * FROM ' . TABLE_STATUS, false, false)) {
     // Must be two-step, since $_STAT can be false and therefore does not have ->fetchAssoc().
     $_STAT = $_STAT->fetchAssoc();
 }
@@ -765,7 +765,7 @@ if (defined('MISSING_CONF') || defined('MISSING_STAT') || !preg_match('/^([1-9]\
     $aTables = array();
     // We can't put TABLE_PREFIX in an argument, since SHOW ... can't be prepared by PDO in some PHP versions.
     // Generated errors on 5.1.6, works fine on 5.3.3.
-    $q = $_DB->query('SHOW TABLES LIKE "' . TABLEPREFIX . '\_%"');
+    $q = $_DB->q('SHOW TABLES LIKE "' . TABLEPREFIX . '\_%"');
     while ($sCol = $q->fetchColumn()) {
         if (in_array($sCol, $_TABLES)) {
             $aTables[] = $sCol;
@@ -942,7 +942,7 @@ if (!defined('NOT_INSTALLED')) {
             );
         } else {
             $_SETT['admin'] = array('name' => '', 'email' => ''); // We must define the keys first, or the order of the keys will not be correct.
-            list($_SETT['admin']['name'], $_SETT['admin']['email']) = $_DB->query('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ? AND id > 0 ORDER BY id ASC', array(LEVEL_ADMIN))->fetchRow();
+            list($_SETT['admin']['name'], $_SETT['admin']['email']) = $_DB->q('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ? AND id > 0 ORDER BY id ASC', array(LEVEL_ADMIN))->fetchRow();
             // Add a cleaned email address, because perhaps the admin has multiple addresses.
             $_SETT['admin']['address_formatted'] = $_SETT['admin']['name'] . ' <' . str_replace(array("\r\n", "\r", "\n"), '>, <', trim($_SETT['admin']['email'])) . '>';
         }
@@ -984,7 +984,7 @@ if (!defined('NOT_INSTALLED')) {
     if (!in_array(lovd_getProjectFile(), array('/check_update.php'))) {
         // Load gene data.
         if (!LOVD_plus && !empty($_SESSION['currdb'])) {
-            $_SETT['currdb'] = @$_DB->query('SELECT * FROM ' . TABLE_GENES . ' WHERE id = ?', array($_SESSION['currdb']))->fetchAssoc();
+            $_SETT['currdb'] = @$_DB->q('SELECT * FROM ' . TABLE_GENES . ' WHERE id = ?', array($_SESSION['currdb']))->fetchAssoc();
             if (!$_SETT['currdb']) {
                 $_SESSION['currdb'] = false;
             } else {

--- a/src/inc-lib-actions.php
+++ b/src/inc-lib-actions.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-12-17
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -64,23 +64,23 @@ function lovd_addAllDefaultCustomColumns ($sObjectType, $ID, $nUserID = false)
     }
 
     // Gather all the required lists of columns.
-    $aCols = $_DB->query('SELECT c.*, (ac.colid IS NOT NULL) AS active FROM ' . TABLE_COLS . ' AS c LEFT OUTER JOIN ' . TABLE_ACTIVE_COLS . ' AS ac ON (c.id = ac.colid) WHERE c.id LIKE "' . $sCategory . '/%" AND (c.standard = 1 OR c.hgvs = 1)')->fetchAllAssoc();
-    $aActiveChecked = $_DB->query('DESCRIBE ' . $sTableName)->fetchAllColumn();
+    $aCols = $_DB->q('SELECT c.*, (ac.colid IS NOT NULL) AS active FROM ' . TABLE_COLS . ' AS c LEFT OUTER JOIN ' . TABLE_ACTIVE_COLS . ' AS ac ON (c.id = ac.colid) WHERE c.id LIKE "' . $sCategory . '/%" AND (c.standard = 1 OR c.hgvs = 1)')->fetchAllAssoc();
+    $aActiveChecked = $_DB->q('DESCRIBE ' . $sTableName)->fetchAllColumn();
     $nAdded = 0;
 
     // Loop columns to first do all ALTER TABLE's, if necessary.
     foreach ($aCols as $aCol) {
         if (!in_array($aCol['id'], $aActiveChecked)) {
-            $_DB->query('ALTER TABLE ' . $sTableName . ' ADD COLUMN `' . $aCol['id'] . '` ' . stripslashes($aCol['mysql_type']));
+            $_DB->q('ALTER TABLE ' . $sTableName . ' ADD COLUMN `' . $aCol['id'] . '` ' . stripslashes($aCol['mysql_type']));
         }
         if (!$aCol['active']) {
-            $_DB->query('INSERT INTO ' . TABLE_ACTIVE_COLS . ' VALUES(?, ?, NOW())', array($aCol['id'], $nUserID));
+            $_DB->q('INSERT INTO ' . TABLE_ACTIVE_COLS . ' VALUES(?, ?, NOW())', array($aCol['id'], $nUserID));
         }
     }
 
     // Then, actually add the column(s) to the specified object's data.
     foreach ($aCols as $aCol) {
-        $q = $_DB->query('INSERT IGNORE INTO ' . TABLE_SHARED_COLS . ' VALUES (' . $sSQLCols . ', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NULL, NULL)', array($ID, $aCol['id'], $aCol['col_order'], $aCol['width'], $aCol['mandatory'], $aCol['description_form'], $aCol['description_legend_short'], $aCol['description_legend_full'], $aCol['select_options'], $aCol['public_view'], $aCol['public_add'], $nUserID));
+        $q = $_DB->q('INSERT IGNORE INTO ' . TABLE_SHARED_COLS . ' VALUES (' . $sSQLCols . ', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NULL, NULL)', array($ID, $aCol['id'], $aCol['col_order'], $aCol['width'], $aCol['mandatory'], $aCol['description_form'], $aCol['description_legend_short'], $aCol['description_legend_full'], $aCol['select_options'], $aCol['public_view'], $aCol['public_add'], $nUserID));
         $nAdded += $q->rowCount();
     }
 

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2021-11-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -76,7 +76,7 @@ function lovd_checkDBID ($aData)
     $nIDtoIgnore = (!empty($aData['id'])? $aData['id'] : 0);
 
     // Check if the DBID entered is already in use by a variant entry excluding the current one.
-    $nHasDBID = $_DB->query('SELECT COUNT(id) FROM ' . TABLE_VARIANTS . ' WHERE `VariantOnGenome/DBID` = ? AND id != ?', array($aData['VariantOnGenome/DBID'], $nIDtoIgnore))->fetchColumn();
+    $nHasDBID = $_DB->q('SELECT COUNT(id) FROM ' . TABLE_VARIANTS . ' WHERE `VariantOnGenome/DBID` = ? AND id != ?', array($aData['VariantOnGenome/DBID'], $nIDtoIgnore))->fetchColumn();
     if ($nHasDBID && (!empty($sGenomeVariant) || !empty($aTranscriptVariants))) {
         // This is the standard query that will be used to determine if the DBID given is correct.
         $sSQL = 'SELECT COUNT(*) ' .
@@ -105,7 +105,7 @@ function lovd_checkDBID ($aData)
             $aArgs[] = sprintf('%010d', $nIDtoIgnore);
         }
         $sSQL .= $sWhere;
-        $nOptions = $_DB->query($sSQL, $aArgs)->fetchColumn();
+        $nOptions = $_DB->q($sSQL, $aArgs)->fetchColumn();
 
         if (!$nOptions) {
             return false;
@@ -447,7 +447,7 @@ function lovd_fetchDBID ($aData)
             $sSQL .= $sWhere;
         }
 
-        $aDBIDOptions = $_DB->query($sSQL, $aArgs)->fetchAllColumn();
+        $aDBIDOptions = $_DB->q($sSQL, $aArgs)->fetchAllColumn();
 
         // Set the default for the DBID.
         $sDBID = 'chr' . $aData['chromosome'] . '_999999';
@@ -500,7 +500,7 @@ function lovd_fetchDBID ($aData)
                     $sSQL .= ' AND `VariantOnGenome/DBID` >= ?';
                     $aArgs[] = $aDBIDsSeen[$aData['chromosome']];
                 }
-                $nDBIDnewNumber = $_DB->query($sSQL, $aArgs)->fetchColumn();
+                $nDBIDnewNumber = $_DB->q($sSQL, $aArgs)->fetchColumn();
                 // Update the cache!
                 $aDBIDsSeen[$aData['chromosome']] = $sSymbol . '_' . sprintf('%06d', ($nDBIDnewNumber - 1));
             } else {
@@ -515,7 +515,7 @@ function lovd_fetchDBID ($aData)
                 //  risk of missing variants is very small (they have to be on
                 //  a different chromosome).
                 $sSymbol = $aGenes[0];
-                $nDBIDnewNumber = $_DB->query('
+                $nDBIDnewNumber = $_DB->q('
                     SELECT IFNULL(RIGHT(MAX(`VariantOnGenome/DBID`), 6), 0) + 1
                     FROM ' . TABLE_VARIANTS . '
                     WHERE chromosome = ? AND `VariantOnGenome/DBID` REGEXP ?',
@@ -839,7 +839,7 @@ function lovd_setUpdatedDate ($aGenes, $bAuth = true)
     }
 
     // Just update the database and we'll see what happens.
-    $q = $_DB->query('
+    $q = $_DB->q('
         UPDATE ' . TABLE_GENES . '
         SET updated_by = ?, updated_date = NOW()
         WHERE id IN (?' . str_repeat(', ?', count($aGenes) - 1) . ')',

--- a/src/inc-lib-users.php
+++ b/src/inc-lib-users.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-04-21
- * Modified    : 2020-09-11
- * For LOVD    : 3.0-25
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2014-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
@@ -104,7 +104,7 @@ function lovd_mailNewColleagues ($sUserID, $sUserFullname, $sUserInstitute, $sUs
     $sPlaceholders = '(?' . str_repeat(',?', count($aNewColleagues)-1) . ')';
     $sColleagueQuery = 'SELECT id, name, institute, email FROM ' . TABLE_USERS . ' WHERE id IN ' .
         $sPlaceholders;
-    $zColleagues = $_DB->query($sColleagueQuery, $aNewColleagues)->fetchAllAssoc();
+    $zColleagues = $_DB->q($sColleagueQuery, $aNewColleagues)->fetchAllAssoc();
 
     $sApplicationURL = lovd_getInstallURL();
     $sGranterFullname = $_AUTH['name'];
@@ -172,7 +172,7 @@ function lovd_colleagueTableHTML ($sUserID, $sUserListID, $aColleagues = null, $
                    FROM ' . TABLE_COLLEAGUES . ' AS c
                     LEFT JOIN ' . TABLE_USERS . ' AS u ON (u.id = c.userid_to)
                    WHERE c.userid_from = ?';
-        $aColleagues = $_DB->query($sQuery, array($sUserID))->fetchAllAssoc();
+        $aColleagues = $_DB->q($sQuery, array($sUserID))->fetchAllAssoc();
     }
 
     $sEditStyleAttribute = ($bAllowGrantEdit? '' : 'display: none;');
@@ -298,13 +298,13 @@ function lovd_setColleagues ($sUserID, $sUserFullname, $sUserInsititute, $sUserE
     }
 
     $sOldColleaguesQuery = 'SELECT userid_to FROM ' . TABLE_COLLEAGUES . ' WHERE userid_from = ?';
-    $aOldColleagueIDs = $_DB->query($sOldColleaguesQuery, array($sUserID))->fetchAllColumn();
+    $aOldColleagueIDs = $_DB->q($sOldColleaguesQuery, array($sUserID))->fetchAllColumn();
     $aColleagueIDs = array(); // Array with new colleague IDs, to see who's new and who's removed.
 
     $_DB->beginTransaction();
 
     // Delete all current colleague records with given user in 'from' field.
-    $_DB->query('DELETE FROM ' . TABLE_COLLEAGUES . ' WHERE userid_from = ?', array($sUserID));
+    $_DB->q('DELETE FROM ' . TABLE_COLLEAGUES . ' WHERE userid_from = ?', array($sUserID));
 
     if (count($aColleagues)) {
         // Build parts for multi-row insert query.
@@ -317,7 +317,7 @@ function lovd_setColleagues ($sUserID, $sUserFullname, $sUserInsititute, $sUserE
             array_push($aData, $sUserID, $aColleague['id'], (int) $aColleague['allow_edit']);
         }
 
-        $_DB->query('INSERT INTO ' . TABLE_COLLEAGUES .
+        $_DB->q('INSERT INTO ' . TABLE_COLLEAGUES .
                     ' (userid_from, userid_to, allow_edit) VALUES ' . $sPlaceholders, $aData);
     }
     $_DB->commit();

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2022-10-20
+ * Modified    : 2022-11-22
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -832,7 +832,7 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
 
     if ($sCalcVersionDB < lovd_calculateVersion('3.0-alpha-07')) {
         // DROP VariantOnTranscript/DBID if it exists.
-        $aColumns = $_DB->query('DESCRIBE ' . TABLE_VARIANTS_ON_TRANSCRIPTS)->fetchAllColumn();
+        $aColumns = $_DB->q('DESCRIBE ' . TABLE_VARIANTS_ON_TRANSCRIPTS)->fetchAllColumn();
         if (in_array('VariantOnTranscript/DBID', $aColumns)) {
             $aUpdates['3.0-alpha-07'][] = 'ALTER TABLE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' DROP COLUMN `VariantOnTranscript/DBID`';
         }
@@ -840,7 +840,7 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
 
     if ($sCalcVersionDB < lovd_calculateVersion('3.0-alpha-07b')) {
         // DROP Individual/Times_Reported if it exists and copy its data to panel_size.
-        $aColumns = $_DB->query('DESCRIBE ' . TABLE_INDIVIDUALS)->fetchAllColumn();
+        $aColumns = $_DB->q('DESCRIBE ' . TABLE_INDIVIDUALS)->fetchAllColumn();
         if (in_array('Individual/Times_Reported', $aColumns)) {
             $aUpdates['3.0-alpha-07b'][] = 'UPDATE ' . TABLE_INDIVIDUALS . ' SET panel_size = `Individual/Times_Reported`';
             $aUpdates['3.0-alpha-07b'][] = 'ALTER TABLE ' . TABLE_INDIVIDUALS . ' DROP COLUMN `Individual/Times_Reported`';
@@ -869,11 +869,11 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
 
     if ($sCalcVersionDB < lovd_calculateVersion('3.0-beta-03b')) {
         // CHANGE DNA_published to Published_as in TABLE_VARIANTS & TABLE_VARIANTS_ON_TRANSCRIPTS if exists.
-        $aColumns = $_DB->query('DESCRIBE ' . TABLE_VARIANTS)->fetchAllColumn();
+        $aColumns = $_DB->q('DESCRIBE ' . TABLE_VARIANTS)->fetchAllColumn();
         if (in_array('VariantOnGenome/DNA_published', $aColumns)) {
             $aUpdates['3.0-beta-03b'][] = 'ALTER TABLE ' . TABLE_VARIANTS . ' CHANGE `VariantOnGenome/DNA_Published` `VariantOnGenome/Published_as` VARCHAR(100)';
         }
-        $aColumns = $_DB->query('DESCRIBE ' . TABLE_VARIANTS_ON_TRANSCRIPTS)->fetchAllColumn();
+        $aColumns = $_DB->q('DESCRIBE ' . TABLE_VARIANTS_ON_TRANSCRIPTS)->fetchAllColumn();
         if (in_array('VariantOnTranscript/DNA_published', $aColumns)) {
             $aUpdates['3.0-beta-03b'][] = 'ALTER TABLE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' CHANGE `VariantOnTranscript/DNA_Published` `VariantOnTranscript/Published_as` VARCHAR(100)';
         }
@@ -887,7 +887,7 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
 
     if ($sCalcVersionDB < lovd_calculateVersion('3.0-beta-05')) {
         // Make Phenotype/Inheritance long enough to actually fit the values in its selection list.
-        $aColumns = $_DB->query('DESCRIBE ' . TABLE_PHENOTYPES)->fetchAllColumn();
+        $aColumns = $_DB->q('DESCRIBE ' . TABLE_PHENOTYPES)->fetchAllColumn();
         if (in_array('Phenotype/Inheritance', $aColumns)) {
             $aUpdates['3.0-beta-05'][] = 'ALTER TABLE ' . TABLE_PHENOTYPES . ' MODIFY `Phenotype/Inheritance` VARCHAR(50)';
         }
@@ -1003,7 +1003,7 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
             foreach ($aSQL as $i => $sSQL) {
                 $i ++;
                 if (!$nSQLFailed) {
-                    $q = $_DB->query($sSQL, false, false); // This means that there is no SQL injection check here. But hey - these are our own queries.
+                    $q = $_DB->q($sSQL, false, false); // This means that there is no SQL injection check here. But hey - these are our own queries.
                     if (!$q) {
                         $nSQLFailed ++;
                         // Error when running query.
@@ -1058,7 +1058,7 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
         }
 
         // Remove update lock.
-        $_DB->query('UPDATE ' . TABLE_STATUS . ' SET lock_update = 0');
+        $_DB->q('UPDATE ' . TABLE_STATUS . ' SET lock_update = 0');
     }
 
     // Now that this is over, let the user proceed to whereever they were going!

--- a/src/index.php
+++ b/src/index.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-25
- * Modified    : 2017-07-20
- * For LOVD    : 3.0-20
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -41,7 +41,7 @@ if ($_AUTH && $_AUTH['level'] >= LEVEL_MANAGER) {
     $sFile = 'genes/' . $_SESSION['currdb'];
 } else {
 
-    $aGeneIDs = $_DB->query('SELECT id FROM ' . TABLE_GENES . ' LIMIT 2')->fetchAllColumn();
+    $aGeneIDs = $_DB->q('SELECT id FROM ' . TABLE_GENES . ' LIMIT 2')->fetchAllColumn();
     if (count($aGeneIDs) == 1) {
         $sFile = 'genes/' . $aGeneIDs[0];
     } else {

--- a/src/links.php
+++ b/src/links.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-04-19
- * Modified    : 2022-06-14
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -137,7 +137,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                     continue;
                 }
                 // Add custom link to column.
-                $q = $_DB->query('INSERT INTO ' . TABLE_COLS2LINKS . ' VALUES (?, ?)', array($sCol, $nID), false);
+                $q = $_DB->q('INSERT INTO ' . TABLE_COLS2LINKS . ' VALUES (?, ?)', array($sCol, $nID), false);
                 if (!$q) {
                     // Silent error.
                     lovd_writeLog('Error', LOG_EVENT, 'Custom link ' . $nID . ' - ' . $_POST['name'] . ' - could not be added to column ' . $sCol);
@@ -248,7 +248,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
             foreach ($aCols AS $sCol) {
                 if ($sCol && !in_array($sCol, $_POST['active_columns'])) {
                     // User has requested removal...
-                    $q = $_DB->query('DELETE FROM ' . TABLE_COLS2LINKS . ' WHERE colid = ? AND linkid = ?', array($sCol, $nID), false);
+                    $q = $_DB->q('DELETE FROM ' . TABLE_COLS2LINKS . ' WHERE colid = ? AND linkid = ?', array($sCol, $nID), false);
                     if (!$q) {
                         // Silent error.
                         lovd_writeLog('Error', LOG_EVENT, 'Custom link ' . $nID . ' - ' . $_POST['name'] . ' - could not be removed from column ' . $sCol);
@@ -270,7 +270,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
                 }
                 if (!in_array($sCol, $aCols)) {
                     // Add custom link to column.
-                    $q = $_DB->query('INSERT INTO ' . TABLE_COLS2LINKS . ' VALUES (?, ?)', array($sCol, $nID), false);
+                    $q = $_DB->q('INSERT INTO ' . TABLE_COLS2LINKS . ' VALUES (?, ?)', array($sCol, $nID), false);
                     if (!$q) {
                         // Silent error.
                         lovd_writeLog('Error', LOG_EVENT, 'Custom link ' . $nID . ' - ' . $_POST['name'] . ' - could not be added to column ' . $sCol);

--- a/src/login.php
+++ b/src/login.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-19
- * Modified    : 2020-07-09
- * For LOVD    : 3.0-24
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -55,7 +55,7 @@ if (!empty($_POST)) {
         // We're now also accepting unlocking accounts.
         if (!empty($_POST['username']) && !empty($_POST['password'])) {
             // First, retrieve account information.
-            $zUser = $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE username = ?', array($_POST['username']))->fetchAssoc();
+            $zUser = $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE username = ?', array($_POST['username']))->fetchAssoc();
 
             if ($zUser) {
                 // The user exists, now check account unlocking, locked accounts, successful and unsuccessful logins.
@@ -65,7 +65,7 @@ if (!empty($_POST)) {
                     lovd_writeLog('Auth', 'AuthError', $_SERVER['REMOTE_ADDR'] . ' (' . lovd_php_gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') is not in IP allow list for ' . $_POST['username'] . ': "' . $zUser['allowed_ip'] . '"');
 
                     // Provide manager information, so that the user knows where to go for help.
-                    $aManagers = $_DB->query('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ? ORDER BY name', array(LEVEL_MANAGER))->fetchAllAssoc();
+                    $aManagers = $_DB->q('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ? ORDER BY name', array(LEVEL_MANAGER))->fetchAllAssoc();
                     if (!$aManagers) {
                         $aManagers = array($_SETT['admin']);
                     }
@@ -96,7 +96,7 @@ if (!empty($_POST)) {
                     // Also update the password field, it needs to be used by the update password form, and force the change of password.
                     $_AUTH['password'] = $zUser['password_autogen'];
                     $_AUTH['password_force_change'] = 1;
-                    $_DB->query('UPDATE ' . TABLE_USERS . ' SET password = ?, phpsessid = ?, last_login = NOW(), login_attempts = 0, password_force_change = 1 WHERE id = ?', array($_AUTH['password'], session_id(), $_AUTH['id']));
+                    $_DB->q('UPDATE ' . TABLE_USERS . ' SET password = ?, phpsessid = ?, last_login = NOW(), login_attempts = 0, password_force_change = 1 WHERE id = ?', array($_AUTH['password'], session_id(), $_AUTH['id']));
 
                     header('Location: ' . lovd_getInstallURL() . 'users/' . $_AUTH['id'] . '?change_password');
                     exit;
@@ -144,10 +144,10 @@ if (!empty($_POST)) {
                     if (strlen($zUser['password']) == 32 && $_STAT['version'] >= '3.0-alpha-02') {
                         // User has logged in, so we have their password. Create salt and regenerate password hash for them.
                         $_SESSION['auth']['password'] = lovd_createPasswordHash($_POST['password']);
-                        $_DB->query('UPDATE ' . TABLE_USERS . ' SET password = ?, password_autogen = "", phpsessid = ?, last_login = NOW(), login_attempts = 0 WHERE id = ?', array($_SESSION['auth']['password'], session_id(), $_AUTH['id']));
+                        $_DB->q('UPDATE ' . TABLE_USERS . ' SET password = ?, password_autogen = "", phpsessid = ?, last_login = NOW(), login_attempts = 0 WHERE id = ?', array($_SESSION['auth']['password'], session_id(), $_AUTH['id']));
                     } else {
                         // FIXME; if this block is removed, keep this query.
-                        $_DB->query('UPDATE ' . TABLE_USERS . ' SET password_autogen = "", phpsessid = ?, last_login = NOW(), login_attempts = 0 WHERE id = ?', array(session_id(), $_AUTH['id']));
+                        $_DB->q('UPDATE ' . TABLE_USERS . ' SET password_autogen = "", phpsessid = ?, last_login = NOW(), login_attempts = 0 WHERE id = ?', array(session_id(), $_AUTH['id']));
                     }
 
                     // Check if referer is given, check it, then forward the user.
@@ -173,7 +173,7 @@ if (!empty($_POST)) {
 
                 // This may not actually update (user misspelled their username) but we can call the query anyway.
                 if ($_CONF['lock_users']) {
-                    $_DB->query('UPDATE ' . TABLE_USERS . ' SET login_attempts = login_attempts + 1 WHERE username = ? AND level < ' . LEVEL_ADMIN, array($_POST['username']), false);
+                    $_DB->q('UPDATE ' . TABLE_USERS . ' SET login_attempts = login_attempts + 1 WHERE username = ? AND level < ' . LEVEL_ADMIN, array($_POST['username']), false);
                 }
 
                 // Check if the user is locked, now.

--- a/src/logout.php
+++ b/src/logout.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-03-19
- * Modified    : 2019-08-28
- * For LOVD    : 3.0-22
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2019 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -38,7 +38,7 @@ if (!$_AUTH) {
     exit;
 }
 
-$_DB->query('UPDATE ' . TABLE_USERS . ' SET phpsessid = "" WHERE id = ?', array($_AUTH['id']), false);
+$_DB->q('UPDATE ' . TABLE_USERS . ' SET phpsessid = "" WHERE id = ?', array($_AUTH['id']), false);
 $nSec = time() - strtotime($_AUTH['last_login']);
 $sCurrDB = $_SESSION['currdb']; // Temp storage.
 $aMapping = (!isset($_SESSION['mapping'])? array() : $_SESSION['mapping']); // Temp storage.

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-23
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -158,7 +158,7 @@ if (PATH_COUNT == 1 && ACTION == 'create' && !empty($_GET['target']) && ctype_di
     lovd_requireAUTH($_SETT['user_level_settings']['submit_new_data']);
 
     $_GET['target'] = sprintf('%0' . $_SETT['objectid_length']['individuals'] . 'd', $_GET['target']);
-    $z = $_DB->query('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($_GET['target']))->fetchAssoc();
+    $z = $_DB->q('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($_GET['target']))->fetchAssoc();
     if (!$z) {
         define('PAGE_TITLE', lovd_getCurrentPageTitle());
         $_T->printHeader();
@@ -179,7 +179,7 @@ if (PATH_COUNT == 1 && ACTION == 'create' && !empty($_GET['target']) && ctype_di
         if (ctype_digit($_GET['diseaseid'])) {
             $_POST['diseaseid'] = sprintf('%0' . $_SETT['objectid_length']['diseases'] . 'd', $_GET['diseaseid']);
             // Check if there are phenotype columns enabled for this disease & check if the $_POST['diseaseid'] is actually linked to this individual.
-            if (!$_DB->query('SELECT COUNT(*) FROM ' . TABLE_IND2DIS . ' AS i2d INNER JOIN ' . TABLE_SHARED_COLS . ' AS sc USING(diseaseid) WHERE i2d.individualid = ? AND i2d.diseaseid = ?', array($_POST['individualid'], $_POST['diseaseid']))->fetchColumn()) {
+            if (!$_DB->q('SELECT COUNT(*) FROM ' . TABLE_IND2DIS . ' AS i2d INNER JOIN ' . TABLE_SHARED_COLS . ' AS sc USING(diseaseid) WHERE i2d.individualid = ? AND i2d.diseaseid = ?', array($_POST['individualid'], $_POST['diseaseid']))->fetchColumn()) {
                 lovd_errorAdd('diseaseid', htmlspecialchars($_POST['diseaseid']) . ' is not a valid disease id or no phenotype columns have been enabled for this disease.');
             }
         } else {
@@ -198,7 +198,7 @@ if (PATH_COUNT == 1 && ACTION == 'create' && !empty($_GET['target']) && ctype_di
     if (empty($_POST['diseaseid']) || lovd_error()) {
         // FIXME; Once we're sure there are no longer individuals with Healthy and something else, we can remove (d.id > 0) from the ORDER BY.
         $sSQL = 'SELECT d.id, CONCAT(d.symbol, " (", d.name, ")") FROM ' . TABLE_DISEASES . ' AS d INNER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (d.id = i2d.diseaseid) INNER JOIN ' . TABLE_SHARED_COLS . ' AS sc ON (d.id = sc.diseaseid) WHERE i2d.individualid = ? GROUP BY d.id ORDER BY (d.id > 0), d.symbol, d.name';
-        $aSelectDiseases = $_DB->query($sSQL, array($_POST['individualid']))->fetchAllCombine();
+        $aSelectDiseases = $_DB->q($sSQL, array($_POST['individualid']))->fetchAllCombine();
         if (!count($aSelectDiseases)) {
             // Wrong individual ID, individual without diseases, or diseases without phenotype columns.
             $_T->printHeader();
@@ -259,7 +259,7 @@ if (PATH_COUNT == 1 && ACTION == 'create' && !empty($_GET['target']) && ctype_di
 
             // Get genes which are modified only when phenotype, individual and variant are marked or public.
             if ($_POST['statusid'] >= STATUS_MARKED) {
-                $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
+                $aGenes = $_DB->q('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                       'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
                                       'INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vog.id = vot.id) ' .
                                       'INNER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s2v.variantid = vog.id) ' .
@@ -410,7 +410,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
 
             if (!$bSubmit && !(GET && ACTION == 'publish')) {
                 // Put $zData with the old values in $_SESSION for mailing.
-                $zData['diseaseid_'] = $_DB->query('SELECT name FROM ' . TABLE_DISEASES . ' WHERE id = ?', array($zData['diseaseid']))->fetchColumn();
+                $zData['diseaseid_'] = $_DB->q('SELECT name FROM ' . TABLE_DISEASES . ' WHERE id = ?', array($zData['diseaseid']))->fetchColumn();
                 $_SESSION['work']['edits']['phenotype'][$nID] = $zData;
             }
 
@@ -419,7 +419,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
 
             // Get genes which are modified only when phenotype, individual and variant are marked or public.
             if ($zData['statusid'] >= STATUS_MARKED || (isset($_POST['statusid']) && $_POST['statusid'] >= STATUS_MARKED)) {
-                $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
+                $aGenes = $_DB->q('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                       'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
                                       'INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vog.id = vot.id) ' .
                                       'INNER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s2v.variantid = vog.id) ' .
@@ -543,7 +543,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
             // Get genes which are modified before we delete the entry.
             // Only when phenotype, individual and variant are marked or public.
             if ($zData['statusid'] >= STATUS_MARKED) {
-                $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
+                $aGenes = $_DB->q('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                       'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
                                       'INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vog.id = vot.id) ' .
                                       'INNER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s2v.variantid = vog.id) ' .

--- a/src/references.php
+++ b/src/references.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2015-03-11
- * Modified    : 2022-06-16
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -91,11 +91,11 @@ if (PATH_COUNT >= 2 && (substr($sReference, 0, 4) == 'DOI:' || substr($sReferenc
         'VariantOnGenome' => array('allele_'),
         'Individual' => array('panelid', 'diseaseids'),
     );
-    $aColNames = $_DB->query('SELECT colid FROM ' . TABLE_COLS2LINKS . ' AS c2l LEFT JOIN ' . TABLE_LINKS . ' AS l ON (l.id = c2l.linkid) WHERE name = ?', array($sType))->fetchAllColumn();
+    $aColNames = $_DB->q('SELECT colid FROM ' . TABLE_COLS2LINKS . ' AS c2l LEFT JOIN ' . TABLE_LINKS . ' AS l ON (l.id = c2l.linkid) WHERE name = ?', array($sType))->fetchAllColumn();
     foreach ($aColNames as $sColName) {
         $sCategory = substr($sColName, 0, strpos($sColName . '/', '/'));
         $aTable = lovd_getTableInfoByCategory($sCategory);
-        $aData = $_DB->query('SELECT id FROM ' . $aTable['table_sql'] . ' WHERE `' . $sColName . '` LIKE ? LIMIT 1', array($sSearchPattern))->fetchAllColumn();
+        $aData = $_DB->q('SELECT id FROM ' . $aTable['table_sql'] . ' WHERE `' . $sColName . '` LIKE ? LIMIT 1', array($sSearchPattern))->fetchAllColumn();
         if (!empty($aData)) {
             if ($bImage){
                 header('Content-type: image/png');

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-20
- * Modified    : 2022-06-21
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -58,13 +58,13 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
         sleep(1);
 
         // Find account.
-        $zData = array($_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE username = ?',
+        $zData = array($_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE username = ?',
             array($_POST['username']))->fetchAssoc());
         if ($zData == array(false)) {
-            $zData = $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE email = ?',
+            $zData = $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE email = ?',
                 array($_POST['username']))->fetchAllAssoc();
             if (!$zData) {
-                $zData = $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE email REGEXP ?',
+                $zData = $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE email REGEXP ?',
                     array("(^|\r\n)" . $_POST['username'] . "(\r\n|$)"))->fetchAllAssoc();
             }
         }
@@ -104,7 +104,7 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
             }
 
             // Update database.
-            $_DB->query('UPDATE ' . TABLE_USERS . ' SET password_autogen = MD5(?) WHERE username = ?', array($sPasswd, $zData['username']));
+            $_DB->q('UPDATE ' . TABLE_USERS . ' SET password_autogen = MD5(?) WHERE username = ?', array($sPasswd, $zData['username']));
 
             lovd_writeLog('Auth', LOG_EVENT, $_SERVER['REMOTE_ADDR'] . ' (' . lovd_php_gethostbyaddr($_SERVER['REMOTE_ADDR']) . ') successfully reset password for account ' .
                 $_POST['username'] . ($_POST['username'] == $zData['username']? '' : ' (' . $zData['username'] . ')'));

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2022-06-06
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -49,7 +49,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
     // View all entries.
 
     if (!empty($_PE[1])) {
-        $sGene = $_DB->query('SELECT id FROM ' . TABLE_GENES . ' WHERE id = ?', array($_PE[1]))->fetchColumn();
+        $sGene = $_DB->q('SELECT id FROM ' . TABLE_GENES . ' WHERE id = ?', array($_PE[1]))->fetchColumn();
         if ($sGene) {
             // We need the authorization call if we would show the screenings with VARIANTS in gene X, not before!
 //            lovd_isAuthorized('gene', $sGene); // To show non public entries.
@@ -167,7 +167,7 @@ if (PATH_COUNT == 1 && ACTION == 'create' && isset($_GET['target']) && ctype_dig
 
     $_GET['target'] = sprintf('%0' . $_SETT['objectid_length']['individuals'] . 'd', $_GET['target']);
     define('PAGE_TITLE', lovd_getCurrentPageTitle());
-    $z = $_DB->query('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($_GET['target']))->fetchAssoc();
+    $z = $_DB->q('SELECT id FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($_GET['target']))->fetchAssoc();
     if (!$z) {
         $_T->printHeader();
         $_T->printTitle();
@@ -213,8 +213,8 @@ if (PATH_COUNT == 1 && ACTION == 'create' && isset($_GET['target']) && ctype_dig
                 foreach ($_POST['genes'] as $sGene) {
                     // Add disease to gene.
                     if (in_array($sGene, lovd_getGeneList())) {
-                        $q = $_DB->query('INSERT INTO ' . TABLE_SCR2GENE . ' VALUES (?, ?)', array($nID, $sGene), false);
-                        // FIXME; I think this is not possible without a query error, that by default halts the system. Maybe you want to set $_DB->query()'s third argument to false?
+                        $q = $_DB->q('INSERT INTO ' . TABLE_SCR2GENE . ' VALUES (?, ?)', array($nID, $sGene), false);
+                        // FIXME; I think this is not possible without a query error, that by default halts the system. Maybe you want to set $_DB->q()'s third argument to false?
                         if (!$q->rowCount()) {
                             // Silent error.
                             // FIXME; maybe better to group the error messages, just like when editing?
@@ -227,7 +227,7 @@ if (PATH_COUNT == 1 && ACTION == 'create' && isset($_GET['target']) && ctype_dig
             }
 
             // Get genes which are modified only when linked individual is marked or public.
-            $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
+            $aGenes = $_DB->q('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                   'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
                                   'INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vog.id = vot.id) ' .
                                   'INNER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s2v.variantid = vog.id) ' .
@@ -356,7 +356,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
             if (!$bSubmit) {
                 // Put $zData with the old values in $_SESSION for mailing.
                 if ($zData['variants_found']) {
-                    $zData['variants_found_'] = $_DB->query('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn();
+                    $zData['variants_found_'] = $_DB->q('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn();
                     if (!$zData['variants_found_']) {
                         $zData['variants_found_'] = 0;
                     }
@@ -385,7 +385,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
             }
 
             if ($aToRemove) {
-                $q = $_DB->query('DELETE FROM ' . TABLE_SCR2GENE . ' WHERE screeningid = ? AND geneid IN (?' . str_repeat(', ?', count($aToRemove) - 1) . ')', array_merge(array($zData['id']), $aToRemove), false);
+                $q = $_DB->q('DELETE FROM ' . TABLE_SCR2GENE . ' WHERE screeningid = ? AND geneid IN (?' . str_repeat(', ?', count($aToRemove) - 1) . ')', array_merge(array($zData['id']), $aToRemove), false);
                 if (!$q) {
                     // Silent error.
                     lovd_writeLog('Error', LOG_EVENT, 'Gene information entr' . (count($aToRemove) == 1? 'y' : 'ies') . ' ' . implode(', ', $aToRemove) . ' could not be removed from screening ' . $nID);
@@ -400,7 +400,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
             foreach ($_POST['genes'] as $sGene) {
                 if (!in_array($sGene, $zData['genes']) && in_array($sGene, lovd_getGeneList())) {
                     // Add gene to screening.
-                    $q = $_DB->query('INSERT IGNORE INTO ' . TABLE_SCR2GENE . ' VALUES (?, ?)', array($nID, $sGene), false);
+                    $q = $_DB->q('INSERT IGNORE INTO ' . TABLE_SCR2GENE . ' VALUES (?, ?)', array($nID, $sGene), false);
                     if (!$q) {
                         $aFailed[] = $sGene;
                     } else {
@@ -410,7 +410,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
             }
 
             // Get genes which are modified only when linked variant is marked or public.
-            $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
+            $aGenes = $_DB->q('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                   'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
                                   'INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vog.id = vot.id) ' .
                                   'INNER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s2v.variantid = vog.id) ' .
@@ -506,9 +506,9 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
     define('PAGE_TITLE', lovd_getCurrentPageTitle());
     define('LOG_EVENT', 'VariantConfirm');
 
-    $z = $_DB->query('SELECT id, individualid, variants_found FROM ' . TABLE_SCREENINGS . ' WHERE id = ?', array($nID))->fetchAssoc();
-    $aVariantsIndividual = $_DB->query('SELECT DISTINCT s2v.variantid FROM ' . TABLE_SCR2VAR . ' AS s2v INNER JOIN ' . TABLE_SCREENINGS . ' AS s ON (s2v.screeningid = s.id) WHERE s.individualid = ?', array($z['individualid']))->fetchAllColumn();
-    $aVariantsScreening = $_DB->query('SELECT variantid FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchAllColumn();
+    $z = $_DB->q('SELECT id, individualid, variants_found FROM ' . TABLE_SCREENINGS . ' WHERE id = ?', array($nID))->fetchAssoc();
+    $aVariantsIndividual = $_DB->q('SELECT DISTINCT s2v.variantid FROM ' . TABLE_SCR2VAR . ' AS s2v INNER JOIN ' . TABLE_SCREENINGS . ' AS s ON (s2v.screeningid = s.id) WHERE s.individualid = ?', array($z['individualid']))->fetchAllColumn();
+    $aVariantsScreening = $_DB->q('SELECT variantid FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchAllColumn();
 
     $sMessage = '';
     if (!$z) {
@@ -586,7 +586,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
             lovd_writeLog('Event', LOG_EVENT, 'Updated the list of variants confirmed with screening #' . $nID);
 
             // Get genes which are modified only when linked variant is marked or public.
-            $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
+            $aGenes = $_DB->q('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                   'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
                                   'INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vog.id = vot.id) ' .
                                   'WHERE vog.statusid >= ? AND vog.id IN (?' . str_repeat(', ?', count($aNewVariants) - 1) . ')', array_merge(array(STATUS_MARKED), $aNewVariants))->fetchAllColumn();
@@ -638,7 +638,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'confirmVariants') {
     lovd_showInfoTable('The variant entries below are all variants found in this individual, not yet confirmed by/added to this screening.', 'information');
 
     $_GET['page_size'] = 10;
-    $_GET['search_screeningids'] = $_DB->query('
+    $_GET['search_screeningids'] = $_DB->q('
         SELECT GROUP_CONCAT(id SEPARATOR "|")
         FROM ' . TABLE_SCREENINGS . '
         WHERE individualid = ? AND id != ?
@@ -680,10 +680,10 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'removeVariants') {
     define('PAGE_TITLE', lovd_getCurrentPageTitle());
     define('LOG_EVENT', 'VariantRemove');
 
-    $z = $_DB->query('SELECT id, individualid, variants_found FROM ' . TABLE_SCREENINGS . ' WHERE id = ?', array($nID))->fetchAssoc();
-    $aVariants = $_DB->query('SELECT variantid FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchAllColumn();
+    $z = $_DB->q('SELECT id, individualid, variants_found FROM ' . TABLE_SCREENINGS . ' WHERE id = ?', array($nID))->fetchAssoc();
+    $aVariants = $_DB->q('SELECT variantid FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchAllColumn();
     if ($aVariants) {
-        $aValidVariants = $_DB->query('SELECT variantid, COUNT(screeningid) AS nCount FROM ' . TABLE_SCR2VAR . ' WHERE variantid IN (?' . str_repeat(', ?', count($aVariants) - 1) . ') GROUP BY variantid HAVING nCount > 1', $aVariants)->fetchAllColumn();
+        $aValidVariants = $_DB->q('SELECT variantid, COUNT(screeningid) AS nCount FROM ' . TABLE_SCR2VAR . ' WHERE variantid IN (?' . str_repeat(', ?', count($aVariants) - 1) . ') GROUP BY variantid HAVING nCount > 1', $aVariants)->fetchAllColumn();
         $aInvalidVariants = array_diff($aVariants, $aValidVariants);
     }
 
@@ -749,7 +749,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'removeVariants') {
             $aToRemove = $_SESSION['viewlists']['Screenings_' . $nID . '_removeVariants']['checked'];
             if (!empty($aToRemove)) {
                 // Remove variants from screening...
-                $_DB->query('DELETE FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ? AND variantid IN (?' . str_repeat(', ?', count($aToRemove) - 1) . ')', array_merge(array($nID), $aToRemove));
+                $_DB->q('DELETE FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ? AND variantid IN (?' . str_repeat(', ?', count($aToRemove) - 1) . ')', array_merge(array($nID), $aToRemove));
             }
 
             // If we get here, it all succeeded.
@@ -757,7 +757,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'removeVariants') {
             unset($_SESSION['viewlists']['Screenings_' . $nID . '_removeVariants']);
 
             // Get genes which are modified only when linked variant is marked or public.
-            $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
+            $aGenes = $_DB->q('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                   'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
                                   'INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vog.id = vot.id) ' .
                                   'WHERE vog.statusid >= ? AND vog.id IN (?' . str_repeat(', ?', count($aToRemove) - 1) . ')', array_merge(array(STATUS_MARKED), $aToRemove))->fetchAllColumn();
@@ -849,10 +849,10 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
     $zData = $_DATA->loadEntry($nID);
     require ROOT_PATH . 'inc-lib-form.php';
 
-    $a = $_DB->query('SELECT variantid, screeningid FROM ' . TABLE_SCR2VAR . ' GROUP BY variantid HAVING COUNT(screeningid) = 1 AND screeningid = ?', array($nID))->fetchAllColumn();
+    $a = $_DB->q('SELECT variantid, screeningid FROM ' . TABLE_SCR2VAR . ' GROUP BY variantid HAVING COUNT(screeningid) = 1 AND screeningid = ?', array($nID))->fetchAllColumn();
     $aVariantsRemovable = array();
     if (!empty($a)) {
-        $aVariantsRemovable = $_DB->query('SELECT variantid FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ? AND variantid IN (?' . str_repeat(', ?', count($a) - 1) . ')', array_merge(array($nID), $a))->fetchAllColumn();
+        $aVariantsRemovable = $_DB->q('SELECT variantid FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ? AND variantid IN (?' . str_repeat(', ?', count($a) - 1) . ')', array_merge(array($nID), $a))->fetchAllColumn();
     }
     $nVariantsRemovable = count($aVariantsRemovable);
 
@@ -875,7 +875,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
 
             // Search for effected genes before the deletion on SCR2VAR, else we can't find the link.
             // Get genes which are modified only when linked variant is marked or public.
-            $aGenes = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
+            $aGenes = $_DB->q('SELECT DISTINCT t.geneid FROM ' . TABLE_TRANSCRIPTS . ' AS t ' .
                                   'INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vot.transcriptid = t.id) ' .
                                   'INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (vog.id = vot.id) ' .
                                   'INNER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s2v.variantid = vog.id) ' .
@@ -885,7 +885,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
 
             if (isset($_POST['remove_variants']) && $_POST['remove_variants'] == 'remove') {
                 // This also deletes the entries in TABLE_SCR2VAR.
-                $_DB->query('DELETE FROM ' . TABLE_VARIANTS . ' WHERE id IN (?' . str_repeat(', ?', count($aVariantsRemovable) - 1) . ')', $aVariantsRemovable);
+                $_DB->q('DELETE FROM ' . TABLE_VARIANTS . ' WHERE id IN (?' . str_repeat(', ?', count($aVariantsRemovable) - 1) . ')', $aVariantsRemovable);
             }
 
             // This also deletes the entries in TABLE_SCR2GENE and TABLE_SCR2VAR.
@@ -927,7 +927,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
     // Table.
     print('      <FORM action="' . CURRENT_PATH . '?' . ACTION . '" method="post">' . "\n");
 
-    $nVariants = $_DB->query('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn();
+    $nVariants = $_DB->q('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn();
     $aOptions = array('remove' => 'Yes, remove ' . ($nVariantsRemovable == 1? 'this variant' : 'these variants') . ' attached to only this screening', 'keep' => 'No, keep ' . ($nVariantsRemovable == 1? 'this variant' : 'these variants') . ' as separate entries');
 
     // Array which will make up the form table.

--- a/src/scripts/convert_lovd2.php
+++ b/src/scripts/convert_lovd2.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-10-04
- * Modified    : 2021-11-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2014-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
@@ -500,7 +500,7 @@ function lovd_getDiseaseID ($sDiseaseName)
     $bNewDisease = false;
     // First try to match on the OMIM ID that is sometimes stored.
     if (preg_match('/^\{OMIMphen(\d+)\}$/', trim($sDiseaseName), $aRegs)) {
-        $nDiseaseID = $_DB->query('SELECT id FROM ' . TABLE_DISEASES . ' WHERE id_omim = ?',
+        $nDiseaseID = $_DB->q('SELECT id FROM ' . TABLE_DISEASES . ' WHERE id_omim = ?',
             array($aRegs[1]))->fetchColumn();
         if ($nDiseaseID) {
             $aKnownDiseases[$sDiseaseName] = $nDiseaseID;
@@ -509,7 +509,7 @@ function lovd_getDiseaseID ($sDiseaseName)
             $bNewDisease = true;
         }
     } elseif (!isset($aKnownDiseases[$sDiseaseName])) {
-        $qDiseases = $_DB->query('SELECT id FROM ' . TABLE_DISEASES . ' WHERE name = ? OR symbol = ?',
+        $qDiseases = $_DB->q('SELECT id FROM ' . TABLE_DISEASES . ' WHERE name = ? OR symbol = ?',
             array($sDiseaseName, $sDiseaseName));
         $zDiseases = $qDiseases->fetchAllAssoc();
         if (!$zDiseases) {
@@ -577,7 +577,7 @@ function lovd_getHeaders ($aData, $aFieldLinks, $aSections, $aCustomColLinks)
                 ($aTable = lovd_getTableInfoByCategory($aImportSection['customcol_prefix']))
                 !== false) {
                 $aSections[$sSection]['db_fields'] =
-                    $_DB->query('DESCRIBE ' . $aTable['table_sql'])->fetchAllColumn();
+                    $_DB->q('DESCRIBE ' . $aTable['table_sql'])->fetchAllColumn();
             } else {
                 $aSections[$sSection]['db_fields'] = array();
             }
@@ -1431,7 +1431,7 @@ function main ($aFieldLinks, $aSections, $aCustomColLinks)
         return;
     } else {
         if (!empty($_POST['transcriptid'])) {
-            $qTranscript = $_DB->query('SELECT t.*, chromosome FROM ' . TABLE_TRANSCRIPTS .
+            $qTranscript = $_DB->q('SELECT t.*, chromosome FROM ' . TABLE_TRANSCRIPTS .
                 ' AS t LEFT JOIN ' . TABLE_GENES . ' AS g ON (g.id = t.geneid)  WHERE t.id = ?',
                 array($_POST['transcriptid']));
             $zTranscript = $qTranscript->fetchAssoc();

--- a/src/scripts/fetch_frequencies.php
+++ b/src/scripts/fetch_frequencies.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2013-08-11
- * Modified    : 2020-11-05
- * For LOVD    : 3.0-26
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -44,7 +44,7 @@ $sURL = 'https://gnomad.lovd.nl/api/rest/get_frequencies?format=application/json
 
 // Fetch frequencies from whole genome installation of LOVD, and import into this LOVD.
 // This query may take some time in very large databases, so we'll try not to run it too often.
-$nToFetch = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' WHERE average_frequency IS NULL AND chromosome IS NOT NULL AND position_g_start IS NOT NULL AND position_g_end IS NOT NULL')->fetchColumn();
+$nToFetch = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' WHERE average_frequency IS NULL AND chromosome IS NOT NULL AND position_g_start IS NOT NULL AND position_g_end IS NOT NULL')->fetchColumn();
 if (!$nToFetch) {
     print('All done.');
     $_T->printFooter();
@@ -60,7 +60,7 @@ $_T->printFooter(false);
 $sVariants = ' ';
 $nDone = 0;
 while ($nDone < $nToFetch && $sVariants) {
-    $aVariants = $_DB->query('SELECT chromosome, position_g_start, position_g_end, `VariantOnGenome/DNA` AS DNA FROM ' . TABLE_VARIANTS . ' WHERE average_frequency IS NULL AND chromosome IS NOT NULL AND position_g_start IS NOT NULL AND position_g_end IS NOT NULL LIMIT ' . $nLimit)->fetchAllAssoc();
+    $aVariants = $_DB->q('SELECT chromosome, position_g_start, position_g_end, `VariantOnGenome/DNA` AS DNA FROM ' . TABLE_VARIANTS . ' WHERE average_frequency IS NULL AND chromosome IS NOT NULL AND position_g_start IS NOT NULL AND position_g_end IS NOT NULL LIMIT ' . $nLimit)->fetchAllAssoc();
     if ($aVariants === array()) {
         // No results.
         $oPB->setProgress(100);
@@ -110,7 +110,7 @@ while ($nDone < $nToFetch && $sVariants) {
                 $nFrequency = 0;
             }
             // By passing False as the third argument, this query will not halt if failed.
-            $q = $_DB->query('UPDATE ' . TABLE_VARIANTS . ' SET average_frequency = ? WHERE chromosome = ? AND position_g_start = ? AND position_g_end = ? AND `VariantOnGenome/DNA` = ?', array($nFrequency, $aVariant['chromosome'], $aVariant['position_g_start'], $aVariant['position_g_end'], $aVariant['DNA']), false);
+            $q = $_DB->q('UPDATE ' . TABLE_VARIANTS . ' SET average_frequency = ? WHERE chromosome = ? AND position_g_start = ? AND position_g_end = ? AND `VariantOnGenome/DNA` = ?', array($nFrequency, $aVariant['chromosome'], $aVariant['position_g_start'], $aVariant['position_g_end'], $aVariant['DNA']), false);
             if (!$q) {
                 $oPB->setMessage('Error, failed to update entry ' . implode(';', $aVariant) . '<BR>' . $_DB->formatError());
                 die('    </BODY>' . "\n" . '</HTML>');

--- a/src/scripts/fix_position_fields.php
+++ b/src/scripts/fix_position_fields.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-01-28
- * Modified    : 2017-07-24
- * For LOVD    : 3.0-20
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2017 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -85,7 +85,7 @@ class LOVD_VariantPositionAnalyses {
                     {
                         // We'll just simply swap the fields. That may not result in correct values, but this will be
                         //  checked later. For now, this simple change may do the trick.
-                        return array(1, $_DB->query('UPDATE ' . TABLE_VARIANTS . ' SET position_g_start = ?, position_g_end = ? WHERE id = ?', array($zRow['position_g_end'], $zRow['position_g_start'], $zRow['id']))->rowCount());
+                        return array(1, $_DB->q('UPDATE ' . TABLE_VARIANTS . ' SET position_g_start = ?, position_g_end = ? WHERE id = ?', array($zRow['position_g_end'], $zRow['position_g_start'], $zRow['id']))->rowCount());
                     },
                 ),
             'vog_positions_in_error' => // The positions that do not match the variant's description (analysis needed).
@@ -101,7 +101,7 @@ class LOVD_VariantPositionAnalyses {
                             // The function recognized the variant.
                             if ($aPositions['position_start'] != $zRow['position_g_start'] || $aPositions['position_end'] != $zRow['position_g_end']) {
                                 // Positions given by function do not match what is in the database. Fix!
-                                return array(1, $_DB->query('UPDATE ' . TABLE_VARIANTS . ' SET position_g_start = ?, position_g_end = ? WHERE id = ?', array($aPositions['position_start'], $aPositions['position_end'], $zRow['id']))->rowCount());
+                                return array(1, $_DB->q('UPDATE ' . TABLE_VARIANTS . ' SET position_g_start = ?, position_g_end = ? WHERE id = ?', array($aPositions['position_start'], $aPositions['position_end'], $zRow['id']))->rowCount());
                             }
                         } else {
                             // Variant not recognized, but positions are stored. We're going to assume they are OK.
@@ -120,7 +120,7 @@ class LOVD_VariantPositionAnalyses {
                         $aPositions = lovd_getVariantInfo($zRow['DNA']);
                         if ($aPositions) {
                             // The function recognized the variant.
-                            return array(1, $_DB->query('UPDATE ' . TABLE_VARIANTS . ' SET position_g_start = ?, position_g_end = ?, mapping_flags = mapping_flags &~ ' . MAPPING_NOT_RECOGNIZED . ' WHERE id = ?', array($aPositions['position_start'], $aPositions['position_end'], $zRow['id']))->rowCount());
+                            return array(1, $_DB->q('UPDATE ' . TABLE_VARIANTS . ' SET position_g_start = ?, position_g_end = ?, mapping_flags = mapping_flags &~ ' . MAPPING_NOT_RECOGNIZED . ' WHERE id = ?', array($aPositions['position_start'], $aPositions['position_end'], $zRow['id']))->rowCount());
                         } else {
                             // Variants not recognized by LOVD, will be handled by the next analysis.
                         }
@@ -151,7 +151,7 @@ class LOVD_VariantPositionAnalyses {
                         $aPositions = lovd_getVariantInfo($zRow['DNA']);
                         if ($aPositions) {
                             // The function recognized the variant.
-                            return array(1, $_DB->query('UPDATE ' . TABLE_VARIANTS . ' SET position_g_start = ?, position_g_end = ?, mapping_flags = mapping_flags &~ ' . MAPPING_NOT_RECOGNIZED . ' WHERE id = ?', array($aPositions['position_start'], $aPositions['position_end'], $zRow['id']))->rowCount());
+                            return array(1, $_DB->q('UPDATE ' . TABLE_VARIANTS . ' SET position_g_start = ?, position_g_end = ?, mapping_flags = mapping_flags &~ ' . MAPPING_NOT_RECOGNIZED . ' WHERE id = ?', array($aPositions['position_start'], $aPositions['position_end'], $zRow['id']))->rowCount());
                         }
                         return array(1, 0);
                     },
@@ -168,7 +168,7 @@ class LOVD_VariantPositionAnalyses {
                     {
                         // We'll just simply swap the fields. That may not result in correct values, but this will be
                         //  checked later. For now, this simple change may do the trick.
-                        return array(1, $_DB->query('UPDATE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' SET position_c_start = ?, position_c_start_intron = ?, position_c_end = ?, position_c_end_intron = ? WHERE id = ? AND transcriptid = ?', array($zRow['position_c_end'], $zRow['position_c_end_intron'], $zRow['position_c_start'], $zRow['position_c_start_intron'], $zRow['id'], $zRow['transcriptid']))->rowCount());
+                        return array(1, $_DB->q('UPDATE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' SET position_c_start = ?, position_c_start_intron = ?, position_c_end = ?, position_c_end_intron = ? WHERE id = ? AND transcriptid = ?', array($zRow['position_c_end'], $zRow['position_c_end_intron'], $zRow['position_c_start'], $zRow['position_c_start_intron'], $zRow['id'], $zRow['transcriptid']))->rowCount());
                     },
                 ),
             'vot_positions_in_error' => // The positions that do not match the variant's description (analysis needed).
@@ -187,7 +187,7 @@ class LOVD_VariantPositionAnalyses {
                                 $aPositions['position_end'] != $zRow['position_c_end'] ||
                                 $aPositions['position_end_intron'] != $zRow['position_c_end_intron']) {
                                 // Positions given by function do not match what is in the database. Fix!
-                                return array(1, $_DB->query('UPDATE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' SET position_c_start = ?, position_c_start_intron = ?, position_c_end = ?, position_c_end_intron = ? WHERE id = ? AND transcriptid = ?', array($aPositions['position_start'], $aPositions['position_start_intron'], $aPositions['position_end'], $aPositions['position_end_intron'], $zRow['id'], $zRow['transcriptid']))->rowCount());
+                                return array(1, $_DB->q('UPDATE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' SET position_c_start = ?, position_c_start_intron = ?, position_c_end = ?, position_c_end_intron = ? WHERE id = ? AND transcriptid = ?', array($aPositions['position_start'], $aPositions['position_start_intron'], $aPositions['position_end'], $aPositions['position_end_intron'], $zRow['id'], $zRow['transcriptid']))->rowCount());
                             }
                         } else {
                             // Variant not recognized, but positions are stored. We're going to assume they are OK.
@@ -206,7 +206,7 @@ class LOVD_VariantPositionAnalyses {
                         $aPositions = lovd_getVariantInfo($zRow['DNA'], $zRow['transcriptid']);
                         if ($aPositions) {
                             // The function recognized the variant.
-                            return array(1, $_DB->query('UPDATE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' SET position_c_start = ?, position_c_start_intron = ?, position_c_end = ?, position_c_end_intron = ? WHERE id = ? AND transcriptid = ?', array($aPositions['position_start'], $aPositions['position_start_intron'], $aPositions['position_end'], $aPositions['position_end_intron'], $zRow['id'], $zRow['transcriptid']))->rowCount());
+                            return array(1, $_DB->q('UPDATE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' SET position_c_start = ?, position_c_start_intron = ?, position_c_end = ?, position_c_end_intron = ? WHERE id = ? AND transcriptid = ?', array($aPositions['position_start'], $aPositions['position_start_intron'], $aPositions['position_end'], $aPositions['position_end_intron'], $zRow['id'], $zRow['transcriptid']))->rowCount());
                         } else {
                             // Variants not recognized by LOVD, will be handled by the next analysis.
                         }
@@ -237,7 +237,7 @@ class LOVD_VariantPositionAnalyses {
                         $aPositions = lovd_getVariantInfo($zRow['DNA'], $zRow['transcriptid']);
                         if ($aPositions) {
                             // The function recognized the variant.
-                            return array(1, $_DB->query('UPDATE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' SET position_c_start = ?, position_c_start_intron = ?, position_c_end = ?, position_c_end_intron = ? WHERE id = ? AND transcriptid = ?', array($aPositions['position_start'], $aPositions['position_start_intron'], $aPositions['position_end'], $aPositions['position_end_intron'], $zRow['id'], $zRow['transcriptid']))->rowCount());
+                            return array(1, $_DB->q('UPDATE ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' SET position_c_start = ?, position_c_start_intron = ?, position_c_end = ?, position_c_end_intron = ? WHERE id = ? AND transcriptid = ?', array($aPositions['position_start'], $aPositions['position_start_intron'], $aPositions['position_end'], $aPositions['position_end_intron'], $zRow['id'], $zRow['transcriptid']))->rowCount());
                         }
                         return array(1, 0);
                     },
@@ -249,7 +249,7 @@ class LOVD_VariantPositionAnalyses {
         $this->oBAR->setProgress(0);
         foreach ($this->aAnalyses as $sAnalysis => $aAnalysis) {
             if (isset($aAnalysis['sql_count'])) {
-                $this->aAnalyses[$sAnalysis]['count'] = $_DB->query($aAnalysis['sql_count'])->fetchColumn();
+                $this->aAnalyses[$sAnalysis]['count'] = $_DB->q($aAnalysis['sql_count'])->fetchColumn();
             }
         }
         $this->oBAR->setMessage('<BR>');
@@ -294,12 +294,12 @@ class LOVD_VariantPositionAnalyses {
                 } else {
                     // A special query was constructed to count the number of entries we need to look at.
                     // If we would be doing a fetchAll(), then we wouldn't need this.
-                    $nData = $_DB->query($aAnalysis['sql_fetch_count'])->fetchColumn();
+                    $nData = $_DB->q($aAnalysis['sql_fetch_count'])->fetchColumn();
                 }
                 // We're optimizing for memory usage here, not speed. So we'll fetch the results line by line,
                 //  and have the fix function called for every line. This does slow things down, and requires
                 //  a separate count query, but I prefer that this script can handle any size of database.
-                $qData = $_DB->query($aAnalysis['sql_fetch']);
+                $qData = $_DB->q($aAnalysis['sql_fetch']);
                 if (!isset($this->aAnalyses[$sAnalysis]['count'])) {
                     $this->aAnalyses[$sAnalysis]['count'] = 0;
                 }

--- a/src/scripts/fix_variant_descriptions.php
+++ b/src/scripts/fix_variant_descriptions.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-09
- * Modified    : 2022-07-27
+ * Modified    : 2022-11-22
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -103,7 +103,7 @@ class LOVD_VVAnalyses {
 
         // Check the arguments we have received.
         // Query takes 0.9 seconds on shared - acceptable.
-        $this->aChromosomes = $_DB->query('
+        $this->aChromosomes = $_DB->q('
             SELECT c.name, COUNT(*)
             FROM ' . TABLE_CHROMOSOMES . ' AS c
                 INNER JOIN ' . TABLE_VARIANTS . ' AS vog ON (c.name = vog.chromosome)
@@ -157,7 +157,7 @@ class LOVD_VVAnalyses {
 
         // Check for custom columns we need; hg38 annotation (GV shared has a
         //  custom column for that) and VOG/Remarks.
-        list($this->bDNA38, $this->bRemarks) = $_DB->query('
+        list($this->bDNA38, $this->bRemarks) = $_DB->q('
             SELECT COUNT(*)
             FROM ' . TABLE_ACTIVE_COLS . '
             WHERE colid = ?
@@ -168,7 +168,7 @@ class LOVD_VVAnalyses {
             array('VariantOnGenome/DNA/hg38', 'VariantOnGenome/Remarks'))->fetchAllColumn();
 
         // Get proper progress count - how much is behind us already for this chromosome?
-        $this->nProgressCount = $_DB->query('
+        $this->nProgressCount = $_DB->q('
                 SELECT COUNT(*)
                 FROM ' . TABLE_VARIANTS . '
                 WHERE chromosome = ? AND position_g_start < ? AND statusid > ?',
@@ -270,7 +270,7 @@ class LOVD_VVAnalyses {
         // As long as I make sure the loop will quit, I should be fine.
         while (true) {
             // Count how much there is left to do.
-            $nLeft = $_DB->query('
+            $nLeft = $_DB->q('
                 SELECT COUNT(*)
                 FROM ' . TABLE_VARIANTS . '
                 WHERE chromosome = ? AND position_g_start >= ? AND statusid > ?',
@@ -294,7 +294,7 @@ class LOVD_VVAnalyses {
             }
 
             // Get next position to work on.
-            $nNextPosition = $_DB->query('
+            $nNextPosition = $_DB->q('
                 SELECT position_g_start
                 FROM ' . TABLE_VARIANTS . '
                 WHERE chromosome = ? AND position_g_start >= ? AND statusid > ?
@@ -306,7 +306,7 @@ class LOVD_VVAnalyses {
             }
 
             // Fetch data for this position.
-            $aVariants = $_DB->query('
+            $aVariants = $_DB->q('
                 SELECT vog.id, vog.statusid, vog.`VariantOnGenome/DNA` AS DNA, ' .
                     (!$this->bDNA38? '' : 'vog.`VariantOnGenome/DNA/hg38` AS DNA38, ') .
                     (!$this->bRemarks? '' : 'vog.`VariantOnGenome/Remarks` AS remarks, ') .
@@ -843,7 +843,7 @@ class LOVD_VVAnalyses {
                         if (!isset($aVVVot['errors']['ERANGE'])) {
                             // This transcript should be reported.
                             // Check if we have reported it before.
-                            if (!$_DB->query('
+                            if (!$_DB->q('
                                 SELECT COUNT(*)
                                 FROM ' . TABLE_LOGS . '
                                 WHERE name = ? AND event = ? AND log LIKE ?',
@@ -1186,7 +1186,7 @@ class LOVD_VVAnalyses {
 
                     if ($aVariant['statusid'] >= STATUS_MARKED) {
                         // Get gene, and have it marked as updated.
-                        $aGenes = $_DB->query('
+                        $aGenes = $_DB->q('
                                 SELECT DISTINCT t.geneid
                                 FROM ' . TABLE_TRANSCRIPTS . ' AS t
                                     INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid)

--- a/src/scripts/refseq_parser.php
+++ b/src/scripts/refseq_parser.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-29
- * Modified    : 2022-05-27
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -97,7 +97,7 @@ if ($_GET['step'] == 1) {
         } else {
             // Get the UD number from the genes table.
             $_POST['transcript_id'] = $_POST['symbol'];
-            list($_POST['symbol'], $sFileID, $_POST['protein_id']) = $_DB->query('SELECT g.id, ' . ($_POST['file'] == 'NC'? 'g.refseq_UD' : 'IF(LEFT(g.refseq_genomic, 2) != "NG", g.refseq_UD, g.refseq_genomic)') . ' AS refseq, t.id_protein_ncbi FROM ' . TABLE_GENES . ' AS g INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (g.id = t.geneid) WHERE t.id_ncbi = ?', array($_POST['symbol']))->fetchRow();
+            list($_POST['symbol'], $sFileID, $_POST['protein_id']) = $_DB->q('SELECT g.id, ' . ($_POST['file'] == 'NC'? 'g.refseq_UD' : 'IF(LEFT(g.refseq_genomic, 2) != "NG", g.refseq_UD, g.refseq_genomic)') . ' AS refseq, t.id_protein_ncbi FROM ' . TABLE_GENES . ' AS g INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (g.id = t.geneid) WHERE t.id_ncbi = ?', array($_POST['symbol']))->fetchRow();
 
             if (empty($sFileID) || empty($_POST['transcript_id']) || empty($_POST['protein_id'])) {
                 lovd_errorAdd('symbol', 'This gene or transcript does not seem to be configured correctly, we currently can\'t generate a human-readable reference sequence file using this gene.');
@@ -404,7 +404,7 @@ if ($_GET['step'] == 1) {
         // Do we have a gene selected?
         if ($_SESSION['currdb'] || !empty($_GET['symbol'])) {
             // Select first transcript added to this gene.
-            $sNCBI = $_DB->query('SELECT id_ncbi FROM ' . TABLE_TRANSCRIPTS . ' WHERE geneid = ? ORDER BY id ASC LIMIT 1', array((!empty($_GET['symbol'])? $_GET['symbol'] : $_SESSION['currdb'])))->fetchColumn();
+            $sNCBI = $_DB->q('SELECT id_ncbi FROM ' . TABLE_TRANSCRIPTS . ' WHERE geneid = ? ORDER BY id ASC LIMIT 1', array((!empty($_GET['symbol'])? $_GET['symbol'] : $_SESSION['currdb'])))->fetchColumn();
             // FIXME; Replace "symbol" with something more useful.
             $_POST['symbol'] = $sNCBI;
         }
@@ -427,7 +427,7 @@ if ($_GET['step'] == 1) {
         $aArgs[] = $_GET['symbol'];
     }
     $sQ .= ' ORDER BY g.id, t.id_ncbi';
-    $aGenes = $_DB->query($sQ, $aArgs)->fetchAllCombine();
+    $aGenes = $_DB->q($sQ, $aArgs)->fetchAllCombine();
 
     // Print the form for step 1: import a GenBank file
     $_T->printTitle('Step 1 - Import annotated Genbank sequence to extract genomic sequence');
@@ -509,7 +509,7 @@ if ($_GET['step'] == 2) {
             $where = 'intron';        // Start with the upstream sequence
             $aExonEnds = array();     // Array with exon ending positions.
 
-            $_POST['gene'] = $_DB->query('SELECT name FROM ' . TABLE_GENES . ' WHERE id = ?', array($_POST['symbol']))->fetchColumn();
+            $_POST['gene'] = $_DB->q('SELECT name FROM ' . TABLE_GENES . ' WHERE id = ?', array($_POST['symbol']))->fetchColumn();
 
             for ($i = 0; $i < strlen($sSeq); $i ++) {
                 $s = $sSeq[$i];
@@ -1179,7 +1179,7 @@ if ($_GET['step'] == 2) {
 //            $sQ .= TABLE_GENES . ' AS g ORDER BY g.id';
 //        }
 //        $qGenes = mysql_query($sQ);
-//        $aGenes = $_DB->query($sQ)->fetchAllCombine();
+//        $aGenes = $_DB->q($sQ)->fetchAllCombine();
 //        $aForm[] = array('Select gene database',  '','select', 'symbol', 1, $aGenes, false, false, false);
 //    }
     $aForm[] = array('Input sequence', '', 'textarea', 'sequence', '60', '8');
@@ -1264,7 +1264,7 @@ if ($_GET['step'] == 3) {
             $nNuclPostTranslStart = 0;   // Number of nucleotides after the translation starts
             $started = false;   // Did we find the translation sign yet?
 
-            $_POST['gene'] = $_DB->query('SELECT name FROM ' . TABLE_GENES . ' WHERE id = ?', array($_POST['symbol']))->fetchColumn();
+            $_POST['gene'] = $_DB->q('SELECT name FROM ' . TABLE_GENES . ' WHERE id = ?', array($_POST['symbol']))->fetchColumn();
 
             for ($i = 0; $i < strlen($sSeq); $i ++) {
                 $s = $sSeq[$i];
@@ -2007,7 +2007,7 @@ if ($_GET['step'] == 3) {
                 } else {
                     $sURL = lovd_getInstallURL() . 'refseq/' . $_POST['symbol'] . '_codingDNA.html';
                 }
-                $_DB->query('UPDATE ' . TABLE_GENES . ' SET refseq = ?, refseq_url = ? WHERE id = ? AND refseq = "" AND refseq_url= ""', array(($_POST['link'] && $bStep2? 'g' : 'c'), $sURL, $_POST['symbol']));
+                $_DB->q('UPDATE ' . TABLE_GENES . ' SET refseq = ?, refseq_url = ? WHERE id = ? AND refseq = "" AND refseq_url= ""', array(($_POST['link'] && $bStep2? 'g' : 'c'), $sURL, $_POST['symbol']));
 
             } else {
                 // This really shouldn't happen, as we have checked this already...

--- a/src/settings.php
+++ b/src/settings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-02-12
- * Modified    : 2021-02-03
- * For LOVD    : 3.0-26
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -92,7 +92,7 @@ if (PATH_COUNT == 1 && ACTION == 'edit') {
                 $aSQL[] = $_POST[$sField];
             }
 
-            $q = $_DB->query($sSQL, $aSQL, true, true);
+            $q = $_DB->q($sSQL, $aSQL, true, true);
 
             // Write to log...
             lovd_writeLog('Event', LOG_EVENT, 'Edited system configuration');

--- a/src/setup.php
+++ b/src/setup.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-02-11
- * Modified    : 2022-05-26
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -49,14 +49,14 @@ lovd_requireAUTH(LEVEL_MANAGER);
 
 
 // Some info & statistics.
-$nUsers       = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_USERS . ' WHERE id > 0')->fetchColumn();
-$nLogs        = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_LOGS)->fetchColumn();
-$nIndividuals = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS)->fetchColumn();
+$nUsers       = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_USERS . ' WHERE id > 0')->fetchColumn();
+$nLogs        = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_LOGS)->fetchColumn();
+$nIndividuals = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS)->fetchColumn();
 $nGenes       = count(lovd_getGeneList());
 $aTotalVars   = array();
 $nTotalVars   = 0;
 if (!LOVD_plus) {
-    $q = $_DB->query('SELECT COUNT(*), statusid FROM ' . TABLE_VARIANTS . ' GROUP BY statusid ORDER BY statusid');
+    $q = $_DB->q('SELECT COUNT(*), statusid FROM ' . TABLE_VARIANTS . ' GROUP BY statusid ORDER BY statusid');
     while ($r = $q->fetchRow()) {
         $aTotalVars[$r[1]] = $r[0];
         $nTotalVars += $r[0];
@@ -106,9 +106,9 @@ if (!LOVD_plus && $_STAT['update_level']) { // Not for LOVD+, unless we build a 
 }
 
 // Check if we have a system-default license, and if we need one at all anyway.
-if ($_DB->query('SELECT default_license FROM ' . TABLE_USERS . ' WHERE id = 0')->fetchColumn() == '') {
+if ($_DB->q('SELECT default_license FROM ' . TABLE_USERS . ' WHERE id = 0')->fetchColumn() == '') {
     // There's no default license. Do we need one?
-    if ($_DB->query('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' WHERE created_by = 0')->fetchColumn() > 0) {
+    if ($_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' WHERE created_by = 0')->fetchColumn() > 0) {
         lovd_showInfoTable(
             'Some of the data in this LOVD instance isn\'t created by a specific user, but there is no default data license selected for these entries. Please help promote data sharing by selecting a default license for this data.',
             'warning',
@@ -153,7 +153,7 @@ $aItems =
                       ),
 /*
 // Modules.
-$nModules = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_MODULES)->fetchColumn();
+$nModules = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_MODULES)->fetchColumn();
 print('            <TABLE border="0" cellpadding="2" cellspacing="0" class="setup" width="100%">' . "\n" .
       '              <TR>' . "\n" .
       '                <TD colspan="2"><B>Modules</B></TD></TR>' . "\n" .

--- a/src/status.php
+++ b/src/status.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-03
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -61,7 +61,7 @@ lovd_includeJS('lib/flot/jquery.flot.pie.min.js');
 print('      <!--[if lte IE 8]><SCRIPT type="text/javascript" src="lib/flot/excanvas.min.js"></SCRIPT><![endif]-->' . "\n\n");
 
 // Statistics about genes:
-$nGenes = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_GENES)->fetchColumn();
+$nGenes = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_GENES)->fetchColumn();
 // Genes, how many variants found? || Genes, how many diseases linked?
 print('      <H5>Genes (' . $nGenes . ')</H5>' . "\n" .
       '      <TABLE border="0" cellpadding="2" cellspacing="0" width="900" style="height : 300px; border-bottom : 3px double #CCC;">' . "\n" .
@@ -114,7 +114,7 @@ $_G->variantsTypeDNA('variantsTypeDNA_unique', '*', $bSeeNonPublicVariants, true
 $nTotalCurators = 0;
 $nTotalCollaborators = 0;
 $sSQL = 'SELECT g.id, g.name, g.updated_date, COUNT(u2g.userid) AS collaborators, SUM(u2g.allow_edit) AS curators FROM ' . TABLE_GENES . ' AS g LEFT OUTER JOIN ' . TABLE_CURATES . ' AS u2g ON (g.id = u2g.geneid) GROUP BY g.id ORDER BY g.id ASC';
-$zGenes = $_DB->query($sSQL)->fetchAllAssoc();
+$zGenes = $_DB->q($sSQL)->fetchAllAssoc();
 $nGenes = count($zGenes);
 foreach ($zGenes as $aGene) {
     $nCollaborators = ($aGene['collaborators'] - $aGene['curators']);

--- a/src/submit.php
+++ b/src/submit.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-21
- * Modified    : 2021-11-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -70,7 +70,7 @@ function lovd_prepareSubmitData ($sDataType, $aData) {
         if ($aData['edited_by'] == $_AUTH['id']) {
             $aData['edited_by'] = $_AUTH['name'];
         } else {
-            $aData['edited_by'] = $_DB->query('SELECT name FROM ' . TABLE_USERS . ' WHERE id = ?', array($aData['edited_by']))->fetchColumn();
+            $aData['edited_by'] = $_DB->q('SELECT name FROM ' . TABLE_USERS . ' WHERE id = ?', array($aData['edited_by']))->fetchColumn();
         }
     }
 
@@ -123,7 +123,7 @@ if (PATH_COUNT == 3 && $_PE[1] == 'individual' && ctype_digit($_PE[2]) && !ACTIO
 
     $nID = sprintf('%0' . $_SETT['objectid_length'][$_PE[1] . 's'] . 'd', $_PE[2]);
 
-    $zData = $_DB->query('SELECT * FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($nID))->fetchAssoc();
+    $zData = $_DB->q('SELECT * FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($nID))->fetchAssoc();
     if (!isset($_AUTH['saved_work']['submissions']['individual'][$nID])) {
         define('PAGE_TITLE', 'Submit');
         $_T->printHeader();
@@ -140,9 +140,9 @@ if (PATH_COUNT == 3 && $_PE[1] == 'individual' && ctype_digit($_PE[2]) && !ACTIO
     }
     $aSubmit = $_SESSION['work']['submits']['individual'][$nID] = $_AUTH['saved_work']['submissions']['individual'][$nID];
 
-    $zData['diseases'] = $_DB->query('SELECT diseaseid FROM ' . TABLE_IND2DIS . ' WHERE individualid = ?', array($nID))->fetchAllColumn();
+    $zData['diseases'] = $_DB->q('SELECT diseaseid FROM ' . TABLE_IND2DIS . ' WHERE individualid = ?', array($nID))->fetchAllColumn();
     if (count($zData['diseases'])) {
-        $zDiseases = $_DB->query('SELECT id, name, symbol FROM ' . TABLE_DISEASES . ' WHERE id IN (?' . str_repeat(', ?', count($zData['diseases']) - 1) . ')', $zData['diseases'])->fetchAllAssoc();
+        $zDiseases = $_DB->q('SELECT id, name, symbol FROM ' . TABLE_DISEASES . ' WHERE id IN (?' . str_repeat(', ?', count($zData['diseases']) - 1) . ')', $zData['diseases'])->fetchAllAssoc();
         $aDiseases = array();
         foreach ($zDiseases as $a) {
             $aDiseases[$a['id']] = array('name' => $a['name'], 'symbol' => $a['symbol']);
@@ -165,13 +165,13 @@ if (PATH_COUNT == 3 && $_PE[1] == 'individual' && ctype_digit($_PE[2]) && !ACTIO
         }
     }
     if (!empty($aSubmit['screenings'])) {
-        $nScreeningsWithoutVariants = $_DB->query('SELECT COUNT(s.id) FROM ' . TABLE_SCREENINGS . ' AS s LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) WHERE s.variants_found = 1 AND s2v.variantid IS NULL AND s.id IN (?' . str_repeat(', ?', count($aSubmit['screenings']) - 1) . ')', $aSubmit['screenings'])->fetchColumn();
+        $nScreeningsWithoutVariants = $_DB->q('SELECT COUNT(s.id) FROM ' . TABLE_SCREENINGS . ' AS s LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) WHERE s.variants_found = 1 AND s2v.variantid IS NULL AND s.id IN (?' . str_repeat(', ?', count($aSubmit['screenings']) - 1) . ')', $aSubmit['screenings'])->fetchColumn();
         if ($nScreeningsWithoutVariants) {
             $bVariants = false;
         }
     }
 
-    $bScreenings = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_SCREENINGS . ' WHERE individualid = ?', array($nID))->fetchColumn();
+    $bScreenings = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_SCREENINGS . ' WHERE individualid = ?', array($nID))->fetchColumn();
 
     define('PAGE_TITLE', 'Submission of individual #' . $nID);
 
@@ -189,7 +189,7 @@ if (PATH_COUNT == 3 && $_PE[1] == 'individual' && ctype_digit($_PE[2]) && !ACTIO
     //$aOptionsList['options'][0]['option_text'] = '<B>I want to edit ' . $sPersons . '</B>';
 
     if (count($zData['diseases'])) {
-        $nDiseases = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_SHARED_COLS . ' WHERE diseaseid IN (?' . str_repeat(', ?', count($zData['diseases']) - 1) . ') GROUP BY diseaseid', $zData['diseases'])->fetchColumn();
+        $nDiseases = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_SHARED_COLS . ' WHERE diseaseid IN (?' . str_repeat(', ?', count($zData['diseases']) - 1) . ') GROUP BY diseaseid', $zData['diseases'])->fetchColumn();
         $sMessage = 'The disease' . (count($zData['diseases']) > 1? 's' : '') . ' added to ' . $sPersons . ' do' . (count($zData['diseases']) > 1? '' : 'es') . ' not have phenotype columns enabled yet.';
     } else {
         $nDiseases = 0;
@@ -284,7 +284,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'individual' && ctype_digit($_PE[2]) && $_PE[3
     $_T->printHeader();
     $_T->printTitle();
 
-    $bExists = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($nID))->fetchColumn();
+    $bExists = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' WHERE id = ?', array($nID))->fetchColumn();
     if (!$bExists || !isset($_AUTH['saved_work']['submissions']['individual'][$nID])) {
         lovd_showInfoTable('No such ID!', 'stop');
         $_T->printFooter();
@@ -320,7 +320,7 @@ if (PATH_COUNT == 3 && $_PE[1] == 'screening' && ctype_digit($_PE[2]) && !ACTION
 
     $nID = sprintf('%0' . $_SETT['objectid_length'][$_PE[1] . 's'] . 'd', $_PE[2]);
 
-    $zData = $_DB->query('SELECT * FROM ' . TABLE_SCREENINGS . ' WHERE id = ? AND created_by = ?', array($nID, $_AUTH['id']))->fetchAssoc();
+    $zData = $_DB->q('SELECT * FROM ' . TABLE_SCREENINGS . ' WHERE id = ? AND created_by = ?', array($nID, $_AUTH['id']))->fetchAssoc();
     if (empty($zData)) {
         define('PAGE_TITLE', 'Submit');
         $_T->printHeader();
@@ -359,7 +359,7 @@ if (PATH_COUNT == 3 && $_PE[1] == 'screening' && ctype_digit($_PE[2]) && !ACTION
     lovd_isAuthorized('screening', $nID);
     lovd_requireAUTH(LEVEL_OWNER);
 
-    $zData['variants'] = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn();
+    $zData['variants'] = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn();
 
     define('PAGE_TITLE', 'Submission of screening #' . $nID);
 
@@ -447,7 +447,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
             $sURI = 'individuals/';
             $sTitle = 'an individual';
             $nID = sprintf('%0' . $_SETT['objectid_length'][$_PE[2] . 's'] . 'd', $_PE[3]);
-            $zData = $_DB->query('SELECT i.id, GROUP_CONCAT(DISTINCT t.geneid ORDER BY t.geneid SEPARATOR ";") AS geneids, GROUP_CONCAT(DISTINCT i2d.diseaseid SEPARATOR ";") AS diseaseids FROM ' . TABLE_INDIVIDUALS . ' AS i LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid) LEFT OUTER JOIN ' . TABLE_SCREENINGS . ' AS s ON (i.id = s.individualid) LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (s2v.variantid = vot.id) LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE i.id = ? AND i.' . (ACTION != 'edit'? 'created' : 'edited') . '_by = ? GROUP BY i.id', array($nID, $_AUTH['id']))->fetchAssoc();
+            $zData = $_DB->q('SELECT i.id, GROUP_CONCAT(DISTINCT t.geneid ORDER BY t.geneid SEPARATOR ";") AS geneids, GROUP_CONCAT(DISTINCT i2d.diseaseid SEPARATOR ";") AS diseaseids FROM ' . TABLE_INDIVIDUALS . ' AS i LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid) LEFT OUTER JOIN ' . TABLE_SCREENINGS . ' AS s ON (i.id = s.individualid) LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (s2v.variantid = vot.id) LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE i.id = ? AND i.' . (ACTION != 'edit'? 'created' : 'edited') . '_by = ? GROUP BY i.id', array($nID, $_AUTH['id']))->fetchAssoc();
             lovd_isAuthorized('individual', $nID);
             break;
         case 'confirmedVariants':
@@ -455,7 +455,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
             $sTitle = 'confirmed variants';
             $nID = sprintf('%0' . $_SETT['objectid_length']['screenings'] . 'd', $_PE[3]);
             $aConfirmedVariants = $_SESSION['work']['submits']['confirmedVariants'][$nID];
-            $zData = $_DB->query('SELECT DISTINCT t.geneid FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE vot.id IN (?' . str_repeat(', ?', count($aConfirmedVariants) - 1) . ') ORDER BY t.geneid ASC', $aConfirmedVariants)->fetchAllColumn();
+            $zData = $_DB->q('SELECT DISTINCT t.geneid FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE vot.id IN (?' . str_repeat(', ?', count($aConfirmedVariants) - 1) . ') ORDER BY t.geneid ASC', $aConfirmedVariants)->fetchAllColumn();
             $zData = array('geneids' => implode(';', $zData));
             lovd_isAuthorized('screening', $nID);
             break;
@@ -463,21 +463,21 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
             $sURI = 'screenings/';
             $sTitle = 'a screening';
             $nID = sprintf('%0' . $_SETT['objectid_length'][$_PE[2] . 's'] . 'd', $_PE[3]);
-            $zData = $_DB->query('SELECT s.id, GROUP_CONCAT(DISTINCT t.geneid ORDER BY t.geneid SEPARATOR ";") AS geneids FROM ' . TABLE_SCREENINGS . ' AS s LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (s2v.variantid = vot.id) LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE s.id = ? AND s.' . (ACTION != 'edit'? 'created' : 'edited') . '_by = ? GROUP BY s.id', array($nID, $_AUTH['id']))->fetchAssoc();
+            $zData = $_DB->q('SELECT s.id, GROUP_CONCAT(DISTINCT t.geneid ORDER BY t.geneid SEPARATOR ";") AS geneids FROM ' . TABLE_SCREENINGS . ' AS s LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (s2v.variantid = vot.id) LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE s.id = ? AND s.' . (ACTION != 'edit'? 'created' : 'edited') . '_by = ? GROUP BY s.id', array($nID, $_AUTH['id']))->fetchAssoc();
             lovd_isAuthorized('screening', $nID);
             break;
         case 'variant':
             $sURI = 'variants/';
             $sTitle = 'a variant';
             $nID = sprintf('%0' . $_SETT['objectid_length'][$_PE[2] . 's'] . 'd', $_PE[3]);
-            $zData = $_DB->query('SELECT v.id, GROUP_CONCAT(DISTINCT t.geneid ORDER BY t.geneid SEPARATOR ";") AS geneids FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (v.id = vot.id) LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE v.id = ? AND v.' . (ACTION != 'edit'? 'created' : 'edited') . '_by = ? GROUP BY v.id', array($nID, $_AUTH['id']))->fetchAssoc();
+            $zData = $_DB->q('SELECT v.id, GROUP_CONCAT(DISTINCT t.geneid ORDER BY t.geneid SEPARATOR ";") AS geneids FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (v.id = vot.id) LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE v.id = ? AND v.' . (ACTION != 'edit'? 'created' : 'edited') . '_by = ? GROUP BY v.id', array($nID, $_AUTH['id']))->fetchAssoc();
             lovd_isAuthorized('variant', $nID);
             break;
         case 'phenotype':
             $sURI = 'phenotypes/';
             $sTitle = 'a phenotype';
             $nID = sprintf('%0' . $_SETT['objectid_length'][$_PE[2] . 's'] . 'd', $_PE[3]);
-            $zData = $_DB->query('SELECT p.id, GROUP_CONCAT(DISTINCT t.geneid ORDER BY t.geneid SEPARATOR ";") AS geneids, GROUP_CONCAT(DISTINCT p.diseaseid SEPARATOR ";") AS diseaseids FROM ' . TABLE_PHENOTYPES . ' AS p LEFT OUTER JOIN ' . TABLE_SCREENINGS . ' AS s USING (individualid) LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (s2v.variantid = vot.id) LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE p.id = ? AND p.' . (ACTION != 'edit'? 'created' : 'edited') . '_by = ? GROUP BY p.id', array($nID, $_AUTH['id']))->fetchAssoc();
+            $zData = $_DB->q('SELECT p.id, GROUP_CONCAT(DISTINCT t.geneid ORDER BY t.geneid SEPARATOR ";") AS geneids, GROUP_CONCAT(DISTINCT p.diseaseid SEPARATOR ";") AS diseaseids FROM ' . TABLE_PHENOTYPES . ' AS p LEFT OUTER JOIN ' . TABLE_SCREENINGS . ' AS s USING (individualid) LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (s2v.variantid = vot.id) LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE p.id = ? AND p.' . (ACTION != 'edit'? 'created' : 'edited') . '_by = ? GROUP BY p.id', array($nID, $_AUTH['id']))->fetchAssoc();
             lovd_isAuthorized('phenotype', $nID);
             break;
         case 'upload':
@@ -512,20 +512,20 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
         if ($_AUTH['level'] == LEVEL_OWNER) {
             // If the user is not a curator or a higher, then the status will be set from "In Progress" to "Pending".
             if (!empty($aSubmit['variants'])) {
-                $q = $_DB->query('UPDATE ' . TABLE_VARIANTS . ' SET statusid = ? WHERE id IN (?' . str_repeat(', ?', count($aSubmit['variants']) - 1) . ')', array_merge(array(STATUS_PENDING), $aSubmit['variants']));
+                $q = $_DB->q('UPDATE ' . TABLE_VARIANTS . ' SET statusid = ? WHERE id IN (?' . str_repeat(', ?', count($aSubmit['variants']) - 1) . ')', array_merge(array(STATUS_PENDING), $aSubmit['variants']));
             }
             if (!empty($aSubmit['phenotypes'])) {
-                $q = $_DB->query('UPDATE ' . TABLE_PHENOTYPES . ' SET statusid = ? WHERE id IN (?' . str_repeat(', ?', count($aSubmit['phenotypes']) - 1) . ')', array_merge(array(STATUS_PENDING), $aSubmit['phenotypes']));
+                $q = $_DB->q('UPDATE ' . TABLE_PHENOTYPES . ' SET statusid = ? WHERE id IN (?' . str_repeat(', ?', count($aSubmit['phenotypes']) - 1) . ')', array_merge(array(STATUS_PENDING), $aSubmit['phenotypes']));
             }
             if ($_PE[2] == 'individual') {
-                $q = $_DB->query('UPDATE ' . TABLE_INDIVIDUALS . ' SET statusid = ? WHERE id = ?', array(STATUS_PENDING, $nID));
+                $q = $_DB->q('UPDATE ' . TABLE_INDIVIDUALS . ' SET statusid = ? WHERE id = ?', array(STATUS_PENDING, $nID));
             }
         } elseif ($_AUTH['level'] == LEVEL_CURATOR && !empty($aSubmit['variants'])) {
             foreach ($aSubmit['variants'] as $nVariantID) {
                 // $_AUTH['level'] will be set here to properly check the level for this variant. We have to keep in mind that the $_AUTH['level'] of the individual/screening check is overwritten.
                 lovd_isAuthorized('variant', $nVariantID, true);
                 if ($_AUTH['level'] == LEVEL_OWNER) {
-                    $q = $_DB->query('UPDATE ' . TABLE_VARIANTS . ' SET statusid = ? WHERE id = ?', array_merge(array(STATUS_PENDING), array($nVariantID)));
+                    $q = $_DB->q('UPDATE ' . TABLE_VARIANTS . ' SET statusid = ? WHERE id = ?', array_merge(array(STATUS_PENDING), array($nVariantID)));
                 }
             }
         }
@@ -563,14 +563,14 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
             case 'confirmedVariants':
                 $nNullTranscript = 0;
                 if (!empty($aSubmit['variants'])) {
-                    $nNullTranscript = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING (id) WHERE vot.id IS NULL AND v.id IN (?' . str_repeat(', ?', count($aSubmit['variants']) - 1) . ')', $aSubmit['variants'])->fetchColumn();
+                    $nNullTranscript = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING (id) WHERE vot.id IS NULL AND v.id IN (?' . str_repeat(', ?', count($aSubmit['variants']) - 1) . ')', $aSubmit['variants'])->fetchColumn();
                 }
                 if (!empty($aSubmit['uploads'])) {
                     $a = array();
                     foreach ($aSubmit['uploads'] as $nUploadID => $aUpload) {
                         $a[] = $aUpload['upload_date'];
                     }
-                    $nNullTranscript += $_DB->query('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING(id) WHERE vot.id IS NULL AND v.created_date IN (?' . str_repeat(', ?', count($a) - 1) . ') AND v.created_by = ?', array_merge($a, array($_AUTH['id'])))->fetchColumn();
+                    $nNullTranscript += $_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING(id) WHERE vot.id IS NULL AND v.created_date IN (?' . str_repeat(', ?', count($a) - 1) . ') AND v.created_by = ?', array_merge($a, array($_AUTH['id'])))->fetchColumn();
                 }
                 if (!empty($aSubmit['confirmedVariants'])) {
                     $a = array();
@@ -578,25 +578,25 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
                         $a = array_merge($a, $aVariants);
                     }
                     $a = array_unique($a);
-                    $nNullTranscript += $_DB->query('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING (id) WHERE vot.id IS NULL AND v.id IN (?' . str_repeat(', ?', count($a) - 1) . ')', $a)->fetchColumn();
+                    $nNullTranscript += $_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING (id) WHERE vot.id IS NULL AND v.id IN (?' . str_repeat(', ?', count($a) - 1) . ')', $a)->fetchColumn();
                 }
                 break;
             case 'phenotype':
-                $nNullTranscript = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_PHENOTYPES . ' AS p LEFT OUTER JOIN ' . TABLE_SCREENINGS . ' AS s USING (individualid) INNER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (s2v.variantid = vot.id) WHERE vot.id IS NULL AND p.id = ?', array($nID))->fetchColumn();
+                $nNullTranscript = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_PHENOTYPES . ' AS p LEFT OUTER JOIN ' . TABLE_SCREENINGS . ' AS s USING (individualid) INNER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid) LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (s2v.variantid = vot.id) WHERE vot.id IS NULL AND p.id = ?', array($nID))->fetchColumn();
                 break;
             case 'upload':
-                $nNullTranscript = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING(id) WHERE vot.id IS NULL AND v.created_date = ? AND v.created_by = ?', array($aSubmit['uploads'][$nID]['upload_date'], $_AUTH['id']))->fetchColumn();
+                $nNullTranscript = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot USING(id) WHERE vot.id IS NULL AND v.created_date = ? AND v.created_by = ?', array($aSubmit['uploads'][$nID]['upload_date'], $_AUTH['id']))->fetchColumn();
                 break;
         }
 
         if ($nNullTranscript) {
-            $aManagers = $_DB->query('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ' . LEVEL_MANAGER)->fetchAllRow();
+            $aManagers = $_DB->q('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ' . LEVEL_MANAGER)->fetchAllRow();
         }
         // Select all curators that need to be mailed.
-        $aCurators = $_DB->query('SELECT u.name, u.email, u.level FROM ' . TABLE_CURATES . ' AS c, ' . TABLE_USERS . ' AS u WHERE c.userid = u.id ' . (count($aManagers)? 'AND u.level != ' . LEVEL_MANAGER . ' ' : '') . 'AND c.geneid IN (?' . str_repeat(', ?', count($aGenes) - 1) . ') AND allow_edit = 1 GROUP BY u.id ORDER BY u.level DESC, u.name', $aGenes)->fetchAllRow();
+        $aCurators = $_DB->q('SELECT u.name, u.email, u.level FROM ' . TABLE_CURATES . ' AS c, ' . TABLE_USERS . ' AS u WHERE c.userid = u.id ' . (count($aManagers)? 'AND u.level != ' . LEVEL_MANAGER . ' ' : '') . 'AND c.geneid IN (?' . str_repeat(', ?', count($aGenes) - 1) . ') AND allow_edit = 1 GROUP BY u.id ORDER BY u.level DESC, u.name', $aGenes)->fetchAllRow();
     } else {
         // If there are no genes then we can only mail managers.
-        $aManagers = $_DB->query('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ' . LEVEL_MANAGER)->fetchAllRow();
+        $aManagers = $_DB->q('SELECT name, email FROM ' . TABLE_USERS . ' WHERE level = ' . LEVEL_MANAGER)->fetchAllRow();
     }
     // Put their names in the email also.
     foreach ($aManagers as $aUser) {
@@ -675,7 +675,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
         );
 
     // Load the non-shared custom columns and add them to the fields list.
-    $qCols = $_DB->query('SELECT c.id, c.head_column FROM ' . TABLE_COLS . ' AS c INNER JOIN ' . TABLE_ACTIVE_COLS . ' AS ac ON (c.id = ac.colid) WHERE c.id NOT LIKE "VariantOnTranscript/%" ' . (empty($aSubmit['screenings']) && $_PE[2] != 'confirmedVariants'? 'AND c.id NOT LIKE "Screening/%" ' : '') . ($_PE[2] != 'individual'? 'AND c.id NOT LIKE "Individual/%" ' : '') . 'AND c.id NOT LIKE "Phenotype/%" ORDER BY c.col_order', array());
+    $qCols = $_DB->q('SELECT c.id, c.head_column FROM ' . TABLE_COLS . ' AS c INNER JOIN ' . TABLE_ACTIVE_COLS . ' AS ac ON (c.id = ac.colid) WHERE c.id NOT LIKE "VariantOnTranscript/%" ' . (empty($aSubmit['screenings']) && $_PE[2] != 'confirmedVariants'? 'AND c.id NOT LIKE "Screening/%" ' : '') . ($_PE[2] != 'individual'? 'AND c.id NOT LIKE "Individual/%" ' : '') . 'AND c.id NOT LIKE "Phenotype/%" ORDER BY c.col_order', array());
     if ($_PE[2] == 'individual') {
         unset($aScreeningFields['individualid']);
         unset($aPhenotypeFields['individualid']);
@@ -698,7 +698,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
     foreach ($aGenes as $sGene) {
         $sColNamesVOT = 'VOTCols_' . $sGene;
         $$sColNamesVOT = $aVariantOnTranscriptFields;
-        $qCols = $_DB->query('SELECT c.id, c.head_column FROM ' . TABLE_COLS . ' AS c INNER JOIN ' . TABLE_SHARED_COLS . ' AS sc ON (sc.colid = c.id) WHERE c.id LIKE "VariantOnTranscript/%" AND sc.geneid = ? ORDER BY sc.col_order', array($sGene));
+        $qCols = $_DB->q('SELECT c.id, c.head_column FROM ' . TABLE_COLS . ' AS c INNER JOIN ' . TABLE_SHARED_COLS . ' AS sc ON (sc.colid = c.id) WHERE c.id LIKE "VariantOnTranscript/%" AND sc.geneid = ? ORDER BY sc.col_order', array($sGene));
         while ($aCol = $qCols->fetchAssoc()) {
             ${$sColNamesVOT}[$aCol['id']] = $aCol['head_column'];
         }
@@ -708,19 +708,19 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
     foreach ($aDiseases as $sDisease) {
         $sColNamesPhen = 'PhenCols_' . $sDisease;
         $$sColNamesPhen = $aPhenotypeFields;
-        $qCols = $_DB->query('SELECT c.id, c.head_column FROM ' . TABLE_COLS . ' AS c INNER JOIN ' . TABLE_SHARED_COLS . ' AS sc ON (sc.colid = c.id) WHERE c.id LIKE "Phenotype/%" AND sc.diseaseid = ? ORDER BY sc.col_order', array($sDisease));
+        $qCols = $_DB->q('SELECT c.id, c.head_column FROM ' . TABLE_COLS . ' AS c INNER JOIN ' . TABLE_SHARED_COLS . ' AS sc ON (sc.colid = c.id) WHERE c.id LIKE "Phenotype/%" AND sc.diseaseid = ? ORDER BY sc.col_order', array($sDisease));
         while ($aCol = $qCols->fetchAssoc()) {
             ${$sColNamesPhen}[$aCol['id']] = $aCol['head_column'];
         }
     }
 
-    $_AUTH['country_'] = $_DB->query('SELECT name FROM ' . TABLE_COUNTRIES . ' WHERE id = ?', array($_AUTH['countryid']))->fetchColumn();
+    $_AUTH['country_'] = $_DB->q('SELECT name FROM ' . TABLE_COUNTRIES . ' WHERE id = ?', array($_AUTH['countryid']))->fetchColumn();
 
     // Build up the arrays that will create the data blocks in the email.
     // Select all data from the database that belong to this submission and put it in a variable.
     $bUnpublished = false;
     if ($_PE[2] == 'individual') {
-        $zIndividualDetails = $_DB->query('SELECT i.*, u.name AS owned_by_ FROM ' . TABLE_INDIVIDUALS . ' AS i LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (i.owned_by = u.id) WHERE i.id = ?', array($nID))->fetchAssoc();
+        $zIndividualDetails = $_DB->q('SELECT i.*, u.name AS owned_by_ FROM ' . TABLE_INDIVIDUALS . ' AS i LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (i.owned_by = u.id) WHERE i.id = ?', array($nID))->fetchAssoc();
         $zIndividualDetails = lovd_prepareSubmitData('individual', $zIndividualDetails);
         if (ACTION == 'edit') {
             $aEdits = $_SESSION['work']['edits']['individual'][$nID];
@@ -768,7 +768,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
             $aEdits = lovd_prepareSubmitData('phenotype', $aEdits);
         }
         foreach ($aSubmit['phenotypes'] as $nPhenotypeID) {
-            $z = $_DB->query('SELECT p.*, d.id AS diseaseid, d.name AS diseaseid_, u.name AS owned_by_ FROM ' . TABLE_PHENOTYPES . ' AS p LEFT OUTER JOIN ' . TABLE_DISEASES . ' AS d ON (p.diseaseid = d.id) LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (p.owned_by = u.id) WHERE p.id = ?', array($nPhenotypeID))->fetchAssoc();
+            $z = $_DB->q('SELECT p.*, d.id AS diseaseid, d.name AS diseaseid_, u.name AS owned_by_ FROM ' . TABLE_PHENOTYPES . ' AS p LEFT OUTER JOIN ' . TABLE_DISEASES . ' AS d ON (p.diseaseid = d.id) LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (p.owned_by = u.id) WHERE p.id = ?', array($nPhenotypeID))->fetchAssoc();
             $z = lovd_prepareSubmitData('phenotype', $z);
             $bUnpublished = ($bUnpublished || $z['statusid'] < STATUS_MARKED);
             $sVariableNamePhen = 'zPhenotypeDetails_' . $nPhenotypeID;
@@ -815,10 +815,10 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
             $sVariableNameSCR = 'zScreeningsDetails_' . $nScreeningID;
             $a = $aScreeningFields;
             $a[0] = $sVariableNameSCR;
-            $$sVariableNameSCR = $_DB->query('SELECT s.*, u.name AS owned_by_ FROM ' . TABLE_SCREENINGS . ' AS s LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (s.owned_by = u.id) WHERE s.id = ?', array($nScreeningID))->fetchAssoc();
+            $$sVariableNameSCR = $_DB->q('SELECT s.*, u.name AS owned_by_ FROM ' . TABLE_SCREENINGS . ' AS s LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (s.owned_by = u.id) WHERE s.id = ?', array($nScreeningID))->fetchAssoc();
             $$sVariableNameSCR = lovd_prepareSubmitData('screening', $$sVariableNameSCR);
             if (${$sVariableNameSCR}['variants_found']) {
-                ${$sVariableNameSCR}['variants_found_'] = $_DB->query('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nScreeningID))->fetchColumn();
+                ${$sVariableNameSCR}['variants_found_'] = $_DB->q('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nScreeningID))->fetchColumn();
                 if (${$sVariableNameSCR}['variants_found_'] && isset($aSubmit['confirmedVariants'][$nScreeningID])) {
                     ${$sVariableNameSCR}['variants_found_'] .= ' (inc. ' . count($aSubmit['confirmedVariants'][$nScreeningID]) . ' confirmed)';
                 } elseif (!${$sVariableNameSCR}['variants_found_']) {
@@ -858,8 +858,8 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
         $sVariableNameSCR = 'zScreeningsDetails_' . $nID;
         $a = $aScreeningFields;
         $a[0] = $sVariableNameSCR;
-        $$sVariableNameSCR = $_DB->query('SELECT s.*, u.name AS owned_by_ FROM ' . TABLE_SCREENINGS . ' AS s LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (s.owned_by = u.id) WHERE s.id = ?', array($nID))->fetchAssoc();
-        ${$sVariableNameSCR}['variants_found_'] = $_DB->query('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn();
+        $$sVariableNameSCR = $_DB->q('SELECT s.*, u.name AS owned_by_ FROM ' . TABLE_SCREENINGS . ' AS s LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (s.owned_by = u.id) WHERE s.id = ?', array($nID))->fetchAssoc();
+        ${$sVariableNameSCR}['variants_found_'] = $_DB->q('SELECT COUNT(variantid) FROM ' . TABLE_SCR2VAR . ' WHERE screeningid = ?', array($nID))->fetchColumn();
         ${$sVariableNameSCR}['variants_found_'] = (${$sVariableNameSCR}['variants_found_'] - count($aSubmit['confirmedVariants'][$nID])) . ' + ' . count($aSubmit['confirmedVariants'][$nID]) . ' additionaly confirmed';
         (${$sVariableNameSCR}['owned_by'] != $_AUTH['id']? $a['owned_by_'] = 'Data owner' : false);
         $aScreeningDetails[] = $a;
@@ -876,9 +876,9 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
             $a = $aVariantOnGenomeFields;
             $a[0] = $sVariableNameVOG;
             if ($_PE[2] == 'variant') {
-                $$sVariableNameVOG = $_DB->query('SELECT v.*, a.name AS allele_, u.name AS owned_by_, IFNULL(s2v.screeningid, "") AS screeningid FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (v.id = s2v.variantid) LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (v.owned_by = u.id) LEFT OUTER JOIN ' . TABLE_ALLELES . ' AS a ON (v.allele = a.id) WHERE v.id = ?', array($nVariantID))->fetchAssoc();
+                $$sVariableNameVOG = $_DB->q('SELECT v.*, a.name AS allele_, u.name AS owned_by_, IFNULL(s2v.screeningid, "") AS screeningid FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (v.id = s2v.variantid) LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (v.owned_by = u.id) LEFT OUTER JOIN ' . TABLE_ALLELES . ' AS a ON (v.allele = a.id) WHERE v.id = ?', array($nVariantID))->fetchAssoc();
             } else {
-                $$sVariableNameVOG = $_DB->query('SELECT v.*, a.name AS allele_, u.name AS owned_by_ FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (v.owned_by = u.id) LEFT OUTER JOIN ' . TABLE_ALLELES . ' AS a ON (v.allele = a.id) WHERE v.id = ?', array($nVariantID))->fetchAssoc();
+                $$sVariableNameVOG = $_DB->q('SELECT v.*, a.name AS allele_, u.name AS owned_by_ FROM ' . TABLE_VARIANTS . ' AS v LEFT OUTER JOIN ' . TABLE_USERS . ' AS u ON (v.owned_by = u.id) LEFT OUTER JOIN ' . TABLE_ALLELES . ' AS a ON (v.allele = a.id) WHERE v.id = ?', array($nVariantID))->fetchAssoc();
             }
             $$sVariableNameVOG = lovd_prepareSubmitData('variant', $$sVariableNameVOG);
             $bUnpublished = ($bUnpublished || ${$sVariableNameVOG}['statusid'] < STATUS_MARKED);
@@ -914,7 +914,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
             }
             $aVariantDetails[] = $a;
 
-            $q = $_DB->query('SELECT vot.*, CONCAT(t.id_ncbi, " (", t.geneid, ")") AS id_ncbi_, t.geneid FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE vot.id = ?', array($nVariantID));
+            $q = $_DB->q('SELECT vot.*, CONCAT(t.id_ncbi, " (", t.geneid, ")") AS id_ncbi_, t.geneid FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id) WHERE vot.id = ?', array($nVariantID));
             while ($z = $q->fetchAssoc()) {
                 $z['statusid'] = 9;
                 $z = lovd_prepareSubmitData('variant', $z);
@@ -973,7 +973,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
             if ($zUploadDetails['owned_by'] != $_AUTH['id']) {
                 // Include 'Data owner' field if owner is not the submitter.
                 $a['owned_by_'] = 'Data owner';
-                ${$sVariableNameUpload}['owned_by_'] = $_DB->query('SELECT name FROM ' . TABLE_USERS . ' WHERE id = ?', array($zUploadDetails['owned_by']))->fetchColumn();
+                ${$sVariableNameUpload}['owned_by_'] = $_DB->q('SELECT name FROM ' . TABLE_USERS . ' WHERE id = ?', array($zUploadDetails['owned_by']))->fetchColumn();
             }
             ${$sVariableNameUpload}['mapping_flags_'] = (($zUploadDetails['mapping_flags'] & MAPPING_ALLOW)? 'On' . (($zUploadDetails['mapping_flags'] & MAPPING_ALLOW_CREATE_GENES)? ', creating genes as needed' : '') : 'Off');
 
@@ -1039,7 +1039,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
 
     // Get owners address.
     if (!empty($aOwner)) {
-        $aCC = array_merge($aCC, $_DB->query('SELECT name, email FROM ' . TABLE_USERS . ' WHERE id IN (?' . str_repeat(', ?', count($aOwner) - 1) . ')', $aOwner)->fetchAllRow());
+        $aCC = array_merge($aCC, $_DB->q('SELECT name, email FROM ' . TABLE_USERS . ' WHERE id IN (?' . str_repeat(', ?', count($aOwner) - 1) . ')', $aOwner)->fetchAllRow());
     }
 
     // Send mail.

--- a/src/transcripts.php
+++ b/src/transcripts.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2022-06-07
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -51,7 +51,7 @@ if (!ACTION && (empty($_PE[1]) || preg_match('/^[a-z][a-z0-9#@-]*$/i', $_PE[1]))
     if (empty($_PE[1])) {
         $sGene = '';
     } else {
-        $sGene = $_DB->query('SELECT id FROM ' . TABLE_GENES . ' WHERE id = ?', array($_PE[1]))->fetchColumn();
+        $sGene = $_DB->q('SELECT id FROM ' . TABLE_GENES . ' WHERE id = ?', array($_PE[1]))->fetchColumn();
         $_GET['search_geneid'] = '="' . $sGene . '"';
         lovd_isAuthorized('gene', $sGene);
     }
@@ -138,7 +138,7 @@ if (PATH_COUNT == 2 && !ctype_digit($_PE[1]) && !ACTION) {
     // When we have multiple hits, refer to listView.
 
     $sID = $_PE[1];
-    if ($nID = $_DB->query('SELECT id FROM ' . TABLE_TRANSCRIPTS . ' WHERE id_ncbi = ?', array($sID))->fetchColumn()) {
+    if ($nID = $_DB->q('SELECT id FROM ' . TABLE_TRANSCRIPTS . ' WHERE id_ncbi = ?', array($sID))->fetchColumn()) {
         header('Location: ' . lovd_getInstallURL() . $_PE[0] . '/' . $nID);
     } else {
         define('PAGE_TITLE', 'Transcript ' . $sID);
@@ -206,7 +206,7 @@ if (ACTION == 'create') {
 
 
     // Gene given, check validity.
-    $sGene = $_DB->query('SELECT id FROM ' . TABLE_GENES . ' WHERE id = ?', array($_PE[1]))->fetchColumn();
+    $sGene = $_DB->q('SELECT id FROM ' . TABLE_GENES . ' WHERE id = ?', array($_PE[1]))->fetchColumn();
     define('PAGE_TITLE', 'Add transcript entry to ' . (!$sGene? 'a' : ' the ' . $sGene) . ' gene');
     $sPath = CURRENT_PATH . '?' . ACTION;
     $sPathBase = $_PE[0] . '?' . ACTION;
@@ -240,7 +240,7 @@ if (ACTION == 'create') {
             unset($_SESSION['work'][$sPathBase][min(array_keys($_SESSION['work'][$sPathBase]))]);
         }
 
-        $zGene = $_DB->query('SELECT id, name, chromosome, refseq_UD FROM ' . TABLE_GENES . ' WHERE id = ?', array($sGene))->fetchAssoc();
+        $zGene = $_DB->q('SELECT id, name, chromosome, refseq_UD FROM ' . TABLE_GENES . ' WHERE id = ?', array($sGene))->fetchAssoc();
 
         $_T->printHeader();
         $_T->printTitle();
@@ -394,7 +394,7 @@ if (ACTION == 'create') {
                         $sTranscriptName = $zData['transcriptNames'][$sTranscript];
 
                         $aTranscriptPositions = $zData['transcriptPositions'][$sTranscript];
-                        $q = $_DB->query('INSERT INTO ' . TABLE_TRANSCRIPTS . '(id, geneid, name, id_mutalyzer, id_ncbi, id_ensembl, id_protein_ncbi, id_protein_ensembl, id_protein_uniprot, remarks, position_c_mrna_start, position_c_mrna_end, position_c_cds_end, position_g_mrna_start, position_g_mrna_end, created_date, created_by) ' .
+                        $q = $_DB->q('INSERT INTO ' . TABLE_TRANSCRIPTS . '(id, geneid, name, id_mutalyzer, id_ncbi, id_ensembl, id_protein_ncbi, id_protein_ensembl, id_protein_uniprot, remarks, position_c_mrna_start, position_c_mrna_end, position_c_cds_end, position_g_mrna_start, position_g_mrna_end, created_date, created_by) ' .
                                          'VALUES(NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), ?)',
                                          array($zData['gene']['id'], $sTranscriptName, $nMutalyzerID, $sTranscript, '', $sTranscriptProtein, '', '', '', $aTranscriptPositions['cTransStart'], $aTranscriptPositions['cTransEnd'], $aTranscriptPositions['cCDSStop'], $aTranscriptPositions['chromTransStart'], $aTranscriptPositions['chromTransEnd'], $_POST['created_by']));
                         if (!$q) {

--- a/src/uninstall.php
+++ b/src/uninstall.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-13
- * Modified    : 2020-09-17
- * For LOVD    : 3.0-25
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *
@@ -99,7 +99,7 @@ if (!empty($_POST)) {
 
                 foreach ($aTables as $sTable) {
                     $sSQL = 'DROP TABLE IF EXISTS ' . $sTable;
-                    $q = $_DB->query($sSQL, array(), false);
+                    $q = $_DB->q($sSQL, array(), false);
                     if (!$q) {
                         // Error when running query. We will use the Div for the form now.
                         $sMessage = 'Error during uninstallation while running query.<BR>I ran:<DIV class="err">' . str_replace(array("\r\n", "\r", "\n"), '<BR>', $sSQL) . '</DIV><BR>I got:<DIV class="err">' . str_replace(array("\r\n", "\r", "\n"), '<BR>', $_DB->formatError()) . '</DIV><BR><BR>' .
@@ -107,7 +107,7 @@ if (!empty($_POST)) {
                                     'Please <A href="' . $_SETT['upstream_URL'] . 'bugs/" target="_blank">file a bug</A> and include the above messages to help us solve the problem.';
                         $_BAR->setMessage($sMessage, 'done');
                         $_BAR->setMessageVisibility('done', true);
-                        $_DB->query('DROP TABLE IF EXISTS ' . implode(', ', $aTables), array(), false); // Try again to remove everything.
+                        $_DB->q('DROP TABLE IF EXISTS ' . implode(', ', $aTables), array(), false); // Try again to remove everything.
                         print('</BODY>' . "\n" .
                               '</HTML>' . "\n");
                         exit;
@@ -143,7 +143,7 @@ if (!empty($_POST)) {
             // Does any of these tables exist yet?
             print('Checking LOVD installation...' . "\n");
             $aTables = array();
-            $qTables = $_DB->query('SHOW TABLES LIKE "' . TABLEPREFIX . '\_%"');
+            $qTables = $_DB->q('SHOW TABLES LIKE "' . TABLEPREFIX . '\_%"');
             while ($sTable = $qTables->fetchColumn()) {
                 if (in_array($sTable, $_TABLES)) {
                     $aTables[] = $sTable;
@@ -156,10 +156,10 @@ if (!empty($_POST)) {
             // General statistics...
             print("\n");
             // 2012-02-01; 3.0-beta-02; Exclude "LOVD" system user.
-            $nUsers = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_USERS . ' WHERE id > 0')->fetchColumn();
-            $nIndividuals = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS)->fetchColumn();
-            $nScreenings = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_SCREENINGS)->fetchColumn();
-            $nVars = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_VARIANTS)->fetchColumn();
+            $nUsers = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_USERS . ' WHERE id > 0')->fetchColumn();
+            $nIndividuals = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS)->fetchColumn();
+            $nScreenings = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_SCREENINGS)->fetchColumn();
+            $nVars = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS)->fetchColumn();
             $nGenes = count(lovd_getGeneList());
             print('  Found ' . $nUsers . ' user' . ($nUsers == 1? '' : 's') . '.' . "\n" .
                   '  Found ' . $nIndividuals . ' individual' . ($nIndividuals == 1? '' : 's') . '.' . "\n" .

--- a/src/users.php
+++ b/src/users.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2022-06-17
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -221,7 +221,7 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
                 } elseif (!lovd_checkORCIDChecksum($_POST['orcid'])) {
                     // Checksum not valid!
                     lovd_errorAdd('orcid', 'The given ORCID ID is not valid.');
-                } elseif ($_DB->query('SELECT COUNT(*) FROM ' . TABLE_USERS . ' WHERE orcid_id = ?', array($_POST['orcid']))->fetchColumn()) {
+                } elseif ($_DB->q('SELECT COUNT(*) FROM ' . TABLE_USERS . ' WHERE orcid_id = ?', array($_POST['orcid']))->fetchColumn()) {
                     // ID is not unique!
                     lovd_errorAdd('orcid', 'There is already an account registered with this ORCID ID.' . (!$_CONF['allow_unlock_accounts']? '' : ' Did you <A href="reset_password">forget your password</A>?'));
                 } else {
@@ -312,7 +312,7 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
                         // FIXME: Do we need to loop through the addresses?
                         $sCountryCode = ($sCountryCode?: $aORCID['person']['addresses']['address'][0]['country']['value']);
                         if ($sCountryCode) {
-                            $sCountry = $_DB->query('SELECT name FROM ' . TABLE_COUNTRIES . ' WHERE id = ?', array($sCountryCode))->fetchColumn();
+                            $sCountry = $_DB->q('SELECT name FROM ' . TABLE_COUNTRIES . ' WHERE id = ?', array($sCountryCode))->fetchColumn();
                         } else {
                             $sCountry = '';
                         }
@@ -487,10 +487,10 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
             $nID = $_DATA->insertEntry($_POST, $aFields);
             if (ACTION == 'register') {
                 // Store that user has been created by themself.
-                $_DB->query('UPDATE ' . TABLE_USERS . ' SET created_by = id WHERE id = ?', array($nID));
+                $_DB->q('UPDATE ' . TABLE_USERS . ' SET created_by = id WHERE id = ?', array($nID));
 
                 // Load authorization.
-                $_SESSION['auth'] = $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchAssoc();
+                $_SESSION['auth'] = $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchAssoc();
                 $_AUTH =& $_SESSION['auth'];
                 // To prevent notices in the header for instance...
                 $_AUTH['curates']      = array();
@@ -540,7 +540,7 @@ if (PATH_COUNT == 1 && in_array(ACTION, array('create', 'register'))) {
 
                 // Array containing the submitter fields.
                 $_POST['id'] = $nID;
-                $_POST['country_'] = $_DB->query('SELECT name FROM ' . TABLE_COUNTRIES . ' WHERE id = ?', array($_POST['countryid']))->fetchColumn();
+                $_POST['country_'] = $_DB->q('SELECT name FROM ' . TABLE_COUNTRIES . ' WHERE id = ?', array($_POST['countryid']))->fetchColumn();
                 $aMailFields =
                     array(
                         '_POST',
@@ -906,7 +906,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
 
     // Deleting a user makes the current user curator of the deleted user's genes if there is no curator left for them.
     // Find curated genes and see if they're alone.
-    $aCuratedGenes = $_DB->query('SELECT DISTINCT geneid FROM ' . TABLE_CURATES . ' WHERE geneid NOT IN (SELECT DISTINCT geneid FROM ' . TABLE_CURATES . ' WHERE userid != ? AND allow_edit = 1)', array($nID))->fetchAllColumn();
+    $aCuratedGenes = $_DB->q('SELECT DISTINCT geneid FROM ' . TABLE_CURATES . ' WHERE geneid NOT IN (SELECT DISTINCT geneid FROM ' . TABLE_CURATES . ' WHERE userid != ? AND allow_edit = 1)', array($nID))->fetchAllColumn();
 
     // Define this here, since it's repeated.
     // Array which will make up the form table.
@@ -945,7 +945,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
                     // First, make the current user curator for the genes about to be abandoned by this user.
                     $_DB->beginTransaction();
                     if ($aCuratedGenes) {
-                        $_DB->query('UPDATE ' . TABLE_CURATES . ' SET userid = ? WHERE userid = ? AND geneid IN (?' . str_repeat(', ?', count($aCuratedGenes) - 1) . ')', array_merge(array($_AUTH['id'], $nID), $aCuratedGenes));
+                        $_DB->q('UPDATE ' . TABLE_CURATES . ' SET userid = ? WHERE userid = ? AND geneid IN (?' . str_repeat(', ?', count($aCuratedGenes) - 1) . ')', array_merge(array($_AUTH['id'], $nID), $aCuratedGenes));
                     }
 
                     // Query text.
@@ -979,12 +979,12 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
             $_T->printTitle();
 
             // FIXME; extend this later.
-            $nLogs = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_LOGS . ' WHERE userid = ?', array($nID))->fetchColumn();
-            $nCurates = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_CURATES . ' WHERE userid = ?', array($nID))->fetchColumn();
-            $nIndividuals = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' WHERE owned_by = ? OR created_by = ? OR edited_by = ?', array($nID, $nID, $nID))->fetchColumn();
-            $nScreenings = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_SCREENINGS . ' WHERE owned_by = ? OR created_by = ? OR edited_by = ?', array($nID, $nID, $nID))->fetchColumn();
-            $nVars = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' WHERE owned_by = ? OR created_by = ? OR edited_by = ?', array($nID, $nID, $nID))->fetchColumn();
-            $nGenes = $_DB->query('SELECT COUNT(*) FROM ' . TABLE_GENES . ' WHERE created_by = ? OR edited_by = ?', array($nID, $nID))->fetchColumn();
+            $nLogs = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_LOGS . ' WHERE userid = ?', array($nID))->fetchColumn();
+            $nCurates = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_CURATES . ' WHERE userid = ?', array($nID))->fetchColumn();
+            $nIndividuals = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_INDIVIDUALS . ' WHERE owned_by = ? OR created_by = ? OR edited_by = ?', array($nID, $nID, $nID))->fetchColumn();
+            $nScreenings = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_SCREENINGS . ' WHERE owned_by = ? OR created_by = ? OR edited_by = ?', array($nID, $nID, $nID))->fetchColumn();
+            $nVars = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' WHERE owned_by = ? OR created_by = ? OR edited_by = ?', array($nID, $nID, $nID))->fetchColumn();
+            $nGenes = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_GENES . ' WHERE created_by = ? OR edited_by = ?', array($nID, $nID))->fetchColumn();
 
             lovd_showInfoTable('<B>The user you are about to delete has the following references to data in this installation:</B><BR>' .
                                $nLogs . ' log entr' . ($nLogs == 1? 'y' : 'ies') . ' will be deleted,<BR>' .
@@ -1058,7 +1058,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'boot') {
     // Require manager clearance.
     lovd_requireAUTH(LEVEL_MANAGER);
 
-    $zData = $_DB->query('SELECT name, username, phpsessid, level FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchAssoc();
+    $zData = $_DB->q('SELECT name, username, phpsessid, level FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchAssoc();
     if (!$zData || $zData['level'] >= $_AUTH['level']) {
         // Wrong ID, apparently.
         lovd_showInfoTable('No such ID!', 'stop');
@@ -1095,7 +1095,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('lock', 'u
     // Require manager clearance.
     lovd_requireAUTH(LEVEL_MANAGER);
 
-    $zData = $_DB->query('SELECT username, name, (login_attempts >= 3) AS locked, level FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchAssoc();
+    $zData = $_DB->q('SELECT username, name, (login_attempts >= 3) AS locked, level FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchAssoc();
     if (!$zData || $zData['level'] >= $_AUTH['level']) {
         // Wrong ID, apparently.
         lovd_showInfoTable('No such ID!', 'stop');
@@ -1110,7 +1110,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('lock', 'u
     }
 
     // The actual query.
-    $_DB->query('UPDATE ' . TABLE_USERS . ' SET login_attempts = ' . ($zData['locked']? 0 : 3) . ' WHERE id = ?', array($nID));
+    $_DB->q('UPDATE ' . TABLE_USERS . ' SET login_attempts = ' . ($zData['locked']? 0 : 3) . ' WHERE id = ?', array($nID));
 
     // Write to log...
     lovd_writeLog('Event', LOG_EVENT, ucfirst(ACTION) . 'ed user ' . $nID . ' - ' . $zData['username'] . ' (' . $zData['name'] . ') - with level ' . $_SETT['user_levels'][$zData['level']]);
@@ -1134,7 +1134,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'submissions') {
     $_T->printHeader();
     $_T->printTitle();
 
-    $zData = $_DB->query('SELECT id, saved_work FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchAssoc();
+    $zData = $_DB->q('SELECT id, saved_work FROM ' . TABLE_USERS . ' WHERE id = ?', array($nID))->fetchAssoc();
     if (!$zData) {
         // Wrong ID, apparently.
         lovd_showInfoTable('No such ID!', 'stop');
@@ -1238,7 +1238,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'share_access') {
     $bAllowGrantEdit = true;
     $sUserListID = 'user_share_access_' . $nID;
 
-    $zData = $_DB->query('
+    $zData = $_DB->q('
         SELECT name, level, institute, email
         FROM ' . TABLE_USERS . '
         WHERE id = ?', array($nID))->fetchAssoc();

--- a/src/view.php
+++ b/src/view.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-12-05
- * Modified    : 2022-02-10
- * For LOVD    : 3.0-28
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -48,7 +48,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
     // URL: /view/DMD/NM_004006.2
     // View all entries in a specific gene, affecting a specific trancript, with all joinable data.
 
-    $qGene = $_DB->query('
+    $qGene = $_DB->q('
         SELECT g.id, COUNT(t.id)
         FROM ' . TABLE_GENES . ' AS g
           LEFT OUTER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON g.id = t.geneid
@@ -66,7 +66,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
 
         // Overview is given per transcript. If there is only one, it will be mentioned.
         // If there are more, you will be able to select which one you'd like to see.
-        $aTranscriptsWithVariants = $_DB->query(
+        $aTranscriptsWithVariants = $_DB->q(
             'SELECT t.id, t.id_ncbi
              FROM ' . TABLE_TRANSCRIPTS . ' AS t
                INNER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (t.id = vot.transcriptid)

--- a/tests/selenium_tests/shared_tests/check_all_authorization_levels.php
+++ b/tests/selenium_tests/shared_tests/check_all_authorization_levels.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-22
- * Modified    : 2020-05-26
- * For LOVD    : 3.0-24
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -80,7 +80,7 @@ class CheckAuthorizationsTest extends LOVDSeleniumWebdriverBaseTestCase
         // 6 - Submitter (colleague).
 
         // Assertions for DATABASE ADMINISTRATOR.
-        $_AUTH = $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 1')->fetchAssoc();
+        $_AUTH = $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 1')->fetchAssoc();
         $this->assertNotFalse($_AUTH);
         $this->assertEquals(LEVEL_ADMIN, $_AUTH['level']);
         $this->assertEquals(1, lovd_isAuthorized('user', 'does_not_exist'), false);
@@ -141,7 +141,7 @@ class CheckAuthorizationsTest extends LOVDSeleniumWebdriverBaseTestCase
         // 6 - Submitter (colleague).
 
         // Assertions for MANAGER.
-        $_AUTH = $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 2')->fetchAssoc();
+        $_AUTH = $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 2')->fetchAssoc();
         $this->assertNotFalse($_AUTH);
         $this->assertEquals(LEVEL_MANAGER, $_AUTH['level']);
         $this->assertEquals(1, lovd_isAuthorized('user', 'does_not_exist'), false);
@@ -203,7 +203,7 @@ class CheckAuthorizationsTest extends LOVDSeleniumWebdriverBaseTestCase
 
         // Assertions for CURATOR.
         $_SESSION = array(
-            'auth' => $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 3')->fetchAssoc(),
+            'auth' => $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 3')->fetchAssoc(),
         );
 
         // Let LOVD load the curator, collaborator, and colleagues access.
@@ -285,7 +285,7 @@ class CheckAuthorizationsTest extends LOVDSeleniumWebdriverBaseTestCase
 
         // Assertions for COLLABORATOR.
         $_SESSION = array(
-            'auth' => $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 4')->fetchAssoc(),
+            'auth' => $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 4')->fetchAssoc(),
         );
 
         // Let LOVD load the curator, collaborator, and colleagues access.
@@ -367,7 +367,7 @@ class CheckAuthorizationsTest extends LOVDSeleniumWebdriverBaseTestCase
 
         // Assertions for OWNER.
         $_SESSION = array(
-            'auth' => $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 5')->fetchAssoc(),
+            'auth' => $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 5')->fetchAssoc(),
         );
 
         // Let LOVD load the curator, collaborator, and colleagues access.
@@ -464,7 +464,7 @@ class CheckAuthorizationsTest extends LOVDSeleniumWebdriverBaseTestCase
 
         // Assertions for COLLEAGUE.
         $_SESSION = array(
-            'auth' => $_DB->query('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 6')->fetchAssoc(),
+            'auth' => $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE id = 6')->fetchAssoc(),
         );
 
         // Let LOVD load the curator, collaborator, and colleagues access.

--- a/tests/unit_tests/query_optimizer.php
+++ b/tests/unit_tests/query_optimizer.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-02-10
- * Modified    : 2020-09-10
- * For LOVD    : 3.0-25
+ * Modified    : 2022-11-22
+ * For LOVD    : 3.0-29
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -152,17 +152,17 @@ foreach ($aSQL as $sSQLInput => $sSQLExpectedOutput) {
     do {
         $nTries ++; // Starts at 1.
         $t = microtime(true);
-        $_DB->query(preg_replace('/^SELECT /', 'SELECT SQL_NO_CACHE ', $sSQLInput));
-        $nFoundInput = $_DB->query('SELECT FOUND_ROWS()')->fetchColumn();
+        $_DB->q(preg_replace('/^SELECT /', 'SELECT SQL_NO_CACHE ', $sSQLInput));
+        $nFoundInput = $_DB->q('SELECT FOUND_ROWS()')->fetchColumn();
         $tSQLInput = microtime(true) - $t;
 
         $t = microtime(true);
         if (strpos($sSQLOutput, 'SQL_CALC_FOUND_ROWS') !== false) {
             // We still had to use SQL_CALC_FOUND_ROWS()...
-            $_DB->query(preg_replace('/^SELECT /', 'SELECT SQL_NO_CACHE ', $sSQLOutput));
-            $nFoundOutput = $_DB->query('SELECT FOUND_ROWS()')->fetchColumn();
+            $_DB->q(preg_replace('/^SELECT /', 'SELECT SQL_NO_CACHE ', $sSQLOutput));
+            $nFoundOutput = $_DB->q('SELECT FOUND_ROWS()')->fetchColumn();
         } else {
-            $nFoundOutput = $_DB->query(preg_replace('/^SELECT /', 'SELECT SQL_NO_CACHE ', $sSQLOutput))->fetchColumn();
+            $nFoundOutput = $_DB->q(preg_replace('/^SELECT /', 'SELECT SQL_NO_CACHE ', $sSQLOutput))->fetchColumn();
         }
         $tSQLOutput = microtime(true) - $t;
     } while ($tSQLOutput > $tSQLInput || $nTries >= 5);


### PR DESCRIPTION
Fix issues with PHP8.1.
- Our LOVD_PDO methods weren't always compatible with PDO's. This needs to be fixed.
  - Rename `$_DB->query()` to `$_DB->q()`. We had to anyway change all calls to our `query()` method to make it compatible, so this is easier.
  - Update our `$_DB->prepare()` to be compatible with `PDO::prepare()`.
  - Update our `LOVD_PDO::__construct()` to be compatible to `PDO::__construct()`. Also, cleaned up the constructor's code a bit. Options were set in the driver, while we use this class elsewhere as well. Therefore, it would be better to put that kind of code where the constructor gets called.
- More might need fixing, but the issue is that our testing environment doesn't run on PHP8.1, either. And upgrading everything will require me to retest and rebuild the whole environment, including the Travis environment, and update a large number of tests... so we'll leave this to later.

Closes #618.
