### PR TITLE
VariantValidator: Reference sequences in `verifyVariant()`.

### DIFF
--- a/src/ajax/check_HGVS.php
+++ b/src/ajax/check_HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-09-06
- * Modified    : 2023-06-01
+ * Modified    : 2023-06-23
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -223,8 +223,10 @@ foreach ($aVariants as $sVariant => $aVariant) {
                 $aVariant['VV']['EINTERNAL'] = 'An internal error within VariantValidator occurred when trying to validate your variant.';
             } elseif (!empty($aVV['data']['DNA'])) {
                 // We got a variant back, so VV at least understood the variant.
-                // Our VV library removed the refseq, put it back.
-                $aVV['data']['DNA'] = lovd_getVariantRefSeq($sVariant) . ':' . $aVV['data']['DNA'];
+                // When we use verifyVariant(), the transcript needs to be re-attached.
+                if (!empty($aVV['data']['transcript'])) {
+                    $aVV['data']['DNA'] = $aVV['data']['transcript'] . ':' . $aVV['data']['DNA'];
+                }
                 if ($sVariant != $aVV['data']['DNA']) {
                     // We don't check for WCORRECTED here, because the VV library accepts some changes
                     //  without setting WCORRECTED. We want to show every difference.

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -904,7 +904,8 @@ class LOVD_VV
             if ($aVariantInfo && isset($_DB)) {
                 // Check for intronic and positions outside of the mRNA.
 
-                // Fetch transcript positions from the database.
+                // Fetch transcript positions from the database. However, we may not have this transcript,
+                //  if the library is used independently (e.g., the checkHGVS interface).
                 $aTranscript = $_DB->q('
                     SELECT position_c_mrna_start, position_c_mrna_end
                     FROM ' . TABLE_TRANSCRIPTS . ' WHERE id_ncbi = ?',
@@ -913,6 +914,7 @@ class LOVD_VV
 
                 $bKeepNC = (!empty($aVariantInfo['position_start_intron'])
                     || !empty($aVariantInfo['position_end_intron'])
+                    || $aTranscript === false
                     || $aVariantInfo['position_start'] < $aTranscript['position_c_mrna_start']
                     || $aVariantInfo['position_end'] > $aTranscript['position_c_mrna_end']);
 

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2023-06-08
+ * Modified    : 2023-06-23
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1044,8 +1044,13 @@ class LOVD_VV
 
         if ($aData['data']['DNA']) {
             // We silently ignore transcripts here that gave us an error, but not for the liftover feature.
-            $aMapping = array(
-                'DNA' => substr(strstr($aData['data']['DNA'], ':'), 1),
+            $aMapping = array_combine(
+                array(
+                    'transcript',
+                    'DNA',
+                ),
+                explode(':', $aData['data']['DNA'], 2)
+            ) + array(
                 'RNA' => 'r.(?)',
                 'protein' => '',
             );
@@ -1054,8 +1059,7 @@ class LOVD_VV
             }
 
             // Try to improve VV's predictions.
-            $sTranscript = strstr($sVariant, ':', true);
-            $this->getRNAProteinPrediction($aMapping, $sTranscript);
+            $this->getRNAProteinPrediction($aMapping, $aMapping['transcript']);
             $aData['data'] = $aMapping;
         }
 


### PR DESCRIPTION
### VariantValidator: Reference sequences in `verifyVariant()`.
Our VariantValidator library handles genomic variants and transcript variants differently; `verifyGenomic()` returns the variant with the reference sequence attached, while `verifyVariant()` removes the reference sequence.
- Keep the transcript in the `verifyVariant()` call. To simplify the output and keep it consistent with the mapping array returned by `verifyGenomic()`, the refseq is removed from the DNA field. But the `verifyVariant()` output had lost the transcript information completely; just by looking at the output, the input refseq could not be determined.
- Fix bug in checkHGVS ajax script related to `verifyVariant()`. Only `verifyVariant()` removes the transcript; `verifyGenomic()` does not.

Also:
- Fix bug; we might not have the given transcript in the database. This applies to our checkHGVS interface; any transcript can be given there, also when we don't have it in the database. This fix prevents the notices generated by unknown transcripts.