### PR TITLE
Sync changes from LOVD+

### DIFF
--- a/src/class/PDO.php
+++ b/src/class/PDO.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-08-17
- * Modified    : 2022-11-28
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -262,7 +262,7 @@ class LOVD_PDOStatement extends PDOStatement
     {
         // Wrapper around PDOStatement::fetchAll(PDO::FETCH_COLUMN).
         // THIS WRAPPER ONLY SUPPORTS THE col number PDOStatement::fetchAll() ARGUMENT!
-        if (!ctype_digit($nCol)) {
+        if (!is_int($nCol) && !ctype_digit($nCol)) {
             $nCol = 0;
         }
         return $this->fetchAll(PDO::FETCH_COLUMN, $nCol);
@@ -276,10 +276,10 @@ class LOVD_PDOStatement extends PDOStatement
     {
         // Wrapper around PDOStatement::fetchAll() that creates an array with one field's
         //  results as the keys and the other field's results as values.
-        if (!ctype_digit($nCol1) && !is_int($nCol1)) {
+        if (!is_int($nCol1) && !ctype_digit($nCol1)) {
             $nCol1 = 0;
         }
-        if (!ctype_digit($nCol2) && !is_int($nCol2)) {
+        if (!is_int($nCol2) && !ctype_digit($nCol2)) {
             $nCol2 = 1;
         }
         // Optimization when using the first column as a key, we can rely on PDO's features.

--- a/src/class/object_custom.php
+++ b/src/class/object_custom.php
@@ -193,7 +193,7 @@ class LOVD_Custom extends LOVD_Object
         global $_AUTH;
 
         $aFields = array();
-        foreach($this->aColumns as $sCol => $aCol) {
+        foreach ($this->aColumns as $sCol => $aCol) {
             if (!$aCol['public_add'] && $_AUTH['level'] < LEVEL_CURATOR) {
                 continue;
             }

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -553,7 +553,7 @@ class LOVD_Gene extends LOVD_Object
             // Associated with diseases...
             $zData['diseases_'] = '';
             $zData['disease_omim_'] = '';
-            foreach($zData['diseases'] as $aDisease) {
+            foreach ($zData['diseases'] as $aDisease) {
                 list($nID, $nOMIMID, $sSymbol, $sName) = $aDisease;
                 // Link to disease entry in LOVD.
                 $zData['diseases_'] .= (!$zData['diseases_']? '' : ', ') . '<A href="diseases/' . $nID . '">' . $sSymbol . '</A>';

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -749,7 +749,7 @@ class LOVD_Gene extends LOVD_Object
             $sYear = substr($zData['created_date'], 0, 4);
             $sYear = ((int) $sYear && $sYear < date('Y')? $sYear . '-' . date('Y') : date('Y'));
             $aDisclaimer = array(0 => 'No', 1 => 'Standard LOVD disclaimer', 2 => 'Own disclaimer');
-            $zData['disclaimer_']      = $aDisclaimer[$zData['disclaimer']];
+            $zData['disclaimer_']      = $aDisclaimer[(int) $zData['disclaimer']];
             $zData['disclaimer_text_'] = (!$zData['disclaimer']? '' : ($zData['disclaimer'] == 2? html_entity_decode($zData['disclaimer_text']) :
                 'The contents of this LOVD database are the intellectual property of the respective submitter(s) and curator(s) of the individual records. Individual data entries may indicate which data license applies to that specific record. When no license is listed, no permissions are granted. Any unauthorized use, copying, storage, or distribution of this material without written permission from the curator(s) will lead to copyright infringement with possible ensuing litigation. Copyright &copy; ' . $sYear . '. All Rights Reserved. For further details, refer to Directive 96/9/EC of the European Parliament and the Council of March 11 (1996) on the legal protection of databases.<BR><BR>We have used all reasonable efforts to ensure that the information displayed on these pages and contained in the databases is of high quality. We make no warranty, express or implied, as to its accuracy or that the information is fit for a particular purpose, and will not be held responsible for any consequences arising from any inaccuracies or omissions. Individuals, organizations, and companies that use this database do so on the understanding that no liability whatsoever, either direct or indirect, shall rest upon the data submitter(s), curator(s), or any of their employees or agents for the effects of any product, process, or method that may be produced or adopted by any part, notwithstanding that the formulation of such product, process or method may be based upon information here provided.'));
 

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -521,28 +521,28 @@ class LOVD_GenomeVariant extends LOVD_Custom
                 }
             }
 
-            if ($zData['mapping_flags'] & MAPPING_ALLOW) {
+            if ((int) $zData['mapping_flags'] & MAPPING_ALLOW) {
                 $sMappingLinkText  = '';
                 $sMappingLinkTitle = '';
-                if ($zData['mapping_flags'] & MAPPING_NOT_RECOGNIZED) {
+                if ((int) $zData['mapping_flags'] & MAPPING_NOT_RECOGNIZED) {
                     $zData['mapping_flags_'] = 'Variant not recognized';
-                    if ($zData['mapping_flags'] & MAPPING_ALLOW_CREATE_GENES) {
+                    if ((int) $zData['mapping_flags'] & MAPPING_ALLOW_CREATE_GENES) {
                         $zData['mapping_flags_'] .= ' (would have created genes as needed)';
                     }
                     $sMappingLinkText = 'Retry';
-                } elseif ($zData['mapping_flags'] & MAPPING_DONE) {
+                } elseif ((int) $zData['mapping_flags'] & MAPPING_DONE) {
                     $zData['mapping_flags_'] = 'Done';
-                    if ($zData['mapping_flags'] & MAPPING_ALLOW_CREATE_GENES) {
+                    if ((int) $zData['mapping_flags'] & MAPPING_ALLOW_CREATE_GENES) {
                         $zData['mapping_flags_'] .= ' (created genes as needed)';
                     }
                     $sMappingLinkText  = 'Map again';
                     $sMappingLinkTitle = 'If new transcripts have been added to LOVD, this will try to map this variant to them.';
                 } else {
                     $zData['mapping_flags_'] = 'Scheduled';
-                    if ($zData['mapping_flags'] & MAPPING_ALLOW_CREATE_GENES) {
+                    if ((int) $zData['mapping_flags'] & MAPPING_ALLOW_CREATE_GENES) {
                         $zData['mapping_flags_'] .= ', creating genes as needed';
                     }
-                    if ($zData['mapping_flags'] & MAPPING_ERROR) {
+                    if ((int) $zData['mapping_flags'] & MAPPING_ERROR) {
                         $zData['mapping_flags_'] .= ' (encountered a problem on the last attempt)';
                     }
                     $sMappingLinkText = 'Map now';

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -478,7 +478,7 @@ class LOVD_Individual extends LOVD_Custom
             }
             // Associated with diseases...
             $zData['diseases_'] = '';
-            foreach($zData['diseases'] as $aDisease) {
+            foreach ($zData['diseases'] as $aDisease) {
                 list($nID, $sSymbol, $sName) = $aDisease;
                 $zData['diseases_'] .= (!$zData['diseases_']? '' : ', ') . '<A href="diseases/' . $nID . '" title="' . $sName . '">' . $sSymbol . '</A>';
             }

--- a/src/class/object_links.php
+++ b/src/class/object_links.php
@@ -146,7 +146,7 @@ class LOVD_Link extends LOVD_Object
         } elseif (!empty($aData['active_columns'])) {
             // Check if columns are text columns, since others cannot even hold the custom link's pattern text.
             $aColumns = $_DB->q('SELECT id FROM ' . TABLE_COLS . ' WHERE mysql_type LIKE \'VARCHAR%\' OR mysql_type LIKE \'TEXT%\'')->fetchAllColumn();
-            foreach($aData['active_columns'] as $sCol) {
+            foreach ($aData['active_columns'] as $sCol) {
                 if (substr_count($sCol, '/') && !in_array($sCol, $aColumns)) {
                     // Columns without slashes are the category headers, that could be selected.
                     lovd_errorAdd('active_columns', 'Please select a valid custom column from the \'Active for columns\' selection box.');

--- a/src/class/object_transcripts.php
+++ b/src/class/object_transcripts.php
@@ -291,7 +291,7 @@ class LOVD_Transcript extends LOVD_Object
         }
 
         $nTranscripts = count($aTranscripts['info']);
-        foreach($aTranscripts['info'] as $aTranscript) {
+        foreach ($aTranscripts['info'] as $aTranscript) {
             $nProgress += ((100 - $nProgress)/$nTranscripts);
             $_BAR->setMessage('Collecting ' . $aTranscript['id'] . ' info...');
 

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -888,7 +888,7 @@ class LOVD_Object
                     if ($this->sRowID !== '') {
                         $zData['row_id'] = str_replace('{{ID}}', rawurlencode($zData['id']), $this->sRowID);
                         foreach ($zData as $key => $val) {
-                            $zData['row_id'] = preg_replace('/\{\{' . preg_quote($key, '/') . '\}\}/', rawurlencode($val), $zData['row_id']);
+                            $zData['row_id'] = preg_replace('/\{\{' . preg_quote($key, '/') . '\}\}/', rawurlencode($val ?: ''), $zData['row_id']);
                         }
                     } else {
                         $zData['row_id'] = $zData['id'];
@@ -2522,16 +2522,16 @@ class LOVD_Object
         $bFRPreview =          (!empty($_GET['FRPreviewClicked_' . $sViewListID]));
         // Selected field name for replace.
         $sFRViewListCol =      (isset($_GET['FRFieldname_' . $sViewListID])?
-                                $_GET['FRFieldname_' . $sViewListID] : null);
+                                $_GET['FRFieldname_' . $sViewListID] : '');
         // Display name of selected field.
         $sFRFieldDisplayname = (isset($_GET['FRFieldDisplayname_' . $sViewListID])?
-                                $_GET['FRFieldDisplayname_' . $sViewListID] : null);
+                                $_GET['FRFieldDisplayname_' . $sViewListID] : '');
         // Search query for find & replace.
         $sFRSearchValue =      (isset($_GET['FRSearch_' . $sViewListID])?
-                                $_GET['FRSearch_' . $sViewListID] : null);
+                                $_GET['FRSearch_' . $sViewListID] : '');
         // Replace value for find & replace.
         $sFRReplaceValue =     (isset($_GET['FRReplace_' . $sViewListID])?
-                                $_GET['FRReplace_' . $sViewListID] : null);
+                                $_GET['FRReplace_' . $sViewListID] : '');
         // Type of matching.
         $sFRMatchType =        (isset($_GET['FRMatchType_' . $sViewListID])?
                                 $_GET['FRMatchType_' . $sViewListID] : null);
@@ -3206,8 +3206,8 @@ FROptions
                     foreach ($zData as $key => $val) {
                         // Also allow data from $zData to be put into the row link & row id.
                         // FIXME; This is a temporary ugly solution, so we need to fix this later!!!!
-                        $zData['row_link'] = preg_replace('/\{\{' . preg_quote($key, '/') . '\}\}/', rawurlencode(htmlspecialchars(addslashes($val))), $zData['row_link']);
-                        $zData['row_link'] = preg_replace('/\{\{zData_' . preg_quote($key, '/') . '\}\}/', rawurlencode(htmlspecialchars(addslashes($val))), $zData['row_link']);
+                        $zData['row_link'] = preg_replace('/\{\{' . preg_quote($key, '/') . '\}\}/', rawurlencode(htmlspecialchars(addslashes($val ?: ''))), $zData['row_link']);
+                        $zData['row_link'] = preg_replace('/\{\{zData_' . preg_quote($key, '/') . '\}\}/', rawurlencode(htmlspecialchars(addslashes($val ?: ''))), $zData['row_link']);
                         // But don't break C>G notation, variants can't be searched using row links otherwise.
                         $zData['row_link'] = str_replace('%26gt%3B', '%3E', $zData['row_link']);
                     }

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -1585,7 +1585,7 @@ class LOVD_Object
         $zData = lovd_php_htmlspecialchars($zData);
 
         $aDateColumns = array('created_date', 'edited_date', 'updated_date', 'last_login', 'start_date', 'end_date', 'valid_from', 'valid_to');
-        foreach($aDateColumns as $sDateColumn) {
+        foreach ($aDateColumns as $sDateColumn) {
             // Replace empty date values with "N/A".
             $zData[$sDateColumn . ($sView == 'list'? '' : '_')] = (!empty($zData[$sDateColumn])? $zData[$sDateColumn] : 'N/A');
             if (preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/', $zData[$sDateColumn . ($sView == 'list'? '' : '_')])) {
@@ -1647,7 +1647,7 @@ class LOVD_Object
         } else {
             // Add links to users from *_by fields.
             $aUserColumns = array('owned_by', 'created_by', 'edited_by', 'updated_by', 'deleted_by', 'analysis_by', 'analysis_approved_by');
-            foreach($aUserColumns as $sUserColumn) {
+            foreach ($aUserColumns as $sUserColumn) {
                 if (empty($zData[$sUserColumn]) || !isset($this->aColumnsViewEntry[$sUserColumn . '_'])) {
                     $zData[$sUserColumn . '_'] = 'N/A';
                 } elseif ($_AUTH && $zData[$sUserColumn] != '00000') {
@@ -1672,7 +1672,7 @@ class LOVD_Object
             }
             // We are going to overwrite the 'owned_by_' field.
             $sOwnedBy = '';
-            foreach($zData['owner'] as $aLinkData) {
+            foreach ($zData['owner'] as $aLinkData) {
                 if (count($aLinkData) >= 6) {
                     list($nID, $sName, $sEmail, $sInstitute, $sDepartment, $sCountryID) = $aLinkData;
                     if (intval($nID) === 0) {
@@ -2054,13 +2054,13 @@ class LOVD_Object
         // Unset columns not allowed to be visible for the current user level.
         global $_AUTH;
 
-        foreach($this->aColumnsViewEntry as $sCol => $Col) {
+        foreach ($this->aColumnsViewEntry as $sCol => $Col) {
             if (is_array($Col) && (!$_AUTH || $_AUTH['level'] < $Col[1])) {
                 unset($this->aColumnsViewEntry[$sCol]);
             }
         }
 
-        foreach($this->aColumnsViewList as $sCol => $aCol) {
+        foreach ($this->aColumnsViewList as $sCol => $aCol) {
             if (isset($aCol['auth']) && (!$_AUTH || $_AUTH['level'] < $aCol['auth'])) {
                 unset($this->aColumnsViewList[$sCol]);
             }

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -1597,6 +1597,8 @@ class LOVD_Object
         if ($sView == 'list') {
             // By default, we put anchors in the id_ and DNA fields, if present.
             if ($zData['row_link']) {
+                // We just used htmlspecialchars() on zData, which includes the rowlink. Undo that.
+                $zData['row_link'] = htmlspecialchars_decode($zData['row_link']);
                 if (substr($zData['row_link'], 0, 11) == 'javascript:') {
                     $zData['row_link'] = htmlspecialchars(rawurldecode($zData['row_link']));
                 }

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -871,7 +871,7 @@ foreach ($zAnnouncements as $zAnnouncement) {
         }
         print('
 <SCRIPT type="text/javascript">
-  $(function(){
+  $(function() {
     var aMenuOptions = {
         widthOverflowOffset: 0,
         heightOverflowOffset: 1,' .
@@ -884,8 +884,7 @@ foreach ($zAnnouncements as $zAnnouncement) {
         autoHide: true,
         delay: 100,
         onSelect: function(e, context){
-            if($(this).hasClass("disabled"))
-            {
+            if ($(this).hasClass("disabled")) {
                 return false;
             } else {
                 window.location = $(this).find("a").attr("href");

--- a/src/columns.php
+++ b/src/columns.php
@@ -1297,7 +1297,7 @@ if (PATH_COUNT > 2 && ACTION == 'add') {
         if (!is_array($aTargets)) {
             $aTargets = array($aTargets);
         }
-        foreach($aTargets as $sTarget) {
+        foreach ($aTargets as $sTarget) {
             if (!isset($aPossibleTargets[$sTarget])) {
                 lovd_errorAdd('target', 'Please a select valid ' . $aTableInfo['unit'] . ' from the list!');
                 break;
@@ -1665,7 +1665,7 @@ if (PATH_COUNT > 2 && ACTION == 'remove') {
         if (!is_array($aTargets)) {
             $aTargets = array($aTargets);
         }
-        foreach($aTargets as $sTarget) {
+        foreach ($aTargets as $sTarget) {
             if (!isset($aPossibleTargets[$sTarget])) {
                 lovd_errorAdd('target', 'Please a select valid ' . $aTableInfo['unit'] . ' from the list!');
                 break;

--- a/src/download.php
+++ b/src/download.php
@@ -435,7 +435,7 @@ if (($_PE[1] == 'all' && (empty($_PE[2]) || in_array($_PE[2], array('gene', 'min
                 $qHiddenCols = 'SELECT id, SUBSTRING_INDEX(id, "/", 1) AS category FROM ' .
                                TABLE_COLS . ' WHERE public_view = ?';
                 $aHiddenCols = $_DB->q($qHiddenCols, array('0'))->fetchAllAssoc();
-                foreach($aHiddenCols as $aHiddenCol) {
+                foreach ($aHiddenCols as $aHiddenCol) {
                     $sObject = $aObjectTranslations[$aHiddenCol['category']];
                     $aObjects[$sObject]['hide_columns'][] = $aHiddenCol['id'];
                 }

--- a/src/genes.php
+++ b/src/genes.php
@@ -594,7 +594,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                 // Add transcripts.
                 $aSuccessTranscripts = array();
                 if (!empty($_POST['active_transcripts'])) {
-                    foreach($_POST['active_transcripts'] as $sTranscript) {
+                    foreach ($_POST['active_transcripts'] as $sTranscript) {
                         // 2014-06-11; 3.0-11; Add check on $sTranscript to make sure a selected "No transcripts found" doesn't cause a lot of errors here.
                         if (!$sTranscript) {
                             continue;
@@ -1650,7 +1650,7 @@ if (PATH_COUNT == 2 && preg_match('/^[a-z][a-z0-9#@-]*$/i', $_PE[1]) && in_array
             } else {
                 // Of the selected persons, at least one should be shown AND able to edit!
                 $bCurator = false;
-                foreach($_POST['curators'] as $nUserID) {
+                foreach ($_POST['curators'] as $nUserID) {
                     if (in_array($nUserID, $_POST['allow_edit']) && in_array($nUserID, $_POST['shown'])) {
                         $bCurator = true;
                         break;

--- a/src/import.php
+++ b/src/import.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -33,7 +33,7 @@
 define('ROOT_PATH', './');
 define('TAB_SELECTED', 'setup');
 require ROOT_PATH . 'inc-init.php';
-ini_set('auto_detect_line_endings', true); // So we can work with Mac files also...
+@ini_set('auto_detect_line_endings', true); // So we can work with Mac files. Deprecated in PHP8.1; removed in PHP9.
 set_time_limit(0); // Disable time limit, parsing may take a long time.
 session_write_close(); // Also don't care about the session (in fact, it locks the whole LOVD while this page is running).
 if (LOVD_plus) {

--- a/src/inc-js-viewlist.php
+++ b/src/inc-js-viewlist.php
@@ -55,7 +55,7 @@ function lovd_AJAX_processViewListHash ()
 
     if (window.location.hash != prevHash && prevHash != 'no_rehash') {
         // In case multiple viewList's exist, we choose the first one. In practice, hashing is turned off on pages with multiple viewLists.
-        $("form").each(function(){
+        $("form").each(function() {
             if ($(this).attr('id') && $(this).attr('id').substring(0, 13) == 'viewlistForm_') {
                 oForm = this;
                 sViewListID = $(this).attr('id').substring(13);
@@ -184,7 +184,7 @@ function lovd_AJAX_viewListAddNextRow (sViewListID)
 
         // Build GET query.
         var sGET = '';
-        $(oForm).find('input').each(function(){
+        $(oForm).find('input').each(function() {
             if (!this.disabled && this.value) {
                 sVal = this.value;
                 if (this.name == 'page_size')
@@ -221,7 +221,7 @@ function lovd_AJAX_viewListDownload (sViewListID, bAll)
     // Build URL.
     var sURL = 'ajax/viewlist.php?download' + (bAll? '' : 'Selected') + '&format=text/plain';
     oForm = document.forms['viewlistForm_' + sViewListID];
-    $(oForm).find('input').each(function(){
+    $(oForm).find('input').each(function() {
         // We actually don't need everything, but it's too difficult to manually add viewListID, object, order and skip.
         if (!this.disabled && this.value && this.name.substring(0,6) != 'check_') {
             sURL +=  '&' + this.name + '=' + encodeURIComponent(this.value);
@@ -267,7 +267,7 @@ function lovd_AJAX_viewListSubmit (sViewListID, callBack)
 {
     oForm = document.forms['viewlistForm_' + sViewListID];
     // Used to have a simple loop through oForm, but Google Chrome does not like that.
-    $(oForm).find('input').each(function(){
+    $(oForm).find('input').each(function() {
         if (this.name && this.name.substring(0, 7) == 'search_' && !this.value) {
             this.disabled = true;
         }
@@ -304,7 +304,7 @@ if (!isset($_GET['nohistory'])) {
                         if (prevHash != 'no_rehash') {
                             // The following adds the page to the history in Firefox, such that the user *can* push the back button.
                             // I chose not to use sGET (created somewhere below) here, because it contains 'viewlistid' and 'object' which I don't want to use now and I guess it would be possible that it won't be set.
-                            $(oForm).find('input[type!="button"]').each(function(){
+                            $(oForm).find('input[type!="button"]').each(function() {
                                 if (!this.disabled && this.value && this.name != 'viewlistid' &&
                                     this.name != 'object' && this.name.substring(0,6) != 'check_' &&
                                     this.name.substring(0,2) != 'FR') {
@@ -344,7 +344,7 @@ if (!isset($_GET['nohistory'])) {
 
         // Put values into a GET param string for all input fields, except fields named check_*
         // and non-checked radio buttons and checkboxes.
-        $(oForm).find('input').each(function(){
+        $(oForm).find('input').each(function() {
             if (!this.disabled && this.value && this.name.substring(0,6) != 'check_' &&
                 (this.type != 'radio' || this.checked) &&
                 (this.type != 'checkbox' || this.checked) &&

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -319,7 +319,7 @@ function lovd_formatMail ($aBody)
     }
     $sBody = $aBody[0];
     unset($aBody[0]);
-    foreach($aBody as $sTopic => $aContent) {
+    foreach ($aBody as $sTopic => $aContent) {
         $sBody .= str_repeat('-', 70) . "\n" .
                   '  ' . strtoupper(str_replace('_', ' ', $sTopic))  . "\n" .
                   str_repeat('-', 70) . "\n";
@@ -451,7 +451,7 @@ function lovd_fetchDBID ($aData)
 
         // Set the default for the DBID.
         $sDBID = 'chr' . $aData['chromosome'] . '_999999';
-        foreach($aDBIDOptions as $sDBIDoption) {
+        foreach ($aDBIDOptions as $sDBIDoption) {
             // Loop through all the options returned from the database and decide which option to take.
             preg_match('/^((.+)_(\d{6}))$/', $sDBID, $aMatches);
             //              2 = chr## or gene

--- a/src/inc-lib-genes.php
+++ b/src/inc-lib-genes.php
@@ -43,7 +43,7 @@ function lovd_getLRGbyGeneSymbol ($sGeneSymbol)
 {
     // Get LRG reference sequence
     preg_match('/(LRG_\d+)\s+' . $sGeneSymbol . '/', implode(' ', lovd_php_file('http://www.lovd.nl/mirrors/lrg/LRG_list.txt')), $aMatches);
-    if(!empty($aMatches)) {
+    if (!empty($aMatches)) {
         return $aMatches[1];
     }
     return false;

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -241,7 +241,7 @@ function lovd_convertBytesToHRSize ($nValue)
 {
     // This function takes integers and converts it to sizes like "128M".
 
-    if (!ctype_digit($nValue) && !is_int($nValue)) {
+    if (!is_int($nValue) && !ctype_digit($nValue)) {
         return false;
     }
 

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3450,7 +3450,7 @@ function lovd_php_htmlspecialchars ($Var)
     if (is_array($Var)) {
         return array_map('lovd_php_htmlspecialchars', $Var);
     } else {
-        return htmlspecialchars($Var);
+        return htmlspecialchars($Var ?: '');
     }
 }
 

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2050,7 +2050,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
         }
 
     } elseif ($aResponse['type'] == 'repeat' && $aVariant['prefix'] == 'c') {
-        foreach(explode('[', $aVariant['type']) as $sRepeat) {
+        foreach (explode('[', $aVariant['type']) as $sRepeat) {
             if (ctype_alpha($sRepeat) && strlen($sRepeat) % 3) {
                 // Repeat variants on coding DNA should always have
                 //  a length of a multiple of three bases.
@@ -2605,7 +2605,7 @@ function lovd_getVariantPrefixesByRefSeq ($s)
     global $_LIBRARIES;
 
     // Get matching DNA type prefixes.
-    foreach($_LIBRARIES['regex_patterns']['refseq_to_DNA_type'] as $sPattern => $aDNATypes) {
+    foreach ($_LIBRARIES['regex_patterns']['refseq_to_DNA_type'] as $sPattern => $aDNATypes) {
         if (preg_match($sPattern, $s)) {
             return $aDNATypes;
         }

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -507,7 +507,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
     $_T->printTitle();
 
     // If we're not the creator nor the owner, warn.
-    if ($_POST['created_by'] != $_AUTH['id'] && $_POST['owned_by'] != $_AUTH['id']) {
+    if ($zData['created_by'] != $_AUTH['id'] && $zData['owned_by'] != $_AUTH['id']) {
         lovd_showInfoTable('Warning: You are editing data not created or owned by you. You are free to correct errors such as data inserted into the wrong field or typographical errors, but make sure that all other edits are made in consultation with the submitter. If you disagree with the submitter\'s findings, add a remark rather than removing or overwriting data.', 'warning', 760);
     }
 

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -175,7 +175,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
         //  phenotype entry for a disease they don't have.
         $zData['diseases'] = $_DB->q('SELECT id, symbol, name FROM ' . TABLE_DISEASES . ' WHERE id IN (?' . str_repeat(', ?', count($zData['phenotypes'])-1) . ')', $zData['phenotypes'])->fetchAllRow();
         require ROOT_PATH . 'class/object_phenotypes.php';
-        foreach($zData['diseases'] as $aDisease) {
+        foreach ($zData['diseases'] as $aDisease) {
             list($nDiseaseID, $sSymbol, $sName) = $aDisease;
             if (in_array($nDiseaseID, $zData['phenotypes'])) {
                 $_GET['search_diseaseid'] = $nDiseaseID;

--- a/src/phenotypes.php
+++ b/src/phenotypes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-23
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -472,7 +472,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
     $_T->printTitle();
 
     // If we're not the creator nor the owner, warn.
-    if ($_POST['created_by'] != $_AUTH['id'] && $_POST['owned_by'] != $_AUTH['id']) {
+    if ($zData['created_by'] != $_AUTH['id'] && $zData['owned_by'] != $_AUTH['id']) {
         lovd_showInfoTable('Warning: You are editing data not created or owned by you. You are free to correct errors such as data inserted into the wrong field or typographical errors, but make sure that all other edits are made in consultation with the submitter. If you disagree with the submitter\'s findings, add a remark rather than removing or overwriting data.', 'warning', 760);
     }
 

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -461,7 +461,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'edit') {
     $_T->printTitle();
 
     // If we're not the creator nor the owner, warn.
-    if ($_POST['created_by'] != $_AUTH['id'] && $_POST['owned_by'] != $_AUTH['id']) {
+    if ($zData['created_by'] != $_AUTH['id'] && $zData['owned_by'] != $_AUTH['id']) {
         lovd_showInfoTable('Warning: You are editing data not created or owned by you. You are free to correct errors such as data inserted into the wrong field or typographical errors, but make sure that all other edits are made in consultation with the submitter. If you disagree with the submitter\'s findings, add a remark rather than removing or overwriting data.', 'warning', 760);
     }
 

--- a/src/submit.php
+++ b/src/submit.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-21
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -239,7 +239,7 @@ if (PATH_COUNT == 3 && $_PE[1] == 'individual' && ctype_digit($_PE[2]) && !ACTIO
     /*require ROOT_PATH . 'class/object_screenings.php';
     $_GET['page_size'] = 10;
     $_DATA['screening'] = new LOVD_Screening();
-    $_DATA['screening']->setRowLink($sScreeningsViewListID, 'submit/screening/' . $_DATA['screening']->sRowID);
+    $_DATA['screening']->setRowLink($sScreeningsViewListID, $_PE[0] . '/screening/' . $_DATA['screening']->sRowID);
     $_GET['search_individualid'] = $nID;
     $_GET['search_screeningid'] = (isset($aSubmit['screenings'])? implode('|', $aSubmit['screenings']) : 0);
     print('      <DIV id="container_screenings"><BR>' . "\n"); // Extra div is to prevent "No entries in the database yet!" error to show up if there are no genes in the database yet.

--- a/src/submit.php
+++ b/src/submit.php
@@ -975,7 +975,7 @@ if (PATH_COUNT == 4 && $_PE[1] == 'finish' && in_array($_PE[2], array('individua
                 $a['owned_by_'] = 'Data owner';
                 ${$sVariableNameUpload}['owned_by_'] = $_DB->q('SELECT name FROM ' . TABLE_USERS . ' WHERE id = ?', array($zUploadDetails['owned_by']))->fetchColumn();
             }
-            ${$sVariableNameUpload}['mapping_flags_'] = (($zUploadDetails['mapping_flags'] & MAPPING_ALLOW)? 'On' . (($zUploadDetails['mapping_flags'] & MAPPING_ALLOW_CREATE_GENES)? ', creating genes as needed' : '') : 'Off');
+            ${$sVariableNameUpload}['mapping_flags_'] = (((int) $zUploadDetails['mapping_flags'] & MAPPING_ALLOW)? 'On' . (((int) $zUploadDetails['mapping_flags'] & MAPPING_ALLOW_CREATE_GENES)? ', creating genes as needed' : '') : 'Off');
 
             // Include 'Data status' as the very last field.
             $a['statusid_'] = 'Data status';

--- a/src/submit.php
+++ b/src/submit.php
@@ -253,7 +253,7 @@ if (PATH_COUNT == 3 && $_PE[1] == 'individual' && ctype_digit($_PE[2]) && !ACTIO
     print('      </DIV>' . "\n" .
           '      <DIV id="container_phenotypes"><BR>' . "\n"); // Extra div is to prevent "No entries in the database yet!" error to show up if there are no genes in the database yet.
     lovd_showInfoTable('Please select a phenotype you would like to edit', 'information');
-    foreach($zData['diseases'] as $nDisease) {
+    foreach ($zData['diseases'] as $nDisease) {
         $_GET['search_diseaseid'] = $nDisease;
         $_DATA['phenotype'][$nDisease] = new LOVD_Phenotype($nDisease);
         $_DATA['phenotype'][$nDisease]->setSortDefault('phenotypeid');

--- a/src/transcripts.php
+++ b/src/transcripts.php
@@ -349,7 +349,7 @@ if (ACTION == 'create') {
             // FIXME; shouldn't this check be done before looping through active_transcripts above? This setup allows submission of the form when selecting "No transcripts available".
             if (!empty($_POST['active_transcripts']) && $_POST['active_transcripts'][0] != '') {
                 $aSuccessTranscripts = array();
-                foreach($_POST['active_transcripts'] as $sTranscript) {
+                foreach ($_POST['active_transcripts'] as $sTranscript) {
                     if (!$sTranscript) {
                         continue;
                     }

--- a/src/transcripts.php
+++ b/src/transcripts.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -118,7 +118,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && !ACTION) {
     require ROOT_PATH . 'class/object_transcript_variants.php';
     $_DATA = new LOVD_TranscriptVariant($zData['geneid']);
     $_DATA->sSortDefault = 'VariantOnTranscript/DNA';
-    $_DATA->setRowLink('VOT_for_T_VE', 'javascript:window.location.href=\'' . lovd_getInstallURL() . 'variants/{{ID}}#{{transcriptid}}\'; return false');
+    $_DATA->setRowLink('VOT_for_T_VE', 'variants/{{ID}}#{{transcriptid}}');
     $aVLOptions = array(
         'cols_to_skip' => array('geneid', 'transcriptid', 'id_ncbi'),
     );
@@ -192,7 +192,7 @@ if (ACTION == 'create') {
             $_GET['search_id_'] = '="' . $_SESSION['currdb'] . '"';
         }
         $_DATA = new LOVD_Gene();
-        $_DATA->setRowLink($sViewListID, $_PE[0] . '/' . $_DATA->sRowID . '?create');
+        $_DATA->setRowLink($sViewListID, CURRENT_PATH . '/' . $_DATA->sRowID . '?create');
         lovd_showInfoTable('Please select the gene to which you wish to add a new transcript. <B>Click on the gene to proceed.</B>', 'information', 600);
         $aVLOptions = array(
             'cols_to_skip' => array('variants', 'uniq_variants', 'updated_date_', 'diseases_'),

--- a/src/variants.php
+++ b/src/variants.php
@@ -2567,7 +2567,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
                 }
 
                 // Remove the MAPPING_NOT_RECOGNIZED and MAPPING_DONE flags if the VariantOnGenome/DNA field changes.
-                $_POST['mapping_flags'] = $zData['mapping_flags'] & ~(MAPPING_NOT_RECOGNIZED | MAPPING_DONE);
+                $_POST['mapping_flags'] = (int) $zData['mapping_flags'] & ~(MAPPING_NOT_RECOGNIZED | MAPPING_DONE);
                 if (!$_POST['position_g_start']) {
                     // We couldn't get a position, mapping will fail.
                     $_POST['mapping_flags'] |= MAPPING_NOT_RECOGNIZED;

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2022-11-22
+ * Modified    : 2022-12-14
  * For LOVD    : 3.0-29
  *
  * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
@@ -351,7 +351,7 @@ if (!ACTION && !empty($_PE[1]) && !ctype_digit($_PE[1])) {
         if ($bUnique) {
             // When this ViewListID is changed, also change the prepareData in object_custom_viewluists.php
             $_DATA = new LOVD_CustomViewList(array('VariantOnTranscriptUnique', 'VariantOnGenome'), $sGene); // Restrict view to gene (correct custom column set, correct order).
-            $_DATA->setRowLink($sViewListID, 'variants/' . $sGene . '?search_position_c_start={{position_c_start}}&search_position_c_start_intron={{position_c_start_intron}}&search_position_c_end={{position_c_end}}&search_position_c_end_intron={{position_c_end_intron}}&search_vot_clean_dna_change=%3D%22{{vot_clean_dna_change}}%22&search_transcriptid={{transcriptid}}');
+            $_DATA->setRowLink($sViewListID, str_replace('/unique', '', CURRENT_PATH) . '?search_position_c_start={{position_c_start}}&search_position_c_start_intron={{position_c_start_intron}}&search_position_c_end={{position_c_end}}&search_position_c_end_intron={{position_c_end_intron}}&search_vot_clean_dna_change=%3D%22{{vot_clean_dna_change}}%22&search_transcriptid={{transcriptid}}');
         } else {
             $_DATA = new LOVD_CustomViewList(array('VariantOnTranscript', 'VariantOnGenome'), $sGene); // Restrict view to gene (correct custom column set, correct order).
         }
@@ -724,7 +724,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
         require ROOT_PATH . 'class/object_genes.php';
         $_GET['page_size'] = 10;
         $_DATA = new LOVD_Gene();
-        $_DATA->setRowLink($sViewListID, 'variants?create&reference=Transcript&geneid=' . $_DATA->sRowID . ($_GET['target']? '&target=' . $_GET['target'] : ''));
+        $_DATA->setRowLink($sViewListID, CURRENT_PATH . '?' . ACTION . '&reference=Transcript&geneid=' . $_DATA->sRowID . ($_GET['target']? '&target=' . $_GET['target'] : ''));
         $_GET['search_transcripts'] = '>0';
         print('      <DIV id="container" style="display : none;">' . "\n"); // Extra div is to prevent "No entries in the database yet!" error to show up if there are no genes in the database yet.
         lovd_showInfoTable('Please find the gene for which you wish to submit this variant below, using the search fields if needed. <B>Click on the gene to proceed to the variant entry form</B>.<BR>If a gene is not shown in this display, but it does exist in this LOVD, then it does not have a transcript configured yet.', 'information', 600);

--- a/src/variants.php
+++ b/src/variants.php
@@ -648,7 +648,7 @@ if ((empty($_PE[1]) || $_PE[1] == 'upload') && ACTION == 'create') {
             $bSubmit = true;
             $aSubmit = &$_AUTH['saved_work']['submissions']['screening'][$_POST['screeningid']];
         } elseif (isset($_POST['screeningid']) && isset($_AUTH['saved_work']['submissions']['individual'])) {
-            foreach($_AUTH['saved_work']['submissions']['individual'] as $nIndividualID => &$aSubmit) {
+            foreach ($_AUTH['saved_work']['submissions']['individual'] as $nIndividualID => &$aSubmit) {
                 if (isset($aSubmit['screenings']) && in_array($_POST['screeningid'], $aSubmit['screenings'])) {
                     $bSubmit = true;
                     break;
@@ -833,7 +833,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
 
             if (isset($sGene)) {
                 $_POST['id'] = $nID;
-                foreach($_POST['aTranscripts'] as $nTranscriptID => $aTranscript) {
+                foreach ($_POST['aTranscripts'] as $nTranscriptID => $aTranscript) {
                     if (!empty($_POST[$nTranscriptID . '_VariantOnTranscript/DNA']) && strlen($_POST[$nTranscriptID . '_VariantOnTranscript/DNA']) >= 6) {
                         // 2017-09-22; 3.0-20; Replacing the old API call to Mutalyzer with our new lovd_getVariantInfo() function.
                         // Don't bother with a fallback, this thing is more solid than Mutalyzer's service.
@@ -979,7 +979,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
 
     if (isset($sGene)) {
         $i = 0;
-        foreach($_DATA['Transcript'][$sGene]->aTranscripts as $nTranscriptID => $aTranscript) {
+        foreach ($_DATA['Transcript'][$sGene]->aTranscripts as $nTranscriptID => $aTranscript) {
             list($sTranscriptNM, $sGeneSymbol, $sMutalyzerID) = $aTranscript;
             echo ($i? ',' . "\n" : '') . '            \'' . $nTranscriptID . '\' : [\'' . $sTranscriptNM . '\', \'' . $sGeneSymbol . '\', \'' . $sMutalyzerID . '\']';
             $i++;
@@ -1319,7 +1319,7 @@ if (PATH_COUNT == 2 && $_PE[1] == 'upload' && ACTION == 'create') {
             lovd_errorAdd('', 'There was an unknown problem with receiving the file properly, possibly because of the current server settings. If the problem persists, contact the database administrator.');
         }
 
-        if(!lovd_error()) {
+        if (!lovd_error()) {
             // No problems found. Start processing the file.
 
             // Initiate progress bar.
@@ -2592,7 +2592,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
             $_DATA['Genome']->updateEntry($nID, $_POST, $aFieldsGenome);
 
             if ($bGene) {
-                foreach($_POST['aTranscripts'] as $nTranscriptID => $aTranscript) {
+                foreach ($_POST['aTranscripts'] as $nTranscriptID => $aTranscript) {
                     if (!empty($_POST[$nTranscriptID . '_VariantOnTranscript/DNA']) && ($_POST[$nTranscriptID . '_VariantOnTranscript/DNA'] != $zData[$nTranscriptID . '_VariantOnTranscript/DNA'] || $zData[$nTranscriptID . '_position_c_start'] === NULL)) {
                         // 2017-09-22; 3.0-20; Replacing the old API call to Mutalyzer with our new lovd_getVariantInfo() function.
                         // Don't bother with a fallback, this thing is more solid than Mutalyzer's service.
@@ -2670,7 +2670,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
         }
         if ($bGene) {
             foreach ($aGenes as $sGene) {
-                foreach($_DATA['Transcript'][$sGene]->aTranscripts as $nTranscriptID => $aTranscript) {
+                foreach ($_DATA['Transcript'][$sGene]->aTranscripts as $nTranscriptID => $aTranscript) {
                     $_POST[$nTranscriptID . '_effect_reported'] = $zData[$nTranscriptID . '_effectid'][0];
                     $_POST[$nTranscriptID . '_effect_concluded'] = $zData[$nTranscriptID . '_effectid'][1];
                 }
@@ -2721,7 +2721,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
           '        var aUDrefseqs = {' . "\n");
     if ($bGene) {
         $i=0;
-        foreach($aGenes as $sGene) {
+        foreach ($aGenes as $sGene) {
             echo ($i? ',' . "\n" : '') . '            \'' . $sGene . '\' : \'' . $_DB->q('SELECT refseq_UD FROM ' . TABLE_GENES . ' WHERE id = ?', array($sGene))->fetchColumn() . '\'';
             $i++;
         }
@@ -2730,7 +2730,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('edit', 'p
           '        var aTranscripts = {' . "\n");
     $i = 0;
     if ($bGene) {
-        foreach($_DATA['Transcript'][$sGene]->aTranscripts as $nTranscriptID => $aTranscript) {
+        foreach ($_DATA['Transcript'][$sGene]->aTranscripts as $nTranscriptID => $aTranscript) {
             list($sTranscriptNM, $sGeneSymbol, $sMutalyzerID) = $aTranscript;
             echo ($i? ',' . "\n" : '') . '            \'' . $nTranscriptID . '\' : [\'' . $sTranscriptNM . '\', \'' . $sGeneSymbol . '\', \'' . $sMutalyzerID . '\']';
             $i++;
@@ -3046,7 +3046,7 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && in_array(ACTION, array('delete_no
                     $bAdded = false;
                     if (count($aVariantDescriptions[$zTranscript['geneid']])) {
                         // Loop through the mutalyzer output for this gene, see if we can find this transcript.
-                        foreach($aVariantDescriptions[$zTranscript['geneid']] as $key => $sVariant) {
+                        foreach ($aVariantDescriptions[$zTranscript['geneid']] as $key => $sVariant) {
                             // Check if our transcript is in the variant description for each value returned by mutalyzer.
                             if (!empty($sVariant) && preg_match('/^' . preg_quote($zTranscript['id_ncbi']) . ':([cn]\..+)$/', $sVariant, $aMatches)) {
                                 // Call the mappingInfo module of mutalyzer to get the start & stop positions of this variant on the transcript.


### PR DESCRIPTION
### Sync changes from LOVD+, related to PHP8.1 compatibility.
- Remove a deprecation notice in `import.php`.
- Prevent warnings when running `ctype_digit()` on integers. Integers can't be run into `ctype_digit()` anymore; check using `is_int()` first, and then run `ctype_digit()`.
- Fix issues with functions no longer liking to receive null.
- Unbreak all JS row links on PHP 8.1. Row links were double-encoded. This was only noticed now that `htmlspecialchars()` also started to encode single quotes used in javascript row links. Undo this double encoding.
- Prevent some calculations on strings and integers. Strings are normally converted into integers, but an empty string isn't converted to 0. Other PHP versions would warn, but PHP 8.1 throws a fatal error. There may be more places where this happens.

#### Also:
- Apply standards in the spacing of control structures.
- Fix warnings for editing data not owned by the current user.
- Standardize row links a bit, removing a JS link where possible.
- Adapt `lovd_getVariantInfo()` to receive an array as the transcript input. This array contains the relevant information otherwise received from the database. LOVD+ uses this technique.