### PR TITLE
Fix multiple issues.

### DIFF
--- a/src/__function_list.txt
+++ b/src/__function_list.txt
@@ -42,11 +42,9 @@
 4.0.0 defined
 4.0.0 die
 4.0.0 dirname
-4.0.0 each
 4.0.0 empty
 4.0.0 end
 4.0.0 error_reporting
-4.0.0 exec
 4.0.0 exit
 4.0.0 explode
 4.0.0 fclose

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2023-02-02
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-28
+ * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -515,9 +515,14 @@ class LOVD_GenomeVariant extends LOVD_Custom
                     if (LOVD_plus) {
                         $sLink = '<A href="variants/DBID/' . $zData['VariantOnGenome/DBID'] .'">See all ' . $n . ' reported entries</A>';
                     }
-                    // This is against our coding policy of never modifying actual contents of values (we always create a copy with _ appended), but now I simply can't without
-                    // modifying the column list manually. If only array_splice() would work on associative arrays... I'm not going to create a workaround here.
-                    $zData['VariantOnGenome/DBID'] .= ' <SPAN style="float:right">' . $sLink . '</SPAN>';
+                    // We have a policy of never modifying actual contents of values; create a copy with an underscore appended.
+                    // Let this new column take the place of the original DBID field.
+                    // But only do this when we're the first prepareData() to run.
+                    if (!isset($this->aColumnsViewEntry['VariantOnGenome/DBID_'])) {
+                        lovd_arrayInsertAfter('VariantOnGenome/DBID', $this->aColumnsViewEntry, 'VariantOnGenome/DBID_', $this->aColumnsViewEntry['VariantOnGenome/DBID']);
+                        unset($this->aColumnsViewEntry['VariantOnGenome/DBID']);
+                    }
+                    $zData['VariantOnGenome/DBID_'] = $zData['VariantOnGenome/DBID'] . ' <SPAN style="float:right">' . $sLink . '</SPAN>';
                 }
             }
 

--- a/src/class/object_transcripts.php
+++ b/src/class/object_transcripts.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2022-11-22
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-23
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -284,7 +284,7 @@ class LOVD_Transcript extends LOVD_Object
         }
 
         $aTranscripts['info'] = lovd_callMutalyzer('getTranscriptsAndInfo', array('genomicReference' => $sRefseqUD, 'geneName' => $sAliasSymbol));
-        if (empty($aTranscripts['info'])) {
+        if (empty($aTranscripts['info']) || !empty($aTranscripts['info']['faultcode'])) {
             // No transcripts found.
             $aTranscripts['info'] = array();
             return $aTranscripts;

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-27
- * Modified    : 2023-01-27
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-28
+ * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -372,7 +372,9 @@ class LOVD_Template
     <TD width="42" align="right">
 <?php
         if (!(defined('NOT_INSTALLED') || defined('MISSING_CONF') || defined('MISSING_STAT'))) {
-            if ((time() - strtotime($_STAT['update_checked_date'])) > (60*60*24)) {
+            // When we've just installed (update_checked_date is NULL) or when it's been 24 hours, check for updates.
+            if (empty($_STAT['update_checked_date'])
+                || (time() - strtotime($_STAT['update_checked_date'])) > (60*60*24)) {
                 // Check for updates!
                 $sImgURL = 'check_update?icon';
                 $sImgAlt = 'Checking for LOVD updates...';

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -558,7 +558,7 @@ class LOVD_VV
         //  than a database, in case this object will ever be pulled out of LOVD.
         $sVariantNC = strstr($sVariant, ':', true);
         $sBuild = '';
-        foreach ($_SETT['human_builds'] as $sCode => $aBuild) {
+        foreach ($_SETT['human_builds'] as $aBuild) {
             if (isset($aBuild['ncbi_sequences'])) {
                 if (in_array($sVariantNC, $aBuild['ncbi_sequences'])) {
                     // We pick the NCBI name here, because for chrM we actually

--- a/src/download.php
+++ b/src/download.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-10
- * Modified    : 2022-11-22
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-23
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
  *
@@ -757,7 +757,13 @@ foreach ($aObjects as $sObject => $aSettings) {
     // Fetch and print the data.
     foreach ($aSettings['data'] as $z) {
         // Quote data.
-        $z = array_map('addslashes', $z);
+        $z = array_map(
+            function ($sVal)
+            {
+                return addslashes(isset($sVal)? $sVal : '');
+            },
+            $z
+        );
 
         foreach ($aColumns as $key => $sCol) {
             if (!isset($aSettings['hide_columns'][$sCol])) {

--- a/src/genes.php
+++ b/src/genes.php
@@ -276,7 +276,9 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
     $_DATA['Transcript'] = new LOVD_transcript();
 
     $sPath = CURRENT_PATH . '?' . ACTION;
-    if (GET) {
+    if (GET
+        || empty($_POST['workID'])
+        || empty($_SESSION['work'][$sPath][$_POST['workID']])) {
         if (!isset($_SESSION['work'][$sPath])) {
             $_SESSION['work'][$sPath] = array();
         }

--- a/src/genes.php
+++ b/src/genes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2022-11-22
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-23
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -386,7 +386,7 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                 } else {
                     // Get UD from mutalyzer.
                     $sRefseqUD = lovd_getUDForGene($_CONF['refseq_build'], $sSymbol);
-                    if (!$sRefseqUD) {
+                    if (!$sRefseqUD || isset($_GET['VV'])) {
                         // The future is VV. However, as we're currently still using
                         //  Mutalyzer for mapping, only use VV when Mutalyzer fails.
                         $_BAR->setMessage('Collecting all available transcripts...');
@@ -434,6 +434,20 @@ if (PATH_COUNT == 1 && ACTION == 'create') {
                     $_BAR->setProgress($nProgress += 17);
 
                     $aTranscripts = $_DATA['Transcript']->getTranscriptPositions($sRefseqUD, $sSymbol, $sGeneName, $nProgress);
+                    if (!$aTranscripts['id']) {
+                        // Mutalyzer found nothing. This could be simply their error. Better try VV.
+                        // But for this, we have to reload.
+                        $_BAR->setMessage('Mutalyzer failed to find transcripts. Trying again using VV...');
+                        print('
+                        <script type="text/javascript">
+                            // Redirect to use VV.
+                            $("form").attr("action", $("form").attr("action") + "&VV");
+                            // Don\'t lose the gene symbol.
+                            $("form").append(\'<input type="hidden" name="hgnc_id" value="' . htmlspecialchars($_POST['hgnc_id']) . '">\');
+                            $("form").submit();
+                        </script>');
+                        exit;
+                    }
                 }
 
                 $_BAR->setProgress(100);

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -1231,5 +1231,4 @@ function utf8_encode_array ($Data)
         return $Data;
     }
 }
-
 ?>

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2740,7 +2740,8 @@ function lovd_hideEmail ($s)
     // Function kindly provided by Ileos.nl in the interest of Open Source.
     // Obscure email addresses from spambots.
 
-    $a_replace = array(45 => '-', '.',
+    $a_replace = array(
+        45 => '-', '.',
         48 => '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
         64 => '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
         95 => '_',

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2022-12-14
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-28
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -562,10 +562,10 @@ if (PATH_COUNT == 2 && ctype_digit($_PE[1]) && ACTION == 'delete') {
 
     $aVariantsRemovable = $_DB->q('
         SELECT s2v.variantid, MAX(s2.individualid)
-        FROM lovd_v3_screenings AS s
-          INNER JOIN lovd_v3_screenings2variants AS s2v ON (s.id = s2v.screeningid)
-          LEFT OUTER JOIN lovd_v3_screenings2variants AS s2v2 ON (s2v.variantid = s2v2.variantid AND s2v.screeningid != s2v2.screeningid)
-          LEFT OUTER JOIN lovd_v3_screenings AS s2 ON (s2v2.screeningid = s2.id AND s2.individualid != ?)
+        FROM ' . TABLE_SCREENINGS . ' AS s
+          INNER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (s.id = s2v.screeningid)
+          LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v2 ON (s2v.variantid = s2v2.variantid AND s2v.screeningid != s2v2.screeningid)
+          LEFT OUTER JOIN ' . TABLE_SCREENINGS . ' AS s2 ON (s2v2.screeningid = s2.id AND s2.individualid != ?)
         WHERE s.individualid = ?
         GROUP BY s2v.variantid
         HAVING MAX(s2.individualid) IS NULL', array($nID, $nID))->fetchAllColumn();

--- a/src/scripts/__test_connectivity.php
+++ b/src/scripts/__test_connectivity.php
@@ -10,6 +10,7 @@ ini_set('display_errors', 1);
 
 $bFopenWrappers = ini_get('allow_url_fopen');
 $bProxy = (bool) $_CONF['proxy_host'];
+$bCurl = function_exists('curl_init');
 
 print('PHP VERSION : ' . PHP_VERSION_ID);
 
@@ -43,6 +44,12 @@ Proxy server " . ($bProxyCanBeBypassed? 'CAN' : 'CAN NOT') . " be bypassed.
 ");
 }
 
+// Check Curl.
+print("
+================================================================================
+" . ($bCurl? "Curl available." : "Curl not available.") . "
+");
+
 // Testing connection to file on LOVD.nl.
 print("
 ================================================================================
@@ -69,6 +76,13 @@ print("
 Contacting Mutalyzer over HTTPS, using non-context file() call, should " . (!$bFopenWrappers? 'fail since fopen wrappers are off' : ($bProxy && !$bProxyCanBeBypassed? 'fail since the proxy is ignored' : 'return IVD mapping data')) . ":
 ");
 var_dump(file($sURL, FILE_IGNORE_NEW_LINES));
+if ($bCurl) {
+    print("
+================================================================================
+Contacting Mutalyzer at ${_CONF['mutalyzer_soap_url']} over Curl, should return IVD mapping data:
+");
+    var_dump(lovd_callMutalyzer('getGeneLocation', array('build' => $_CONF['refseq_build'], 'gene' => 'IVD')));
+}
 
 // Checking SNI_server_name / peer_name.
 print("

--- a/src/scripts/__test_connectivity.php
+++ b/src/scripts/__test_connectivity.php
@@ -68,12 +68,12 @@ var_dump(lovd_php_file('http://rest.genenames.org/search/symbol/IVD', false, '',
 $sURL = str_replace('/services', '', $_CONF['mutalyzer_soap_url']) . '/json/getGeneLocation?build=' . $_CONF['refseq_build'] . '&gene=IVD';
 print("
 ================================================================================
-Contacting Mutalyzer over HTTPS, using fsockopen() fallback, should return IVD mapping data:
+Contacting Mutalyzer at ${_CONF['mutalyzer_soap_url']} over HTTPS, using fsockopen() fallback, should return IVD mapping data:
 ");
 var_dump(lovd_php_file($sURL));
 print("
 ================================================================================
-Contacting Mutalyzer over HTTPS, using non-context file() call, should " . (!$bFopenWrappers? 'fail since fopen wrappers are off' : ($bProxy && !$bProxyCanBeBypassed? 'fail since the proxy is ignored' : 'return IVD mapping data')) . ":
+Contacting Mutalyzer at ${_CONF['mutalyzer_soap_url']} over HTTPS, using non-context file() call, should " . (!$bFopenWrappers? 'fail since fopen wrappers are off' : ($bProxy && !$bProxyCanBeBypassed? 'fail since the proxy is ignored' : 'return IVD mapping data')) . ":
 ");
 var_dump(file($sURL, FILE_IGNORE_NEW_LINES));
 if ($bCurl) {
@@ -89,5 +89,5 @@ print("
 ================================================================================
 Contacting LOVD server over HTTPS, using our file() wrapper, testing SNI_server_name vs peer_name settings, should " . (!$bFopenWrappers? 'fail since fopen wrappers are off' : 'return a large positive number') . ":
 ");
-var_dump(strlen(implode("\n", lovd_php_file('https://grenada.lumc.nl/'))));
+var_dump(strlen(implode("\n", lovd_php_file('https://www.LOVD.nl/'))));
 ?>

--- a/src/scripts/__test_connectivity.php
+++ b/src/scripts/__test_connectivity.php
@@ -62,7 +62,14 @@ print("
 ================================================================================
 Contacting HGNC over HTTP, using " . ($bFopenWrappers? 'our file() since wrapper is enabled' : 'fsockopen() fallback since wrapper is disabled') . ", should return IVD gene data:
 ");
-var_dump(lovd_php_file('http://rest.genenames.org/search/symbol/IVD', false, '', 'Accept: application/json'));
+$aOutput = lovd_php_file('http://rest.genenames.org/search/symbol/IVD', false, '', 'Accept: application/json');
+if (!is_array($aOutput)) {
+    var_dump($aOutput);
+} else {
+    $sOutput = implode($aOutput);
+    var_dump($sOutput);
+    var_dump(json_decode($sOutput, true));
+}
 
 // Testing connection to Mutalyzer.
 $sURL = str_replace('/services', '', $_CONF['mutalyzer_soap_url']) . '/json/getGeneLocation?build=' . $_CONF['refseq_build'] . '&gene=IVD';
@@ -70,12 +77,26 @@ print("
 ================================================================================
 Contacting Mutalyzer at ${_CONF['mutalyzer_soap_url']} over HTTPS, using fsockopen() fallback, should return IVD mapping data:
 ");
-var_dump(lovd_php_file($sURL));
+$aOutput = lovd_php_file($sURL);
+if (!is_array($aOutput)) {
+    var_dump($aOutput);
+} else {
+    $sOutput = implode($aOutput);
+    var_dump($sOutput);
+    var_dump(json_decode($sOutput, true));
+}
 print("
 ================================================================================
 Contacting Mutalyzer at ${_CONF['mutalyzer_soap_url']} over HTTPS, using non-context file() call, should " . (!$bFopenWrappers? 'fail since fopen wrappers are off' : ($bProxy && !$bProxyCanBeBypassed? 'fail since the proxy is ignored' : 'return IVD mapping data')) . ":
 ");
-var_dump(file($sURL, FILE_IGNORE_NEW_LINES));
+$aOutput = file($sURL, FILE_IGNORE_NEW_LINES);
+if (!is_array($aOutput)) {
+    var_dump($aOutput);
+} else {
+    $sOutput = implode($aOutput);
+    var_dump($sOutput);
+    var_dump(json_decode($sOutput, true));
+}
 if ($bCurl) {
     print("
 ================================================================================

--- a/src/transcripts.php
+++ b/src/transcripts.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2022-12-14
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-23
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -278,7 +278,7 @@ if (ACTION == 'create') {
                                                                   'transcriptsAdded' => $aTranscripts['added'],
                                                                 );
 
-        if (!$aTranscripts['id']) {
+        if (!$aTranscripts['id'] || isset($_GET['VV'])) {
             // Mutalyzer doesn't see any transcripts at all.
             // The future is VV. However, as we're currently still using
             //  Mutalyzer for mapping, only use VV when Mutalyzer fails.


### PR DESCRIPTION
### Fix multiple issues.
- Prevent notices when escaping `NULL` data in `download.php`.
- When Mutalyzer fails when listing transcripts, handle it nicely.
- When Mutalyzer fails to fetch a new gene's transcripts, try VV. This also opens up a possibility to bypass Mutalyzer when there are no errors by adding `&VV` to the URL.
- Add the same bypass option to `transcripts.php`.
- Fix warnings in `genes.php` when `?create` is loaded by `POST`. This happens, e.g., when we were running an LOVD update.
- Fix incorrect table names in code for deleting an individual.
- Fix an incorrect overwriting of a variable in `$zData`. Values in `$zData` should never be overwritten; we should create a copy and modify the copy.
- Fixed warning just after the installation due to a `NULL` value.
- Add Curl checks to the connectivity debugging script.
- Improve output and fix a URL in the connectivity debugging script.
- Improve output of connectivity debugging script. Data fetching JSON code is first checked, and then decoded. This way, we can both debug connection issues as well decoding issues.
- Some general code cleanups.