### PR TITLE
Links to Orphanet no longer work

### DIFF
--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2024-01-24
+ * Modified    : 2024-04-16
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -66,8 +66,7 @@ class LOVD_Gene extends LOVD_Object
 
         // SQL code for viewing an entry.
         $this->aSQLViewEntry['SELECT']   = 'g.*, g.id_entrez AS id_pubmed_gene,
-                                            IF(g.show_genetests AND g.id_entrez, g.id_entrez, 0) AS show_genetests,
-                                            IF(g.show_orphanet AND g.id_hgnc, g.id_hgnc, 0) AS show_orphanet, ' .
+                                            IF(g.show_genetests AND g.id_entrez, g.id_entrez, 0) AS show_genetests, ' .
                                            'GROUP_CONCAT(DISTINCT d.id, ";", IFNULL(d.id_omim, 0), ";", IF(CASE d.symbol WHEN "-" THEN "" ELSE d.symbol END = "", d.name, d.symbol), ";", d.name ORDER BY (d.symbol != "" AND d.symbol != "-") DESC, d.symbol, d.name SEPARATOR ";;") AS __diseases, ' .
                                            'GROUP_CONCAT(DISTINCT t.id, ";", t.id_ncbi ORDER BY t.id_ncbi SEPARATOR ";;") AS __transcripts, ' .
                                            'MAX(t.position_g_mrna_start < t.position_g_mrna_end) AS sense, ' .
@@ -733,7 +732,7 @@ class LOVD_Gene extends LOVD_Object
                     //  it would be good if we'd standardize that.
                     $zData[$sColID . '_'] = '<A href="' .
                         lovd_getExternalSource($sSource,
-                            ($sType == 'id' || $sSource == 'genetests' || $sSource == 'orphanet'? $zData[$sColID] :
+                            ($sType == 'id' || $sSource == 'genetests'? $zData[$sColID] :
                                 rawurlencode($zData['id'])), true) . '" target="_blank">' .
                         ($sType == 'id'? $zData[$sColID] : rawurlencode($zData['id'])) . '</A>';
                 } else {

--- a/src/inc-init.php
+++ b/src/inc-init.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2023-02-15
- * For LOVD    : 3.0-29
+ * Modified    : 2024-04-16
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -174,7 +174,7 @@ $aRequired =
 $_SETT = array(
                 'system' =>
                      array(
-                            'version' => '3.0-29',
+                            'version' => '3.0-29b',
                           ),
                 'user_levels' =>
                      array(

--- a/src/inc-upgrade.php
+++ b/src/inc-upgrade.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-14
- * Modified    : 2023-01-27
- * For LOVD    : 3.0-29
+ * Modified    : 2024-04-16
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.NL>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -825,6 +825,10 @@ if ($sCalcVersionFiles != $sCalcVersionDB) {
                  '3.0-28d' =>
                  array(
                      'UPDATE ' . TABLE_LINKS . ' SET replace_text = "<A href=\"https://www.ncbi.nlm.nih.gov/snp/[1]\" target=\"_blank\">dbSNP</A>" WHERE name = "DbSNP" AND replace_text = "<A href=\"https://www.ncbi.nlm.nih.gov/SNP/snp_ref.cgi?rs=[1]\" target=\"_blank\">dbSNP</A>"',
+                 ),
+                 '3.0-29b' =>
+                 array(
+                     'UPDATE ' . TABLE_SOURCES . ' SET url = "https://www.orpha.net/en/disease/gene/{{ ID }}" WHERE id = "orphanet"',
                  ),
              );
 

--- a/src/install/inc-sql-sources.php
+++ b/src/install/inc-sql-sources.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-23
- * Modified    : 2021-01-28
- * For LOVD    : 3.0-26
+ * Modified    : 2024-04-16
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2021 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -41,7 +41,7 @@ $aSourceSQL =
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("hgnc",         "https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/HGNC:{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("hpo_disease",  "https://hpo.jax.org/app/browse/disease/OMIM:{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("omim",         "http://www.omim.org/entry/{{ ID }}")',
-                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("orphanet",     "https://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&Gene={{ ID }}")',
+                'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("orphanet",     "https://www.orpha.net/en/disease/gene/{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("pubmed_gene",  "https://www.ncbi.nlm.nih.gov/pubmed?LinkName=gene_pubmed&from_uid={{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("pubmed_article", "https://www.ncbi.nlm.nih.gov/pubmed/{{ ID }}")',
                 'INSERT INTO ' . TABLE_SOURCES . ' VALUES ("uniprot",      "http://www.uniprot.org/uniprot/{{ ID }}")',


### PR DESCRIPTION
### Links to Orphanet no longer work.
- Fix link to the Orphanet gene-specific pages.
- Orphanet no longer allows using HGNC IDs for linking. That's a bad thing, but there's no alternative.
- Version bump to 3.0-29b.

Closes #645.
