### PR TITLE
Add dates to records

### DIFF
--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1517,6 +1517,10 @@ class LOVD_API_GA4GH
                                 'term' => trim($sPhenotype),
                                 'inheritance_pattern' => $aInheritance,
                             );
+
+                        } else {
+                            // Nothing to do here.
+                            continue;
                         }
                     }
 

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1409,7 +1409,9 @@ class LOVD_API_GA4GH
                                INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id)
                              WHERE vot.id = vog.id), "")
                         )
-                        ORDER BY vog.chromosome, vog.position_g_start, vog.position_g_end, vog.`VariantOnGenome/DNA`, vog.id SEPARATOR ";;") AS variants
+                        ORDER BY vog.chromosome, vog.position_g_start, vog.position_g_end, vog.`VariantOnGenome/DNA`, vog.id SEPARATOR ";;") AS variants,
+                      i.created_date,
+                      i.edited_date
                     FROM ' . TABLE_INDIVIDUALS . ' AS i
                       LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid)
                       LEFT OUTER JOIN ' . TABLE_PHENOTYPES . ' AS p ON (i.id = p.individualid AND p.statusid >= ?)
@@ -1602,6 +1604,14 @@ class LOVD_API_GA4GH
                         $aIndividual['phenotypes'],
                         SORT_REGULAR)
                 );
+
+                // Leave out dates when they're missing.
+                if ($aSubmission['created_date']) {
+                    $aIndividual['creation_date'] = array('value' => date('c', strtotime($aSubmission['created_date'])));
+                }
+                if ($aSubmission['edited_date']) {
+                    $aIndividual['modification_date'] = array('value' => date('c', strtotime($aSubmission['edited_date'])));
+                }
 
                 if (!empty($aSubmission['remarks'])) {
                     $aIndividual['comments'] = $this->addComment(array(), $aSubmission['remarks']);

--- a/src/class/object_diseases.php
+++ b/src/class/object_diseases.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-07-28
- * Modified    : 2022-11-22
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-29
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -203,9 +203,9 @@ class LOVD_Disease extends LOVD_Object
                         'features' => 'Disease features',
                         'remarks' => 'Remarks',
                         'created_by_' => array('Created by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'created_date_' => array('Date created', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'created_date_' => 'Date created',
                         'edited_by_' => array('Last edited by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'edited_date_' => array('Date last edited', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'edited_date_' => 'Date last edited',
                       );
 
         // List of columns and (default?) order for viewing a list of entries.

--- a/src/class/object_genome_variants.php
+++ b/src/class/object_genome_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2023-06-28
+ * Modified    : 2023-06-29
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -130,9 +130,9 @@ class LOVD_GenomeVariant extends LOVD_Custom
                 'status' => array('Variant data status', $_SETT['user_level_settings']['see_nonpublic_data']),
                 'license_' => 'Database submission license',
                 'created_by_' => 'Created by',
-                'created_date_' => array('Date created', $_SETT['user_level_settings']['see_nonpublic_data']),
+                'created_date_' => 'Date created',
                 'edited_by_' => array('Last edited by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                'edited_date_' => array('Date last edited', $_SETT['user_level_settings']['see_nonpublic_data']),
+                'edited_date_' => 'Date last edited',
             )
         );
         if (!LOVD_plus) {

--- a/src/class/object_individuals.php
+++ b/src/class/object_individuals.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2022-11-22
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-29
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -153,9 +153,9 @@ class LOVD_Individual extends LOVD_Custom
                         'status' => array('Individual data status', $_SETT['user_level_settings']['see_nonpublic_data']),
                         'license_' => 'Database submission license',
                         'created_by_' => 'Created by',
-                        'created_date_' => array('Date created', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'created_date_' => 'Date created',
                         'edited_by_' => array('Last edited by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'edited_date_' => array('Date last edited', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'edited_date_' => 'Date last edited',
                       ));
 
         // List of columns and (default?) order for viewing a list of entries.

--- a/src/class/object_phenotypes.php
+++ b/src/class/object_phenotypes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-02-16
- * Modified    : 2022-11-22
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-29
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -107,9 +107,9 @@ class LOVD_Phenotype extends LOVD_Custom
                         'status' => array('Phenotype data status', $_SETT['user_level_settings']['see_nonpublic_data']),
                         'license_' => 'Database submission license',
                         'created_by_' => 'Created by',
-                        'created_date_' => array('Date created', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'created_date_' => 'Date created',
                         'edited_by_' => array('Last edited by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'edited_date_' => array('Date last edited', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'edited_date_' => 'Date last edited',
                       ));
 
         // List of columns and (default?) order for viewing a list of entries.

--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2022-11-22
- * For LOVD    : 3.0-29
+ * Modified    : 2023-06-29
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -127,9 +127,9 @@ class LOVD_Screening extends LOVD_Custom
                         'owned_by_' => 'Owner name',
                         'license_' => 'Database submission license',
                         'created_by_' => 'Created by',
-                        'created_date_' => array('Date created', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'created_date_' => 'Date created',
                         'edited_by_' => array('Last edited by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'edited_date_' => array('Date last edited', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'edited_date_' => 'Date last edited',
                       ));
 
         // List of columns and (default?) order for viewing a list of entries.

--- a/src/class/object_transcripts.php
+++ b/src/class/object_transcripts.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-20
- * Modified    : 2023-06-23
+ * Modified    : 2023-06-29
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -114,9 +114,9 @@ class LOVD_Transcript extends LOVD_Object
                         'exon_table' => 'Exon/intron information',
                         'remarks' => 'Remarks',
                         'created_by_' => array('Created by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'created_date_' => array('Date created', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'created_date_' => 'Date created',
                         'edited_by_' => array('Last edited by', $_SETT['user_level_settings']['see_nonpublic_data']),
-                        'edited_date_' => array('Date last edited', $_SETT['user_level_settings']['see_nonpublic_data']),
+                        'edited_date_' => 'Date last edited',
                       );
 
         // List of columns and (default?) order for viewing a list of entries.

--- a/tests/test_data_files/AdminTestSuiteResult-GA4GH.txt
+++ b/tests/test_data_files/AdminTestSuiteResult-GA4GH.txt
@@ -137,6 +137,9 @@
                                 }
                             }
                         ],
+                        "creation_date": {
+                            "value": "0000-00-00T00:00:00+00:00"
+                        },
                         "db_xrefs": [
                             {
                                 "source": "pubmed",
@@ -432,6 +435,9 @@
                                 }
                             }
                         ],
+                        "creation_date": {
+                            "value": "0000-00-00T00:00:00+00:00"
+                        },
                         "db_xrefs": [
                             {
                                 "source": "pubmed",


### PR DESCRIPTION
### Add dates to records.
- Set the `created_date` and `edited_date` fields to public access on ViewEntries. Only for genes, the `edited_date` is not made public to prevent confusion with the `updated_date` field. I can't remember why these fields are hidden, but many users would like to know how recent an entry is.
- Add dates to variant-only observations in the GA4GH API output.
- Add dates to full submissions in the GA4GH API output.
- Adapt the GA4GH test files after the updates.

Also:
- Clean phenotype output a bit in the GA4GH API output. I saw some empty phenotype objects; these are now skipped.