### PR TITLE
Sync code from the API

### DIFF
--- a/src/ajax/check_HGVS.php
+++ b/src/ajax/check_HGVS.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-09-06
- * Modified    : 2022-11-28
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-01
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               L. Werkman <L.Werkman@LUMC.nl>
  *
@@ -165,9 +165,11 @@ foreach ($aVariants as $sVariant => $aVariant) {
         // Exception 2; Treat the result as HGVS compliant (i.e., accept
         //  suggestion and show) when all we have now is a EWRONGREFERENCE and
         //  that was anyway already part of what we had.
+        // Obviously, this only applies when the fixed variant is different from what we had.
         if ($aVariant['variant_info'] && $aVariant['fixed_variant_variant_info']
             && array_keys($aVariant['fixed_variant_variant_info']['errors'] + $aVariant['fixed_variant_variant_info']['warnings']) == array('EWRONGREFERENCE')
-            && isset($aVariant['variant_info']['errors']['EWRONGREFERENCE'])) {
+            && isset($aVariant['variant_info']['errors']['EWRONGREFERENCE'])
+            && $sVariant != $aVariant['fixed_variant']) {
             unset($aVariant['fixed_variant_variant_info']['errors']['EWRONGREFERENCE']);
         }
 
@@ -185,6 +187,7 @@ foreach ($aVariants as $sVariant => $aVariant) {
         );
 
         // And add the confidence for us.
+        // This already checks if $sFixedVariant is different, and error-free. If not, it will return false.
         $aVariant['fixed_variant_confidence'] = lovd_fixHGVSGetConfidence(
             $sVariant,
             $aVariant['fixed_variant'],

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2023-02-03
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-01
+ * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -224,6 +224,8 @@ function lovd_cleanDirName ($s)
     $s = preg_replace('/\/\.\//', '/', $s);
     // Clean up the pwd; remove '/dir/../'
     $s = preg_replace('/\/[^\/]+\/\.\.\//', '/', $s);
+    // Hackers may try to give us links that start with a parent dir. That would cause an infinite loop.
+    $s = preg_replace('/^\/\.\.\//', '/', $s);
 
     if (preg_match('/\/(\.)?\.\//', $s)) {
         // Still not clean... Pff...


### PR DESCRIPTION
There were some fixes in the API; sync the code to LOVD3.
- Sync fix from api.lovd.nl. This caused NC:c variants to provide themselves as the fix for the problem, which makes no sense. This type of mistake requires human intervention.
- Add a fix to `lovd_cleanDirName()` that caused issues in the API. Constructing some URLs caused infinite recursion and crashed the PHP process due to maxing out the memory consumption.