### PR TITLE
Various small fixes.

### DIFF
--- a/src/ajax/check_HGVS.php
+++ b/src/ajax/check_HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-09-06
- * Modified    : 2022-10-20
+ * Modified    : 2022-11-28
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -150,7 +150,7 @@ foreach ($aVariants as $sVariant => $aVariant) {
             }
         }
 
-        // We normally don't show non-HGVS compliant suggestions. Exception;
+        // We normally don't show non-HGVS compliant suggestions. Exception 1;
         // Treat the result as HGVS compliant (i.e., accept suggestion and show)
         //  when all we had was a WTOOMUCHUNKNOWN and now we get a ESUFFIXMISSING.
         // The issue is that WTOOMUCHUNKNOWN suggests a fix, so it's stupid to then not show it.
@@ -160,6 +160,15 @@ foreach ($aVariants as $sVariant => $aVariant) {
             && array_keys($aVariant['fixed_variant_variant_info']['errors'] + $aVariant['fixed_variant_variant_info']['warnings']) == array('ESUFFIXMISSING')) {
             $aVariant['variant_info']['errors'] += array_map('htmlspecialchars', $aVariant['fixed_variant_variant_info']['errors']); // For the output.
             unset($aVariant['fixed_variant_variant_info']['errors']['ESUFFIXMISSING']);
+        }
+
+        // Exception 2; Treat the result as HGVS compliant (i.e., accept
+        //  suggestion and show) when all we have now is a EWRONGREFERENCE and
+        //  that was anyway already part of what we had.
+        if ($aVariant['variant_info'] && $aVariant['fixed_variant_variant_info']
+            && array_keys($aVariant['fixed_variant_variant_info']['errors'] + $aVariant['fixed_variant_variant_info']['warnings']) == array('EWRONGREFERENCE')
+            && isset($aVariant['variant_info']['errors']['EWRONGREFERENCE'])) {
+            unset($aVariant['fixed_variant_variant_info']['errors']['EWRONGREFERENCE']);
         }
 
         // Then check if the fix is HGVS-compliant.

--- a/src/class/PDO.php
+++ b/src/class/PDO.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-17
- * Modified    : 2022-11-23
+ * Modified    : 2022-11-28
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -64,6 +64,9 @@ class LOVD_PDO extends PDO
 
 
 
+    // Suppress Deprecated notices in PHP8.1, warning us that our method is missing a return type.
+    // This suppression works for PHP <= 8; PHP9 will force us to define return types and therefore, drop PHP5 support.
+    #[\ReturnTypeWillChange]
     function exec ($sSQL, $bHalt = true)
     {
         // Wrapper around PDO::exec().
@@ -110,6 +113,9 @@ class LOVD_PDO extends PDO
 
 
 
+    // Suppress Deprecated notices in PHP8.1, warning us that our method is missing a return type.
+    // This suppression works for PHP <= 8; PHP9 will force us to define return types and therefore, drop PHP5 support.
+    #[\ReturnTypeWillChange]
     function prepare ($sSQL, $aOptions = array(), $bHalt = true)
     {
         // Wrapper around PDO::prepare().
@@ -197,6 +203,9 @@ class LOVD_PDOStatement extends PDOStatement
     // This class provides a wrapper around PDOStatement such that database errors are handled automatically by LOVD and LOVD can use fetch*() features more easily.
     // FIXME; apparently we don't need to call parent::__construct()? I can't get that to work, and this wrapper seems to work without it anyway...
 
+    // Suppress Deprecated notices in PHP8.1, warning us that our method is missing a return type.
+    // This suppression works for PHP <= 8; PHP9 will force us to define return types and therefore, drop PHP5 support.
+    #[\ReturnTypeWillChange]
     function execute ($aSQL = array(), $bHalt = true, $bTrim = false) // Needs first argument as optional because the original function has it as optional.
     {
         // Wrapper around PDOStatement::execute().

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2022-11-22
+ * Modified    : 2022-11-25
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -273,7 +273,7 @@ function lovd_errorFindField ($sField)
     // Returns index of whether or not a certain form field has an error.
     global $_ERROR;
 
-    return @array_search($sField, $_ERROR['fields']);
+    return (!empty($_ERROR['fields']) && array_search($sField, $_ERROR['fields']));
 }
 
 


### PR DESCRIPTION
### Various small fixes.

#### PHP8.1 related.
- Properly check for `$_ERROR` before `array_search()`ing it. This is now a fatal error in PHP8.1.
- Suppress deprecation notices on PHP8.1. Method return types should now always be defined; otherwise, they will cause a deprecation notice when their parent method does have a return type defined. Suppress this. This will help us get through PHP8; PHP9 will enforce this, thereby forcing us to drop our PHP5 support.

#### HGVS library related.
- Add an exception in the HGVS interface for fixes that still have an `EWRONGREFERENCE`. The variant description is a fix; it's just that the refseq doesn't match, but it already didn't.