### PR TITLE
More fixes to the date fields in the GA4GH API and in form data processing.

### DIFF
--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -962,7 +962,7 @@ class LOVD_API_GA4GH
                            IFNULL(uo.orcid_id, ""), "##", uo.name, "##", uo.email
                          ), ""), "||",
                        IFNULL(NULLIF(vog.created_date, "0000-00-00 00:00:00"), ""), "||",
-                       IFNULL(NULLIF(vog.edited_date, "0000-00-00 00:00:00"), "")
+                       IFNULL(NULLIF(IFNULL(vog.edited_date, vog.created_date), "0000-00-00 00:00:00"), "")
                      )
                    ) ORDER BY vog.id SEPARATOR ";;") AS variants,
                  MIN(NULLIF(vog.created_date, "0000-00-00 00:00:00")) AS created_date,
@@ -1411,7 +1411,7 @@ class LOVD_API_GA4GH
                         )
                         ORDER BY vog.chromosome, vog.position_g_start, vog.position_g_end, vog.`VariantOnGenome/DNA`, vog.id SEPARATOR ";;") AS variants,
                       IFNULL(NULLIF(i.created_date, "0000-00-00 00:00:00"), "") AS created_date,
-                      IFNULL(NULLIF(i.edited_date, "0000-00-00 00:00:00"), "") AS edited_date
+                      IFNULL(NULLIF(IFNULL(i.edited_date, i.created_date), "0000-00-00 00:00:00"), "") AS edited_date
                     FROM ' . TABLE_INDIVIDUALS . ' AS i
                       LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid)
                       LEFT OUTER JOIN ' . TABLE_PHENOTYPES . ' AS p ON (i.id = p.individualid AND p.statusid >= ?)

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -1407,7 +1407,9 @@ class LOVD_API_GA4GH
                                  SEPARATOR "$$")
                              FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot
                                INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id)
-                             WHERE vot.id = vog.id), "")
+                             WHERE vot.id = vog.id), ""), "||",
+                          IFNULL(NULLIF(vog.created_date, "0000-00-00 00:00:00"), ""), "||",
+                          IFNULL(NULLIF(IFNULL(vog.edited_date, vog.created_date), "0000-00-00 00:00:00"), "")
                         )
                         ORDER BY vog.chromosome, vog.position_g_start, vog.position_g_end, vog.`VariantOnGenome/DNA`, vog.id SEPARATOR ";;") AS variants,
                       IFNULL(NULLIF(i.created_date, "0000-00-00 00:00:00"), "") AS created_date,
@@ -1710,7 +1712,9 @@ class LOVD_API_GA4GH
                         $sRemarks,
                         $sTemplate,
                         $sTechnique,
-                        $sVOTs
+                        $sVOTs,
+                        $sCreatedDate,
+                        $sEditedDate
                     ) = explode('||', $sVariant);
                     $aVariant = array(
                         'id' => $nID,
@@ -1737,6 +1741,8 @@ class LOVD_API_GA4GH
                             ),
                         )),
                         'pathogenicities' => array(),
+                        'creation_date' => array(),
+                        'modification_date' => array(),
                     );
 
                     // Large submissions generate a lot of data and waste resources (CPU time and disk space),
@@ -1816,6 +1822,18 @@ class LOVD_API_GA4GH
                             },
                             $aVariant['pathogenicities']
                         );
+                    }
+
+                    // Leave out dates when they're missing.
+                    if ($sCreatedDate) {
+                        $aVariant['creation_date']['value'] = date('c', strtotime($sCreatedDate));
+                    } else {
+                        unset($aVariant['creation_date']);
+                    }
+                    if ($sEditedDate) {
+                        $aVariant['modification_date']['value'] = date('c', strtotime($sEditedDate));
+                    } else {
+                        unset($aVariant['modification_date']);
                     }
 
                     if ($sOrigin && isset($this->aValueMappings['genetic_origin'][$sOrigin])) {

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2023-06-30
+ * Modified    : 2023-07-03
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -961,8 +961,8 @@ class LOVD_API_GA4GH
                          CONCAT(
                            IFNULL(uo.orcid_id, ""), "##", uo.name, "##", uo.email
                          ), ""), "||",
-                       IFNULL(vog.created_date, ""), "||",
-                       IFNULL(vog.edited_date, "")
+                       IFNULL(NULLIF(vog.created_date, "0000-00-00 00:00:00"), ""), "||",
+                       IFNULL(NULLIF(vog.edited_date, "0000-00-00 00:00:00"), "")
                      )
                    ) ORDER BY vog.id SEPARATOR ";;") AS variants,
                  MIN(NULLIF(vog.created_date, "0000-00-00 00:00:00")) AS created_date,
@@ -1410,8 +1410,8 @@ class LOVD_API_GA4GH
                              WHERE vot.id = vog.id), "")
                         )
                         ORDER BY vog.chromosome, vog.position_g_start, vog.position_g_end, vog.`VariantOnGenome/DNA`, vog.id SEPARATOR ";;") AS variants,
-                      i.created_date,
-                      i.edited_date
+                      IFNULL(NULLIF(i.created_date, "0000-00-00 00:00:00"), "") AS created_date,
+                      IFNULL(NULLIF(i.edited_date, "0000-00-00 00:00:00"), "") AS edited_date
                     FROM ' . TABLE_INDIVIDUALS . ' AS i
                       LEFT OUTER JOIN ' . TABLE_IND2DIS . ' AS i2d ON (i.id = i2d.individualid)
                       LEFT OUTER JOIN ' . TABLE_PHENOTYPES . ' AS p ON (i.id = p.individualid AND p.statusid >= ?)

--- a/src/class/objects.php
+++ b/src/class/objects.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2023-02-14
- * For LOVD    : 3.0-29
+ * Modified    : 2023-07-05
+ * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -590,7 +590,7 @@ class LOVD_Object
                     switch ($sMySQLType) {
                         case 'DATE':
                             if (!lovd_matchDate($sFieldvalue)) {
-                                lovd_errorAdd($sFieldname, 'The field \'' . $sHeader . '\' must contain a date in the format YYYY-MM-DD, "' . htmlspecialchars($sFieldvalue) . '" does not match.');
+                                lovd_errorAdd($sFieldname, 'The field \'' . $sHeader . '\' must contain a valid date in the format YYYY-MM-DD, "' . htmlspecialchars($sFieldvalue) . '" does not match.');
                             }
                             break;
                         case 'DATETIME':

--- a/src/columns.php
+++ b/src/columns.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-03-04
- * Modified    : 2023-02-01
- * For LOVD    : 3.0-29
+ * Modified    : 2023-07-05
+ * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -411,7 +411,7 @@ if (PATH_COUNT == 1 && ACTION == 'data_type_wizard') {
 
             // Format for the DATE/DATETIME column types.
             if ($_POST['form_type'] == 'date' && !lovd_matchDate($_POST['default_val'], !empty($_POST['time']))) {
-                lovd_errorAdd('default_val', 'The \'Default value\' for the date field should be like YYYY-MM-DD' . (empty($_POST['time'])? '.' : ' HH:MM:SS.'));
+                lovd_errorAdd('default_val', 'The \'Default value\' for the date field should be a valid date in the format YYYY-MM-DD' . (empty($_POST['time'])? '.' : ' HH:MM:SS.'));
             }
         }
 

--- a/src/import.php
+++ b/src/import.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2022-12-14
- * For LOVD    : 3.0-29
+ * Modified    : 2023-07-05
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -1573,7 +1573,7 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
                         $aLine[$sCol] = $sDate;
                     } elseif (!$zData || in_array($sCol, $aColumns)) {
                         if ($aLine[$sCol] && !lovd_matchDate($aLine[$sCol], true)) {
-                            lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): ' . $sCol . ' value "' . htmlspecialchars($aLine[$sCol]) . '" is not a correct date format, use the format YYYY-MM-DD HH:MM:SS.');
+                            lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): ' . $sCol . ' value "' . htmlspecialchars($aLine[$sCol]) . '" is not a valid date, use a valid date in the format YYYY-MM-DD HH:MM:SS.');
                         } elseif (($sCol == 'created_date' || $aLine['edited_by']) && !$aLine[$sCol]) {
                             // Edited_date is only filled in if empty and edited_by is filled in.
                             $aLine[$sCol] = $sDate;

--- a/src/import.php
+++ b/src/import.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-09-19
- * Modified    : 2023-07-05
+ * Modified    : 2023-07-06
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1572,7 +1572,7 @@ if (POST || $_FILES) { // || $_FILES is in use for the automatic loading of file
                         // If zData is set, always set the edited date.
                         $aLine[$sCol] = $sDate;
                     } elseif (!$zData || in_array($sCol, $aColumns)) {
-                        if ($aLine[$sCol] && !lovd_matchDate($aLine[$sCol], true)) {
+                        if ($aLine[$sCol] && !lovd_matchDate($aLine[$sCol], true, true)) {
                             lovd_errorAdd('import', 'Error (' . $sCurrentSection . ', line ' . $nLine . '): ' . $sCol . ' value "' . htmlspecialchars($aLine[$sCol]) . '" is not a valid date, use a valid date in the format YYYY-MM-DD HH:MM:SS.');
                         } elseif (($sCol == 'created_date' || $aLine['edited_by']) && !$aLine[$sCol]) {
                             // Edited_date is only filled in if empty and edited_by is filled in.

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2023-07-05
+ * Modified    : 2023-07-06
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -573,7 +573,7 @@ function lovd_buildOptionTable ($aOptionsList = array())
 
 
 
-function lovd_matchDate ($s, $bTime = false)
+function lovd_matchDate ($s, $bTime = false, $bNoZeroDate = false)
 {
     // Function kindly provided by Ileos.nl in the interest of Open Source.
     // Matches a string to the date pattern, one that MySQL can understand.
@@ -593,7 +593,7 @@ function lovd_matchDate ($s, $bTime = false)
 
     // Finally, since strtotime() allows 31 days in months that have 30, do a better check.
     list($nYear, $nMonth, $nDay) = explode('-', $sDate);
-    if (!checkdate($nMonth, $nDay, $nYear)) {
+    if (!checkdate($nMonth, $nDay, $nYear) && !(!$bNoZeroDate && $sDate == '0000-00-00')) {
         return false;
     }
 

--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2023-02-03
- * For LOVD    : 3.0-29
+ * Modified    : 2023-07-05
+ * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -578,7 +578,26 @@ function lovd_matchDate ($s, $bTime = false)
     // Function kindly provided by Ileos.nl in the interest of Open Source.
     // Matches a string to the date pattern, one that MySQL can understand.
 
-    return (preg_match('/^[0-9]{4}[.\/-][0-9]{2}[.\/-][0-9]{2}' . ($bTime? ' [0-2][0-9]\:[0-5][0-9]\:[0-5][0-9]' : '') . '$/', $s));
+    $bFormat = preg_match('/^[0-9]{4}[.\/-][0-9]{2}[.\/-][0-9]{2}' . ($bTime? ' [0-2][0-9]\:[0-5][0-9]\:[0-5][0-9]' : '') . '$/', $s);
+    if (!$bFormat) {
+        return false;
+    }
+
+    // We'll need this a few times.
+    $sDate = substr($s, 0, 10);
+
+    // We need a valid date, always.
+    if (strtotime($s) === false) {
+        return false;
+    }
+
+    // Finally, since strtotime() allows 31 days in months that have 30, do a better check.
+    list($nYear, $nMonth, $nDay) = explode('-', $sDate);
+    if (!checkdate($nMonth, $nDay, $nYear)) {
+        return false;
+    }
+
+    return true;
 }
 
 

--- a/src/inc-lib-genes.php
+++ b/src/inc-lib-genes.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-01-25
- * Modified    : 2021-04-15
- * For LOVD    : 3.0-27
+ * Modified    : 2023-07-06
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Jerry Hoogenboom <J.Hoogenboom@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -164,6 +164,18 @@ function lovd_getGeneInfoFromHGNC ($sHgncId, $bRecursion = false)
         }
         return false;
     }
+
+    // 2023-07-06; Sometimes, the HGNC sends a subset of fields back.
+    foreach (
+        array(
+            'status' => 'Approved',
+            'locus_group' => 'protein-coding gene',
+        ) as $sField => $sValue) {
+        if (!isset($aGene[$sField])) {
+            $aGene[$sField] = $sValue;
+        }
+    }
+
 
 
 

--- a/tests/test_data_files/AdminTestSuiteResult-GA4GH.txt
+++ b/tests/test_data_files/AdminTestSuiteResult-GA4GH.txt
@@ -140,6 +140,9 @@
                         "creation_date": {
                             "value": "0000-00-00T00:00:00+00:00"
                         },
+                        "modification_date": {
+                            "value": "0000-00-00T00:00:00+00:00"
+                        },
                         "db_xrefs": [
                             {
                                 "source": "pubmed",
@@ -201,6 +204,12 @@
                                         }
                                     }
                                 ],
+                                "creation_date": {
+                                    "value": "0000-00-00T00:00:00+00:00"
+                                },
+                                "modification_date": {
+                                    "value": "0000-00-00T00:00:00+00:00"
+                                },
                                 "db_xrefs": [
                                     {
                                         "source": "pubmed",
@@ -294,6 +303,12 @@
                                         }
                                     }
                                 ],
+                                "creation_date": {
+                                    "value": "0000-00-00T00:00:00+00:00"
+                                },
+                                "modification_date": {
+                                    "value": "0000-00-00T00:00:00+00:00"
+                                },
                                 "db_xrefs": [
                                     {
                                         "source": "pubmed",
@@ -438,6 +453,9 @@
                         "creation_date": {
                             "value": "0000-00-00T00:00:00+00:00"
                         },
+                        "modification_date": {
+                            "value": "0000-00-00T00:00:00+00:00"
+                        },
                         "db_xrefs": [
                             {
                                 "source": "pubmed",
@@ -499,6 +517,12 @@
                                         }
                                     }
                                 ],
+                                "creation_date": {
+                                    "value": "0000-00-00T00:00:00+00:00"
+                                },
+                                "modification_date": {
+                                    "value": "0000-00-00T00:00:00+00:00"
+                                },
                                 "db_xrefs": [
                                     {
                                         "source": "pubmed",
@@ -592,6 +616,12 @@
                                         }
                                     }
                                 ],
+                                "creation_date": {
+                                    "value": "0000-00-00T00:00:00+00:00"
+                                },
+                                "modification_date": {
+                                    "value": "0000-00-00T00:00:00+00:00"
+                                },
                                 "db_xrefs": [
                                     {
                                         "source": "pubmed",


### PR DESCRIPTION
### Date-related improvements.
#### More fixes to the date fields in the GA4GH API.
- Consider 0-dates as no dates.
- When there is no modification date, take the creation date.
- Also add dates to variants within full submissions.
- Fix tests.

#### Enforce correct dates entered through forms.
- Improve `lovd_matchDate()` to enforce a valid date.
- Clarify error messages, mention valid dates are needed.
- Adjust `lovd_matchDate()` to optionally disallow 0-dates.
- Force non-zero dates for `created_date` and `edited_date` during import.

### Also:
- Circumvent recurrent API issues with the HGNC that make the tests fail.