### PR TITLE
Improve the HGVS functions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "findElements() (plural) can then also go."
     ],
     "require-dev": {
-        "phpunit/phpunit": "5.*",
-        "php-webdriver/webdriver": "1.7.*"
+        "phpunit/phpunit": "8.*",
+        "php-webdriver/webdriver": "1.9.*"
     }
 }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2386,6 +2386,22 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                             }
                         }
 
+                    } elseif (preg_match('/^([-*]?[0-9]+([-+][0-9]+)?)_([-*]?[0-9]+([-+]([0-9]+))?)(inv)?$/', $sInsertion, $aRegs)) {
+                        // c.1_2ins10_20 or c.1_2ins10+1_*20-1.
+                        // Instead of writing our own logic here, re-use our own function.
+                        $sVariantInInsertion = $aVariant['prefix'] . '.' . $aRegs[0] . ($aRegs[6] ?? 'del');
+                        $aVariantInInsertion = lovd_getVariantInfo($sVariantInInsertion, false);
+                        // We can expect any error here. EFALSEUTR, EPOSITIONFORMAT, WPOSITIONFORMAT, a combination, etc.
+                        if ($aVariantInInsertion['errors']) {
+                            $aResponse['errors']['ESUFFIXFORMAT'] =
+                                'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines. ' .
+                                current($aVariantInInsertion['errors']);
+                        } elseif ($aVariantInInsertion['warnings']) {
+                            $aResponse['warnings']['WSUFFIXFORMAT'] =
+                                'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines. ' .
+                                current($aVariantInInsertion['warnings']);
+                        }
+
                     } elseif (!(
                         (preg_match(                                                                       // c.1_2ins15+1_16-1
                             '/^([-*]?[0-9]+([-+][0-9]+)?)_([-*]?[0-9]+([-+]([0-9]+))?)(inv)?$/', $sInsertion, $aRegs)

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2337,7 +2337,14 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
             if ($bCheckHGVS) {
                 return false;
             }
-            $aResponse['warnings']['WSUFFIXGIVEN'] = 'Nothing should follow "' . $aVariant['type'] . '".';
+            // If the suffix is just sequence, though, they probably forgot a "[1]".
+            if (preg_match('/^' . $_LIBRARIES['regex_patterns']['bases']['alt'] . '+$/', $aVariant['suffix'])) {
+                $aResponse['warnings']['WSUFFIXFORMAT'] = 'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines. Please rewrite "' . $aVariant['type'] . $aVariant['suffix'] . '" to "' . $aVariant['type'] . $aVariant['suffix'] . '[1]".';
+            } else {
+                $aResponse['warnings']['WSUFFIXGIVEN'] = 'Nothing should follow "' . $aVariant['type'] . '".';
+            }
+            // We'll have to fix the WNOTSUPPORTED.
+            $aResponse['warnings']['WNOTSUPPORTED'] = 'This syntax is currently not supported for mapping and validation.';
 
         } elseif (in_array($aResponse['type'], array('ins', 'delins'))) {
             // Note: Using $aResponse's type here, because 'con' is changed to 'delins' there.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2023-08-30
+ * Modified    : 2023-09-01
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1547,15 +1547,19 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
         $aVariant['type'] = str_replace('bsrc', 'bsrC', $aVariant['type']);
     }
     // Now check.
-    if ((isset($aMatches[1]) && $aVariant['prefix'] != $aMatches[1])
-        || (isset($aMatches[20]) && $aVariant['type'] != $aMatches[20])) {
-        // There's a case problem.
-        if ($bCheckHGVS) {
-            return false;
-        }
+    if ((isset($aMatches[1]) && $aVariant['prefix'] != $aMatches[1])) {
+        // There's a case problem in the prefix.
+        $aResponse['warnings']['WWRONGCASE'] =
+            'This is not a valid HGVS description, due to characters being in the wrong case.' .
+            ' Please rewrite "' . $aMatches[1] . '." to "' . $aVariant['prefix'] . '.".';
+    } elseif (isset($aMatches[20]) && $aVariant['type'] != $aMatches[20]) {
+        // There's a case problem in the variant type.
         $aResponse['warnings']['WWRONGCASE'] =
             'This is not a valid HGVS description, due to characters being in the wrong case.' .
             ' Please check the use of upper- and lowercase characters.';
+    }
+    if (isset($aResponse['warnings']['WWRONGCASE']) && $bCheckHGVS) {
+        return false;
     }
 
     // Storing the variant type.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1721,6 +1721,10 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.';
         } elseif ($bCheckHGVS) {
             return false;
+        } else {
+            // Even with errors, add a WNOTSUPPORTED, but with a different text.
+            $aResponse['warnings']['WNOTSUPPORTED'] =
+                'This syntax is currently not supported for mapping and validation.';
         }
 
     } elseif ($aVariant['type'] == '?') {

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2528,7 +2528,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     } elseif (preg_match('/^([-*]?[0-9]+([-+][0-9]+)?)_([-*]?[0-9]+([-+]([0-9]+))?)(inv)?$/', $sInsertion, $aRegs)) {
                         // c.1_2ins10_20 or c.1_2ins10+1_*20-1.
                         // Instead of writing our own logic here, re-use our own function.
-                        $sVariantInInsertion = $aVariant['prefix'] . '.' . $aRegs[0] . ($aRegs[6] ?? 'del');
+                        $sVariantInInsertion = $aVariant['prefix'] . '.' . $aRegs[0] . (!empty($aRegs[6])? '' : 'del');
                         $aVariantInInsertion = lovd_getVariantInfo($sVariantInInsertion, false);
                         // We can expect any error here. EFALSEUTR, EPOSITIONFORMAT, WPOSITIONFORMAT, a combination, etc.
                         if ($aVariantInInsertion['errors']) {

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2023-09-06
+ * Modified    : 2023-09-08
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2411,7 +2411,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
             // All other variants should get their suffix checked first, before
             //  we warn that it shouldn't be there. Because if it contains a
             //  different type of error, we should report that first.
-            // Case problems are not checked yet. So it's important to do that here.
+            // Case problems in the suffix are not checked yet. So it's important to do that here.
             $bCaseOK = true;
 
             // First check all length issues. Can we parse the suffix into a
@@ -2519,8 +2519,9 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 }
             }
             if ($bCheckHGVS
+                // We deliberately ignore WWRONGCASE here, as we want to analyze the suffix even more.
                 && (isset($aResponse['errors']['EINVALIDNUCLEOTIDES'])
-                    || isset($aResponse['warnings']['WSUFFIXFORMAT']) || isset($aResponse['warnings']['WWRONGCASE']))) {
+                    || isset($aResponse['warnings']['WSUFFIXFORMAT']))) {
                 return false;
             }
 
@@ -2570,7 +2571,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                         $aResponse['warnings']['WSUFFIXINVALIDLENGTH'] =
                             'The positions indicate a range longer than the given length of the variant.' .
                             ' Please adjust the positions if the variant length is certain, or remove the variant length.';
-                    } elseif (!isset($aResponse['warnings']['WWRONGCASE'])) {
+                    } else {
                         // Length is not (partially) larger, is not (partially) smaller, so must be equal.
                         // This is where the suffix becomes unnecessary.
                         $aResponse['warnings']['WSUFFIXGIVEN'] = 'Nothing should follow "' . $aVariant['type'] . '".';
@@ -2647,15 +2648,15 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                             'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.';
                     }
                 }
+            }
 
-                if ($bCheckHGVS
-                    && (isset($aResponse['warnings']['WSUFFIXFORMAT'])
-                        || isset($aResponse['warnings']['WSUFFIXGIVEN'])
-                        || isset($aResponse['warnings']['WSUFFIXINVALIDLENGTH'])
-                        || isset($aResponse['warnings']['WWRONGCASE'])
-                        || isset($aResponse['warnings']['WWRONGTYPE']))) {
-                    return false;
-                }
+            if ($bCheckHGVS
+                && (isset($aResponse['warnings']['WSUFFIXFORMAT'])
+                    || isset($aResponse['warnings']['WSUFFIXGIVEN'])
+                    || isset($aResponse['warnings']['WSUFFIXINVALIDLENGTH'])
+                    || isset($aResponse['warnings']['WWRONGCASE'])
+                    || isset($aResponse['warnings']['WWRONGTYPE']))) {
+                return false;
             }
         }
     }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2306,15 +2306,31 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                             ' Do you mean to indicate inserted positions (e.g., "ins' . $sInsertion . '_' . ((int) $sInsertion[0] + 1) . substr($sInsertion, 1) . '")' .
                             ' or an inserted fragment with an unknown sequence but a given length (e.g., "insN[' . $sInsertion . ']")?';
 
-                    } elseif (preg_match('/^\(([0-9]+)\)$/', $sInsertion, $aRegs)) {
-                        // c.1_2ins(10). We'll assume here that this is a length.
-                        $sInsertion = $aRegs[1]; // We don't use this variable outside of this loop, anyway.
-                        // Even though we choose to throw a warning here and fixHGVS() actually rewrites
-                        //  ins(10) into insN[10], we still want to provide both choices in the warning message.
-                        $aResponse['warnings']['WSUFFIXFORMAT'] =
-                            'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
-                            ' Do you mean to indicate inserted positions (e.g., "ins' . $sInsertion . '_' . ((int) $sInsertion[0] + 1) . substr($sInsertion, 1) . '")' .
-                            ' or an inserted fragment with an unknown sequence but a given length (e.g., "insN[' . $sInsertion . ']")?';
+                    } elseif (preg_match('/^\(([0-9]+)(?:_([0-9]+))?\)$/', $sInsertion, $aRegs)) {
+                        // c.1_2ins(10) or c.1_2ins(10_20). We'll assume here that this is a length.
+                        list(, $nSuffixMinLength, $nSuffixMaxLength) = array_pad($aRegs, 3, '');
+                        if ($nSuffixMaxLength && $nSuffixMinLength > $nSuffixMaxLength) {
+                            list($nSuffixMinLength, $nSuffixMaxLength) = array($nSuffixMaxLength, $nSuffixMinLength);
+                        }
+                        // First, disallow any zero-values.
+                        if ($nSuffixMinLength === '0' || $nSuffixMaxLength === '0') {
+                            $aResponse['errors']['ESUFFIXFORMAT'] =
+                                'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
+                                ' This variant description contains an invalid position or length: "0". Do you mean to indicate inserted positions (e.g., "ins100_200")' .
+                                ' or an inserted fragment with an unknown sequence but a given length (e.g., "insN[' . (!$nSuffixMaxLength? '100' : '(100_200)') . ']")?';
+                        } else {
+                            // Even though we choose to throw a warning here and fixHGVS() actually rewrites
+                            //  ins(10) into insN[10], we still want to provide both choices in the warning message.
+                            $aResponse['warnings']['WSUFFIXFORMAT'] =
+                                'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
+                                ' Do you mean to indicate inserted positions (e.g., "ins' . $nSuffixMinLength . '_' .
+                                ($nSuffixMaxLength && $nSuffixMinLength != $nSuffixMaxLength ?
+                                    $nSuffixMaxLength : ((int)$nSuffixMinLength[0] + 1) . substr($nSuffixMinLength, 1)) . '")' .
+                                ' or an inserted fragment with an unknown sequence but a given length (e.g., "insN[' .
+                                (!$nSuffixMaxLength || $nSuffixMinLength == $nSuffixMaxLength ?
+                                    $nSuffixMinLength :
+                                    '(' . $nSuffixMinLength . '_' . $nSuffixMaxLength . ')') . ']")?';
+                        }
 
                     } elseif (preg_match('/^([A-Z]+)\[(([0-9]+|\?)_([0-9]+|\?))\]$/', strtoupper($sInsertion), $aRegs)) {
                         // c.1_2insN[10_20].

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2446,6 +2446,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     }
                     if ($bCheckHGVS
                         && (isset($aResponse['errors']['EINVALIDNUCLEOTIDES'])
+                            || isset($aResponse['errors']['ESUFFIXFORMAT'])
                             || isset($aResponse['warnings']['WSUFFIXFORMAT'])
                             || isset($aResponse['warnings']['WWRONGCASE']))) {
                         return false;

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1536,7 +1536,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
 
     // Clean position string. We'll use it for reporting later on.
     if ($aVariant['positions']) {
-        $aVariant['positions'] = strstr($aVariant['positions'], $aVariant['type'], true);
+        $aVariant['positions'] = stristr($aVariant['positions'], $aVariant['type'], true);
         // And now with more precision.
         $aResponse['range'] = (strpos($aVariant['positions'], '_') !== false);
     }
@@ -1556,7 +1556,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
         // There's a case problem in the variant type.
         $aResponse['warnings']['WWRONGCASE'] =
             'This is not a valid HGVS description, due to characters being in the wrong case.' .
-            ' Please check the use of upper- and lowercase characters.';
+            ' Please rewrite "' . $aMatches[20] . '" to "' . $aVariant['type'] . '".';
     }
     if (isset($aResponse['warnings']['WWRONGCASE']) && $bCheckHGVS) {
         return false;

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2178,12 +2178,14 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
         }
 
     } elseif ($aResponse['type'] == 'repeat') {
-        $aRepeatUnits = array_filter(
-            preg_split('/[\[\]]/', $aVariant['type']),
-            function ($sValue, $nKey)
-            {
-                return ($sValue && !($nKey % 2));
-            }, ARRAY_FILTER_USE_BOTH
+        $aRepeatUnits = array_values(
+            array_filter(
+                preg_split('/[\[\]]/', $aVariant['type']),
+                function ($sValue, $nKey)
+                {
+                    return ($sValue && !($nKey % 2));
+                }, ARRAY_FILTER_USE_BOTH
+            )
         );
         if ($aVariant['prefix'] == 'c') {
             foreach ($aRepeatUnits as $sRepeat) {
@@ -2208,6 +2210,11 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
             if (strlen($sRepeatBases) > $nLength) {
                 $aResponse['errors']['EINVALIDREPEATLENGTH'] =
                     'The sequence ' . $sRepeatBases . ' does not fit in the given positions ' . $aVariant['positions'] . '. Adjust your positions or the given sequences.';
+            } elseif (count($aRepeatUnits) == 1 && ($nLength % strlen($aRepeatUnits[0])) !== 0) {
+                $aResponse['errors']['EINVALIDREPEATLENGTH'] =
+                    'The given repeat unit ' . $sRepeatBases . ' does not fit in the given positions ' . $aVariant['positions'] . '. Adjust your positions or the given sequences.';
+            }
+            if ($aResponse['errors']) {
                 if ($bCheckHGVS) {
                     return false;
                 }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2178,9 +2178,16 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
         }
 
     } elseif ($aResponse['type'] == 'repeat') {
+        $aRepeatUnits = array_filter(
+            preg_split('/[\[\]]/', $aVariant['type']),
+            function ($sValue, $nKey)
+            {
+                return ($sValue && !($nKey % 2));
+            }, ARRAY_FILTER_USE_BOTH
+        );
         if ($aVariant['prefix'] == 'c') {
-            foreach (explode('[', $aVariant['type']) as $sRepeat) {
-                if (ctype_alpha($sRepeat) && strlen($sRepeat) % 3) {
+            foreach ($aRepeatUnits as $sRepeat) {
+                if (strlen($sRepeat) % 3) {
                     // Repeat variants on coding DNA should always have
                     //  a length of a multiple of three bases.
                     $aResponse['errors']['EINVALIDREPEATLENGTH'] =

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2299,11 +2299,11 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
 
                     } elseif (preg_match('/^([A-Z]+)\[(([0-9]+|\?)_([0-9]+|\?))\]$/', strtoupper($sInsertion), $aRegs)) {
                         // c.1_2insN[10_20].
-                        if ($bCheckHGVS) {
-                            return false;
-                        }
                         $bCaseOK = ($sInsertion == strtoupper($sInsertion));
-                        list(, $sSequence, $nSuffixMinLength, $nSuffixMaxLength) = $aRegs;
+                        list(, $sSequence, $nSuffixLength, $nSuffixMinLength, $nSuffixMaxLength) = $aRegs;
+                        if (strpos($nSuffixLength, '?') === false && $nSuffixMinLength > $nSuffixMaxLength) {
+                            list($nSuffixMinLength, $nSuffixMaxLength) = array($nSuffixMaxLength, $nSuffixMinLength);
+                        }
 
                         // Check if only correct bases have been used.
                         $sUnknownBases = preg_replace(
@@ -2319,9 +2319,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                             ' Please rewrite "' . $sInsertion . '" to "' . $sSequence . '[' .
                             ($nSuffixMinLength == $nSuffixMaxLength?
                                 $nSuffixMinLength :
-                                '(' . (strpos($sInsertion, '?') !== false || $nSuffixMinLength < $nSuffixMaxLength?
-                                    $nSuffixMinLength . '_' . $nSuffixMaxLength :
-                                    min($nSuffixMinLength, $nSuffixMaxLength) . '_' . max($nSuffixMinLength, $nSuffixMaxLength)) . ')') . ']".';
+                                '(' . $nSuffixMinLength . '_' . $nSuffixMaxLength . ')') . ']".';
 
                     } elseif (preg_match('/^([A-Z]+)\[(([0-9]+|\?)|\(([0-9]+|\?)_([0-9]+|\?)\))\]$/', strtoupper($sInsertion), $aRegs)) {
                         // c.1_2insN[40] or ..N[(1_2)].
@@ -2340,9 +2338,6 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                             // Range was given.
                             list(, $sSequence, $nSuffixLength,, $nSuffixMinLength, $nSuffixMaxLength) = $aRegs;
                             if (strpos($nSuffixLength, '?') === false && $nSuffixMinLength >= $nSuffixMaxLength) {
-                                if ($bCheckHGVS) {
-                                    return false;
-                                }
                                 list($nSuffixMinLength, $nSuffixMaxLength) = array($nSuffixMaxLength, $nSuffixMinLength);
                                 $aResponse['warnings']['WSUFFIXFORMAT'] =
                                     'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2023-09-08
+ * Modified    : 2023-09-11
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2280,7 +2280,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 }
 
                 foreach ($aInsertions as $sInsertion) {
-                    // Looping through all possible variants.
+                    // Looping through all possible suffixes.
                     // Some have specific errors, so we handle these first.
                     $bCaseOK = true;
                     if (preg_match('/^[A-Z]+$/i', $sInsertion)) {
@@ -2296,6 +2296,15 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                         if ($sUnknownBases) {
                             $aResponse['errors']['EINVALIDNUCLEOTIDES'] = 'This variant description contains invalid nucleotides: "' . implode('", "', array_unique(str_split($sUnknownBases))) . '".';
                         }
+
+                    } elseif (ctype_digit($sInsertion)) {
+                        // c.1_2ins10.
+                        // We don't know if this should be a position or a length.
+                        // Because we don't know, this is an error, and not a warning.
+                        $aResponse['errors']['ESUFFIXFORMAT'] =
+                            'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
+                            ' Do you mean to indicate inserted positions (e.g., "ins' . $sInsertion . '_' . ((int) $sInsertion[0] + 1) . substr($sInsertion, 1) . '")' .
+                            ' or an inserted fragment with an unknown sequence but a given length (e.g., "insN[' . $sInsertion . ']")?';
 
                     } elseif (preg_match('/^([A-Z]+)\[(([0-9]+|\?)_([0-9]+|\?))\]$/', strtoupper($sInsertion), $aRegs)) {
                         // c.1_2insN[10_20].

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2402,6 +2402,24 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                             $aResponse['errors']['EINVALIDNUCLEOTIDES'] = 'This variant description contains invalid nucleotides: "' . implode('", "', array_unique(str_split($sUnknownBases))) . '".';
                         }
 
+                    } elseif (preg_match('/^\(([A-Z]+)\)$/i', $sInsertion, $aRegs)) {
+                        // g.1_2ins(AA).
+                        $bCaseOK = ($sInsertion == strtoupper($sInsertion));
+
+                        // Check if only correct bases have been used.
+                        $sUnknownBases = preg_replace(
+                            '/' . $_LIBRARIES['regex_patterns']['bases']['alt'] . '+/',
+                            '',
+                            strtoupper($aRegs[1])
+                        );
+                        if ($sUnknownBases) {
+                            $aResponse['errors']['EINVALIDNUCLEOTIDES'] = 'This variant description contains invalid nucleotides: "' . implode('", "', array_unique(str_split($sUnknownBases))) . '".';
+                        }
+
+                        $aResponse['warnings']['WSUFFIXFORMAT'] =
+                            'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
+                            ' Please rewrite "' . $sInsertion . '" to "' . strtoupper($aRegs[1]) . '".';
+
                     } elseif (ctype_digit($sInsertion)) {
                         // c.1_2ins10.
                         // We don't know if this should be a position or a length.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2430,8 +2430,10 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                                 ' Please rewrite "' . $aVariant['type'] . $aVariant['suffix'] . '" to "' . $sDeleted . '>' . $sInserted . '".';
                         } else {
                             // We're not going to check here if this is a delAinsAT here that should be a shifted ins
-                            //  or even check for insertions that should be dups. VV will handle that if we need it.
-                            // Simply tell them to rewrite it.
+                            //  or even check for insertions that should be dups. lovd_fixHGVS() has some logic that can
+                            //  handle that. Since our function doesn't depend on lovd_fixHGVS(), simply throw a message
+                            //  telling the user to rewrite their input. If lovd_fixHGVS() will do a better job, the
+                            //  interface can present its result.
                             $aResponse['warnings']['WSUFFIXFORMAT'] =
                                 'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
                                 ' Please rewrite "' . $aVariant['type'] . $aVariant['suffix'] . '" to "delins' . $sInserted . '".';

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2177,12 +2177,14 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
             if (ctype_alpha($sRepeat) && strlen($sRepeat) % 3) {
                 // Repeat variants on coding DNA should always have
                 //  a length of a multiple of three bases.
-                $aResponse['warnings']['WINVALIDREPEATLENGTH'] =
+                $aResponse['errors']['EINVALIDREPEATLENGTH'] =
                     'A repeat sequence of coding DNA should always have a length of (a multiple of) 3.';
                 if ($bCheckHGVS) {
                     return false;
                 }
                 break;
+                // We'll have to fix the WNOTSUPPORTED.
+                $aResponse['warnings']['WNOTSUPPORTED'] = 'This syntax is currently not supported for mapping and validation.';
             }
         }
     }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2023-08-23
+ * Modified    : 2023-08-30
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2261,7 +2261,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 // g.123_124del2.
                 $nSuffixMinLength = $aVariant['suffix'];
                 $aResponse['warnings']['WSUFFIXFORMAT'] =
-                    'The length of the variant is not formatted following the HGVS guidelines.' .
+                    'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
                     ' Please rewrite "' . $aVariant['suffix'] . '" to "N[' . $nSuffixMinLength . ']".';
 
             } elseif (preg_match('/^[ACGTNU]+$/i', $aVariant['suffix'])) {
@@ -2281,7 +2281,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     list($nSuffixMinLength, $nSuffixMaxLength) = array($nSuffixMaxLength, $nSuffixMinLength);
                 }
                 $aResponse['warnings']['WSUFFIXFORMAT'] =
-                    'The length of the variant is not formatted following the HGVS guidelines.' .
+                    'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
                     ' Please rewrite "' . $aVariant['suffix'] . '" to "N[' .
                     (!$nSuffixMaxLength || $nSuffixMinLength == $nSuffixMaxLength?
                         $nSuffixMinLength :
@@ -2295,7 +2295,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     list($nSuffixMinLength, $nSuffixMaxLength) = array($nSuffixMaxLength, $nSuffixMinLength);
                 }
                 $aResponse['warnings']['WSUFFIXFORMAT'] =
-                    'The length of the variant is not formatted following the HGVS guidelines.' .
+                    'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
                     ' Please rewrite "' . $aVariant['suffix'] . '" to "N[' .
                     ($nSuffixMinLength == $nSuffixMaxLength?
                         $nSuffixMinLength :
@@ -2311,7 +2311,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
 
                     if ($nSuffixMinLength > $nSuffixMaxLength || $nSuffixMinLength == $nSuffixMaxLength) {
                         $aResponse['warnings']['WSUFFIXFORMAT'] =
-                            'The length of the variant is not formatted following the HGVS guidelines.' .
+                            'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
                             ' Please rewrite "' . $aVariant['suffix'] . '" to "N[' .
                             ($nSuffixMinLength == $nSuffixMaxLength?
                                 $nSuffixMinLength :

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2306,6 +2306,16 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                             ' Do you mean to indicate inserted positions (e.g., "ins' . $sInsertion . '_' . ((int) $sInsertion[0] + 1) . substr($sInsertion, 1) . '")' .
                             ' or an inserted fragment with an unknown sequence but a given length (e.g., "insN[' . $sInsertion . ']")?';
 
+                    } elseif (preg_match('/^\(([0-9]+)\)$/', $sInsertion, $aRegs)) {
+                        // c.1_2ins(10). We'll assume here that this is a length.
+                        $sInsertion = $aRegs[1]; // We don't use this variable outside of this loop, anyway.
+                        // Even though we choose to throw a warning here and fixHGVS() actually rewrites
+                        //  ins(10) into insN[10], we still want to provide both choices in the warning message.
+                        $aResponse['warnings']['WSUFFIXFORMAT'] =
+                            'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
+                            ' Do you mean to indicate inserted positions (e.g., "ins' . $sInsertion . '_' . ((int) $sInsertion[0] + 1) . substr($sInsertion, 1) . '")' .
+                            ' or an inserted fragment with an unknown sequence but a given length (e.g., "insN[' . $sInsertion . ']")?';
+
                     } elseif (preg_match('/^([A-Z]+)\[(([0-9]+|\?)_([0-9]+|\?))\]$/', strtoupper($sInsertion), $aRegs)) {
                         // c.1_2insN[10_20].
                         $bCaseOK = ($sInsertion == strtoupper($sInsertion));

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2023-06-01
+ * Modified    : 2023-08-23
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2463,6 +2463,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 if ($bCheckHGVS
                     && (isset($aResponse['warnings']['WSUFFIXFORMAT'])
                         || isset($aResponse['warnings']['WSUFFIXGIVEN'])
+                        || isset($aResponse['warnings']['WSUFFIXINVALIDLENGTH'])
                         || isset($aResponse['warnings']['WWRONGCASE'])
                         || isset($aResponse['warnings']['WWRONGTYPE']))) {
                     return false;

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2541,14 +2541,12 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                                 current($aVariantInInsertion['warnings']);
                         }
 
-                    } elseif (!(
-                        (preg_match(                                                                       // c.1_2ins15+1_16-1
-                            '/^([-*]?[0-9]+([-+][0-9]+)?)_([-*]?[0-9]+([-+]([0-9]+))?)(inv)?$/', $sInsertion, $aRegs)
-                            && !(ctype_digit($aRegs[1]) && ctype_digit($aRegs[3]) && $aRegs[1] > $aRegs[3])))) { // if positions are simple, is A < B?
+                    } else {
+                        // Anything else that we don't recognize (yet).
                         if ($bCheckHGVS) {
                             return false;
                         }
-                        $aResponse['warnings']['WSUFFIXFORMAT'] =
+                        $aResponse['errors']['ESUFFIXFORMAT'] =
                             'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.';
                     }
                     if (!$bCaseOK) {

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2534,6 +2534,14 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     $nSuffixMaxLength = $nSuffixMinLength;
                 }
 
+                // To make sure we can handle questionmarks used in lengths, reset them to numeric values.
+                if ($nSuffixMinLength == '?') {
+                    $nSuffixMinLength = 1;
+                }
+                if ($nSuffixMaxLength == '?') {
+                    $nSuffixMaxLength = $nVariantLength;
+                }
+
                 if (isset($aResponse['messages']['IUNCERTAINRANGE'])) {
                     // Variants with three or more positions. We have the inner positions stored; we know nothing about
                     //  the outer range currently, so we can not check this.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2023-09-11
+ * Modified    : 2024-05-01
  * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -1673,9 +1673,9 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
             $aResponse['errors']['EINVALIDNUCLEOTIDES'] = 'This variant description contains invalid nucleotides: "' . implode('", "', str_split($sUnknownBases)) . '".';
         }
 
-        // This code is based on the deletion suffix check code.
-        foreach (array_filter(preg_split('/(?<=])/', strtoupper($aVariant['type']))) as $sRepeat) {
-            if (preg_match('/^([A-Z]+)\[(([0-9]+|\?)_([0-9]+|\?))\]$/i', $sRepeat, $aRegs)) {
+        // This code is based on the deletion suffix check code. The variant type is already in uppercase.
+        foreach (array_filter(preg_split('/(?<=])/', $aVariant['type'])) as $sRepeat) {
+            if (preg_match('/^([A-Z]+)\[(([0-9]+|\?)_([0-9]+|\?))\]$/', $sRepeat, $aRegs)) {
                 // ...N[50_60].
                 list(, $sSequence, $nSuffixLength, $nSuffixMinLength, $nSuffixMaxLength) = $aRegs;
                 if (strpos($nSuffixLength, '?') === false && $nSuffixMinLength > $nSuffixMaxLength) {
@@ -1689,7 +1689,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                         '(' . $nSuffixMinLength . '_' . $nSuffixMaxLength . ')') . ']".';
                 break; // We can only handle one, anyway.
 
-            } elseif (preg_match('/^([A-Z]+)\[(([0-9]+|\?)|\(([0-9]+|\?)_([0-9]+|\?)\))\]$/i', $sRepeat, $aRegs)) {
+            } elseif (preg_match('/^([A-Z]+)\[(([0-9]+|\?)|\(([0-9]+|\?)_([0-9]+|\?)\))\]$/', $sRepeat, $aRegs)) {
                 // ...N[2], ...N[(50_60)].
                 if (isset($aRegs[4])) {
                     // Range was given.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2425,7 +2425,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
                     ' Please rewrite "' . $aVariant['suffix'] . '" to "N[' . $nSuffixMinLength . ']".';
 
-            } elseif (preg_match('/^[A-Z]+$/i', $aVariant['suffix'])) {
+            } elseif (stripos($aVariant['suffix'], 'ins') === false && preg_match('/^[A-Z]+$/i', $aVariant['suffix'])) {
                 // g.123_124delAA.
                 $bCaseOK = ($aVariant['suffix'] == strtoupper($aVariant['suffix']));
                 $nSuffixMinLength = strlen($aVariant['suffix']);

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -205,7 +205,7 @@ function lovd_fixHGVS ($sVariant, $sType = '')
     }
 
     // Protein formatting for DNA variants.
-    if (preg_match('/^([cgmn]\.)([ACGTUN]+)([0-9]+)([ACGTUN]+)$/', $sVariant, $aRegs)) {
+    if (preg_match('/^([cgmn]\.)([A-Z]+)([0-9]+)([A-Z]+)$/i', $sVariant, $aRegs)) {
         // Rebuild the variant into a substitution.
         list(, $sPrefix, $sRef, $nPosition, $sAlt) = $aRegs;
         return lovd_fixHGVS($sReference . $sPrefix . $nPosition . $sRef . '>' . $sAlt, $sType);

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2024-01-26
+ * Modified    : 2024-05-07
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -275,6 +275,19 @@ function lovd_fixHGVS ($sVariant, $sType = '')
         && !isset($aVariant['errors']['EPOSITIONFORMAT'])
         && isset($aVariant['warnings']['WTOOMUCHUNKNOWN'])) {
         return $sReference . $sVariant; // Not HGVS, unrepairable.
+    }
+
+    // Handle any given lovd_getVariantInfo() suggestion.
+    foreach ($aVariant['warnings'] as $sCode => $sWarning) {
+        if (preg_match('/Please rewrite "([^"]+)" to "([^"]+)"\.$/', $sWarning, $aRegs)
+            // Don't fix things in the suffix when there is anyway an invalid length.
+            && !($sCode == 'WSUFFIXFORMAT' && isset($aVariant['warnings']['WSUFFIXINVALIDLENGTH']))) {
+            list(, $sOld, $sNew) = $aRegs;
+            // To prevent a disaster when g.100del1 gets replaced to g.N[1]00delN[1], replace only the last occurrence.
+            // That's where usually the issues are.
+            $nPosition = strrpos($sReference . $sVariant, $sOld);
+            return lovd_fixHGVS(substr_replace($sReference . $sVariant, $sNew, $nPosition, strlen($sOld)), $sType);
+        }
     }
 
     // Make fixes to the reference sequences as indicated by lovd_getVariantInfo().

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -325,6 +325,16 @@ function lovd_fixHGVS ($sVariant, $sType = '')
                 str_replace('U', 'T', strtoupper($aRegs[2]) .
                     (!isset($aRegs[3])? '' : 'ins' . strtoupper($aRegs[3]))), $sType);
         }
+
+    } elseif (isset($aVariant['errors']['EINVALIDNUCLEOTIDES'])
+        && strpos($aVariant['errors']['EINVALIDNUCLEOTIDES'], ': "U".')
+        && strpos($sVariant, 'U') !== false) {
+        // Check if there is a U that we can change to a T.
+        // This is usually an error, but could be a warning if we only found a U.
+        // But, only do this when we don't have a WWRONGCASE left, and only when we actually find a "U".
+        // Case issues can result in a warning for a "U" while the variant contains a "u".
+        // Assuming a capital U doesn't happen anywhere in the variant, we'll just do a str_replace().
+        return lovd_fixHGVS($sReference . str_replace('U', 'T', $sVariant), $sType);
     }
 
     // Change the variant type (if possible) if the wrong type was chosen.

--- a/tests/selenium_tests/LOVDScreenshotListener.php
+++ b/tests/selenium_tests/LOVDScreenshotListener.php
@@ -29,7 +29,7 @@
  *
  *************/
 
-class LOVDScreenshotListener implements PHPUnit_Framework_TestListener
+class LOVDScreenshotListener implements PHPUnit\Framework\TestListener
 {
     // Takes a screenshot on failing tests.
     // Based on PHPUnit's Selenium2TestCase/ScreenshotListener.php
@@ -53,7 +53,7 @@ class LOVDScreenshotListener implements PHPUnit_Framework_TestListener
 
 
 
-    public function addError (PHPUnit_Framework_Test $test, Exception $e, $time)
+    public function addError (PHPUnit\Framework\Test $test, Exception $e, $time)
     {
         $this->storeAScreenshot($test, $e);
     }
@@ -62,7 +62,7 @@ class LOVDScreenshotListener implements PHPUnit_Framework_TestListener
 
 
 
-    public function addFailure (PHPUnit_Framework_Test $test, PHPUnit_Framework_AssertionFailedError $e, $time)
+    public function addFailure (PHPUnit\Framework\Test $test, PHPUnit\Framework\AssertionFailedError $e, $time)
     {
         $this->storeAScreenshot($test, $e);
     }
@@ -71,7 +71,7 @@ class LOVDScreenshotListener implements PHPUnit_Framework_TestListener
 
 
 
-    private function storeAScreenshot (PHPUnit_Framework_Test $test, $e)
+    private function storeAScreenshot (PHPUnit\Framework\Test $test, $e)
     {
         // Store screenshot. Also try to print some information on the error.
         // Unfortunately, we don't seem to have access to the precise location
@@ -101,7 +101,7 @@ class LOVDScreenshotListener implements PHPUnit_Framework_TestListener
 
 
 
-    public function endTestSuite (PHPUnit_Framework_TestSuite $suite)
+    public function endTestSuite (PHPUnit\Framework\TestSuite $suite)
     {
         // Normally run at the end of the test suite, but PHPUnit decides that
         //  every file in our suite is a suite in itself. So, this is run after
@@ -115,13 +115,13 @@ class LOVDScreenshotListener implements PHPUnit_Framework_TestListener
 
 
 
-    // Really dumb, but since PHPUnit_Framework_TestListener doesn't
+    // Really dumb, but since PHPUnit\Framework\TestListener doesn't
     //  implement these, but does define them, we should implement them.
     // Yes, it makes no sense.
-    public function addIncompleteTest (PHPUnit_Framework_Test $test, Exception $e, $time) {}
-    public function addSkippedTest (PHPUnit_Framework_Test $test, Exception $e, $time) {}
-    public function addRiskyTest (PHPUnit_Framework_Test $test, Exception $e, $time) {}
-    public function startTest (PHPUnit_Framework_Test $test) {}
-    public function endTest (PHPUnit_Framework_Test $test, $time) {}
-    public function startTestSuite (PHPUnit_Framework_TestSuite $suite) {}
+    public function addIncompleteTest (PHPUnit\Framework\Test $test, Exception $e, $time) {}
+    public function addSkippedTest (PHPUnit\Framework\Test $test, Exception $e, $time) {}
+    public function addRiskyTest (PHPUnit\Framework\Test $test, Exception $e, $time) {}
+    public function startTest (PHPUnit\Framework\Test $test) {}
+    public function endTest (PHPUnit\Framework\Test $test, $time) {}
+    public function startTestSuite (PHPUnit\Framework\TestSuite $suite) {}
 }

--- a/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
+++ b/tests/selenium_tests/LOVDSeleniumBaseTestCase.php
@@ -44,7 +44,7 @@ use \Facebook\WebDriver\WebDriverKeys;
 
 
 
-abstract class LOVDSeleniumWebdriverBaseTestCase extends PHPUnit_Framework_TestCase
+abstract class LOVDSeleniumWebdriverBaseTestCase extends PHPUnit\Framework\TestCase
 {
     // Base class for all Selenium tests.
 
@@ -379,7 +379,7 @@ abstract class LOVDSeleniumWebdriverBaseTestCase extends PHPUnit_Framework_TestC
 
 
 
-    protected function setUp ()
+    protected function setUp (): void
     {
         // This method is called before every test invocation.
         $this->driver = getWebDriverInstance();

--- a/tests/selenium_tests/admin_tests/multi_value_search.php
+++ b/tests/selenium_tests/admin_tests/multi_value_search.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class MultiValueSearchTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/genes/NOC2L');

--- a/tests/selenium_tests/admin_tests/verify_full_download.php
+++ b/tests/selenium_tests/admin_tests/verify_full_download.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class VerifyFullDownloadTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/setup');

--- a/tests/selenium_tests/manager_tests/create_user_manager_not_authorized.php
+++ b/tests/selenium_tests/manager_tests/create_user_manager_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateUserManagerNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/manager_tests/delete_announcement.php
+++ b/tests/selenium_tests/manager_tests/delete_announcement.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class DeleteAnnouncementTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/announcements');

--- a/tests/selenium_tests/manager_tests/import_data_file.php
+++ b/tests/selenium_tests/manager_tests/import_data_file.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class ImportDataFileTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/genes/IVD');

--- a/tests/selenium_tests/manager_tests/import_data_file_failed.php
+++ b/tests/selenium_tests/manager_tests/import_data_file_failed.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class ImportDataFileFailedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/genes/IVD');

--- a/tests/selenium_tests/manager_tests/import_data_for_update.php
+++ b/tests/selenium_tests/manager_tests/import_data_for_update.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class ImportDataForUpdateTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/genes/IVD');

--- a/tests/selenium_tests/manager_tests/import_data_for_update_failed.php
+++ b/tests/selenium_tests/manager_tests/import_data_for_update_failed.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class ImportDataForUpdateFailedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/genes/IVD');

--- a/tests/selenium_tests/shared_tests/access_submission_from_colleague.php
+++ b/tests/selenium_tests/shared_tests/access_submission_from_colleague.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class AccessSubmissionFromColleagueTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/individuals');

--- a/tests/selenium_tests/shared_tests/assign_collaborator_to_IVD.php
+++ b/tests/selenium_tests/shared_tests/assign_collaborator_to_IVD.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class AssignCollaboratorToIVDTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/assign_colleague_to_owner.php
+++ b/tests/selenium_tests/shared_tests/assign_colleague_to_owner.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class AssignColleagueToOwnerTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/assign_curator_to_IVD.php
+++ b/tests/selenium_tests/shared_tests/assign_curator_to_IVD.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class AssignCuratorToIVDTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/assign_curator_to_IVD_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/assign_curator_to_IVD_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class AssignCuratorToIVDNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/genes/IVD');

--- a/tests/selenium_tests/shared_tests/check_custom_links.php
+++ b/tests/selenium_tests/shared_tests/check_custom_links.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverKeys;
 
 class CheckCustomLinks extends LOVDSeleniumWebdriverBaseTestCase
 {
-    public function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/variants');

--- a/tests/selenium_tests/shared_tests/convert_LOVD2_export_IVD.php
+++ b/tests/selenium_tests/shared_tests/convert_LOVD2_export_IVD.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class ConvertLOVD2ExportIVDTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/genes/IVD');

--- a/tests/selenium_tests/shared_tests/create_custom_column_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/create_custom_column_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateCustomColumnNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/columns?create');

--- a/tests/selenium_tests/shared_tests/create_custom_column_phenotype.php
+++ b/tests/selenium_tests/shared_tests/create_custom_column_phenotype.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverExpectedCondition;
 
 class CreateCustomColumnPhenotypeTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_disease_IVA.php
+++ b/tests/selenium_tests/shared_tests/create_disease_IVA.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateDiseaseIVATest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_disease_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/create_disease_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateDiseaseNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/diseases?create');

--- a/tests/selenium_tests/shared_tests/create_gene_IVD.php
+++ b/tests/selenium_tests/shared_tests/create_gene_IVD.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateGeneIVDTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_gene_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/create_gene_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateGeneNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/genes?create');

--- a/tests/selenium_tests/shared_tests/create_summary_data_upload_seattleseq_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/create_summary_data_upload_seattleseq_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateSummaryDataUploadSeattleseqNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_summary_data_upload_vcf_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/create_summary_data_upload_vcf_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateSummaryDataUploadVCFNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_summary_variant_located_within_gene_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/create_summary_variant_located_within_gene_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateSummaryVariantLocatedWithinGeneNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_summary_variant_on_genomic_level_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/create_summary_variant_on_genomic_level_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateSummaryVariantOnGenomicLevelNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_user_collaborator.php
+++ b/tests/selenium_tests/shared_tests/create_user_collaborator.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateUserCollaboratorTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_user_curator.php
+++ b/tests/selenium_tests/shared_tests/create_user_curator.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateUserCuratorTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_user_manager.php
+++ b/tests/selenium_tests/shared_tests/create_user_manager.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateUserManagerTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_user_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/create_user_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateUserNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_user_owner.php
+++ b/tests/selenium_tests/shared_tests/create_user_owner.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateUserOwnerTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/create_user_submitter.php
+++ b/tests/selenium_tests/shared_tests/create_user_submitter.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class CreateUserSubmitterTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/delete_disease_IVA.php
+++ b/tests/selenium_tests/shared_tests/delete_disease_IVA.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class DeleteDiseaseIVATest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/diseases/IVA');

--- a/tests/selenium_tests/shared_tests/delete_disease_IVA_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/delete_disease_IVA_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class DeleteDiseaseIVANotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/diseases/IVA');

--- a/tests/selenium_tests/shared_tests/delete_gene_IVD.php
+++ b/tests/selenium_tests/shared_tests/delete_gene_IVD.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class DeleteGeneIVDTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/delete_gene_IVD_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/delete_gene_IVD_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class DeleteGeneIVDNotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/genes/IVD');

--- a/tests/selenium_tests/shared_tests/enable_custom_column_for_IVA.php
+++ b/tests/selenium_tests/shared_tests/enable_custom_column_for_IVA.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverExpectedCondition;
 
 class EnableCustomColumnForIVATest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/enable_custom_column_for_IVA_not_authorized.php
+++ b/tests/selenium_tests/shared_tests/enable_custom_column_for_IVA_not_authorized.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class EnableCustomColumnForIVANotAuthorizedTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         parent::setUp();
         $this->driver->get(ROOT_URL . '/src/columns/Phenotype/Age/Diagnosis');

--- a/tests/selenium_tests/shared_tests/enable_custom_column_for_individuals.php
+++ b/tests/selenium_tests/shared_tests/enable_custom_column_for_individuals.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverExpectedCondition;
 
 class EnableCustomColumnForIndividualsTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/login_as_collaborator.php
+++ b/tests/selenium_tests/shared_tests/login_as_collaborator.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class LoginAsCollaboratorTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/login_as_curator.php
+++ b/tests/selenium_tests/shared_tests/login_as_curator.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class LoginAsCuratorTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/login_as_manager.php
+++ b/tests/selenium_tests/shared_tests/login_as_manager.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class LoginAsManagerTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/login_as_owner.php
+++ b/tests/selenium_tests/shared_tests/login_as_owner.php
@@ -34,7 +34,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class LoginAsOwnerTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/login_as_submitter.php
+++ b/tests/selenium_tests/shared_tests/login_as_submitter.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverExpectedCondition;
 
 class LoginAsSubmitterTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/selenium_tests/shared_tests/uninstall_LOVD.php
+++ b/tests/selenium_tests/shared_tests/uninstall_LOVD.php
@@ -35,7 +35,7 @@ use \Facebook\WebDriver\WebDriverBy;
 
 class UninstallLOVDTest extends LOVDSeleniumWebdriverBaseTestCase
 {
-    protected function setUp ()
+    protected function setUp (): void
     {
         // Test if we have what we need for this test. If not, skip this test.
         parent::setUp();

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -92,6 +92,9 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('c.123—5del', 'c.123-5del'),
             array('c,123del', 'c.123del'),
             array('c.A123C', 'c.123A>C'),
+            array('c.a123u', 'c.123A>T'),
+            array('c.a123uu', 'c.123delinsTT'),
+            array('c.ua123uu', 'c.124A>T'),
             array('c.216G A', 'c.216G>A'), // " " seen in AIPL1_20702822_Jacobson-2011.pdf ("c.216G A")
             array('c.1106G®A', 'c.1106G>A'), // "®" seen in CACNA1F_9662399_Strom-1998.pdf ("1106G®A")
             array('c.220T?C', 'c.220T>C'), // "?" seen in CACNA1F_12111638_Wutz-2002.pdf ("220T?C")

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2023-02-03
- * For LOVD    : 3.0-29
+ * Modified    : 2024-05-01
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Loes Werkman <L.Werkman@LUMC.nl>
  *
@@ -207,6 +207,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g.(100_200)del(50_50)', 'g.(100_200)delN[50]'),
             array('g.(100_200)del(60_50)', 'g.(100_200)delN[(50_60)]'),
             array('g.1_5delins20_10', 'g.1_5delins10_20'),
+            array('g.1AC[20]GT', 'g.1AC[20]GT[1]'),
 
             // Question marks.
             // Note, that some of these variants do *not* need fixing and

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -116,6 +116,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
 
             // U given instead of T.
             array('g.123insAUG', 'g.123insATG'),
+            array('c.123A>U', 'c.123A>T'),
 
             // Variant types should be something else.
             array('g.100_200con400_500', 'g.100_200delins400_500'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -36,7 +36,7 @@
 require_once 'src/inc-lib-init.php'; // For the dependency on lovd_getVariantInfo().
 require_once 'src/inc-lib-variants.php'; // For lovd_fixHGVS().
 
-class FixHGVSTest extends PHPUnit_Framework_TestCase
+class FixHGVSTest extends PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -140,6 +140,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g.123A>.', 'g.123del'),
             array('g.123AA>.', 'g.123_124del'),
             array('g.123delAinsG', 'g.123A>G'),
+            array('g.123delAAinsGA', 'g.123A>G'),
             array('g.123delainst', 'g.123A>T'),
             array('g.123delainsu', 'g.123A>T'),
 
@@ -181,6 +182,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g.123_124del(2)', 'g.123_124del'),
             array('g.123_124delN[2]', 'g.123_124del'),
             array('g.123delAinsGG', 'g.123delinsGG'),
+            array('g.123delAAinsGG', 'g.123_124delinsGG'),
 
             // Wrongly formatted suffixes.
             array('c.1_2ins[A]', 'c.1_2insA'),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1854,6 +1854,44 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                     'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
                 ),
             )),
+            array('g.(1_100)delA[?_50]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "A[?_50]" to "A[(?_50)]".',
+                ),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
+            array('g.(1_100)dela[30_?]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters after "del".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "a[30_?]" to "A[(30_?)]".',
+                ),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
+            array('g.(1_100)delA[?]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
             array('g.(100_200)_(400_500)delEX5', array(
                 'position_start' => 200,
                 'position_end' => 400,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1752,9 +1752,29 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'ins',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.',
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Do you mean to indicate inserted positions (e.g., "ins5_10") or an inserted fragment with an unknown sequence but a given length (e.g., "insN[(5_10)]")?',
                 ),
                 'errors' => array(),
+            )),
+            array('g.1_2ins(0_5)', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(
+                    'ESUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. This variant description contains an invalid position or length: "0". Do you mean to indicate inserted positions (e.g., "ins100_200") or an inserted fragment with an unknown sequence but a given length (e.g., "insN[(100_200)]")?',
+                ),
+            )),
+            array('g.1_2ins(5_0)', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(
+                    'ESUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. This variant description contains an invalid position or length: "0". Do you mean to indicate inserted positions (e.g., "ins100_200") or an inserted fragment with an unknown sequence but a given length (e.g., "insN[100]")?',
+                ),
             )),
             array('g.1_2insN[5]', array(
                 'position_start' => 1,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -449,6 +449,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.1_2insU[5_10]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
+            )),
             array('g.1_2insN[(5_10)]', array(
                 'position_start' => 1,
                 'position_end' => 2,
@@ -456,6 +466,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'range' => true,
                 'warnings' => array(),
                 'errors' => array(),
+            )),
+            array('g.1_2insU[(5_10)]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
             )),
             array('g.1_2insN[(10_5)]', array(
                 'position_start' => 1,
@@ -801,6 +821,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                     'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
                 ),
                 'errors' => array(),
+            )),
+            array('g.1_2AN[20]UZ[10]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'repeat',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U", "Z".',
+                ),
             )),
 
             // Mosaicism and chimerism.

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -976,6 +976,7 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'range' => false,
                 'warnings' => array(
                     'WREPEATLENGTHFORMAT' => 'The repeat length format does not follow HGVS guidelines. Please rewrite "AC[21_20]" to "AC[(20_21)]".',
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
                 ),
                 'errors' => array(),
             )),
@@ -986,6 +987,7 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'range' => false,
                 'warnings' => array(
                     'WREPEATLENGTHFORMAT' => 'The repeat length format does not follow HGVS guidelines. Please rewrite "GT[10_10]" to "GT[10]".',
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
                 ),
                 'errors' => array(),
             )),
@@ -1014,7 +1016,9 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end' => 1,
                 'type' => 'repeat',
                 'range' => false,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
+                ),
                 'errors' => array(
                     'EREPEATLENGTHFORMAT' => 'The repeat length format does not follow HGVS guidelines.',
                 ),
@@ -1034,7 +1038,9 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end' => 2,
                 'type' => 'repeat',
                 'range' => true,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
+                ),
                 'errors' => array(
                     'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U", "Z".',
                 ),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -772,6 +772,68 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.123delAinsAG', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'delins',
+                'range' => false,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "g.123delAinsAG" to "g.123_124insG".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.123delAAinsGA', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'delins',
+                'range' => false,
+                'warnings' => array(
+                    'WSUFFIXINVALIDLENGTH' => 'The positions indicate a range shorter than the given length of the variant. Please adjust the positions if the variant length is certain, or remove the variant length.',
+                ),
+                'errors' => array(),
+            )),
+            array('g.123delAAinsGG', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'delins',
+                'range' => false,
+                'warnings' => array(
+                    'WSUFFIXINVALIDLENGTH' => 'The positions indicate a range shorter than the given length of the variant. Please adjust the positions if the variant length is certain, or remove the variant length.',
+                ),
+                'errors' => array(),
+            )),
+            array('g.123_124delAAinsAA', array(
+                'position_start' => 123,
+                'position_end' => 124,
+                'type' => 'delins',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "g.123_124delAAinsAA" to "g.123_124=".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.123_124delaainsGA', array(
+                'position_start' => 123,
+                'position_end' => 124,
+                'type' => 'delins',
+                'range' => true,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters after "del".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "g.123_124delaainsGA" to "g.123A>G".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.123_124delAAinsggaa', array(
+                'position_start' => 123,
+                'position_end' => 124,
+                'type' => 'delins',
+                'range' => true,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters after "del".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "g.123_124delAAinsggaa" to "g.122_123insGG".',
+                ),
+                'errors' => array(),
+            )),
             array('g.100_200con400_500', array(
                 'position_start' => 100,
                 'position_end' => 200,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -959,6 +959,17 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.1AC[20]GT', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'repeat',
+                'range' => false,
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
+                    'WSUFFIXFORMAT' => 'The part after "AC[20]" does not follow HGVS guidelines. Please rewrite "AC[20]GT" to "AC[20]GT[1]".',
+                ),
+                'errors' => array(),
+            )),
             array('g.1AC[20]GT[10]', array(
                 'position_start' => 1,
                 'position_end' => 1,
@@ -2415,8 +2426,8 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'type' => 'repeat',
                 'range' => false,
                 'warnings' => array(
-                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
-                    'WSUFFIXGIVEN' => 'Nothing should follow "ACT[20]".',
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
+                    'WSUFFIXFORMAT' => 'The part after "ACT[20]" does not follow HGVS guidelines. Please rewrite "ACT[20]A" to "ACT[20]A[1]".',
                 ),
                 'errors' => array(),
             )),
@@ -2426,8 +2437,8 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'type' => 'repeat',
                 'range' => true,
                 'warnings' => array(
-                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
-                    'WSUFFIXGIVEN' => 'Nothing should follow "ACT[20]".',
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
+                    'WSUFFIXFORMAT' => 'The part after "ACT[20]" does not follow HGVS guidelines. Please rewrite "ACT[20]A" to "ACT[20]A[1]".',
                 ),
                 'errors' => array(),
                 'messages' => array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -478,7 +478,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'ins',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.',
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Do you mean to indicate inserted positions (e.g., "ins50_60") or an inserted fragment with an unknown sequence but a given length (e.g., "insN[50]")?',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2668,7 +2668,9 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                     'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters after "del".',
                     'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "delgagagauu" to "delGAGAGATT".',
                 ),
-                'errors' => array(),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
             )),
             array('g.123_130deln[8]', array(
                 'position_start' => 123,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1068,7 +1068,19 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                     'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
                 ),
                 'errors' => array(
-                    'EINVALIDREPEATLENGTH' => 'The given repeat unit AC does not fit in the given positions 1_9. Adjust your positions or the given sequences.',
+                    'EINVALIDREPEATLENGTH' => 'The given repeat unit (AC) does not fit in the given positions 1_9. Adjust your positions or the given sequences.',
+                ),
+            )),
+            array('g.1_9AC[20]GT[10]', array(
+                'position_start' => 1,
+                'position_end' => 9,
+                'type' => 'repeat',
+                'range' => true,
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
+                ),
+                'errors' => array(
+                    'EINVALIDREPEATLENGTH' => 'The given repeat units (AC, GT) do not fit in the given positions 1_9. Adjust your positions or the given sequences.',
                 ),
             )),
             array('g.1_40AC[20]GT[10]', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -851,7 +851,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'range' => false,
                 'warnings' => array(
                     'WWRONGTYPE' => 'A conversion should be described as a deletion-insertion. Please rewrite "con" to "delins".',
-                    'WSUFFIXFORMAT' => 'The part after "con" does not follow HGVS guidelines.',
+                    'WSUFFIXFORMAT' => 'The part after "con" does not follow HGVS guidelines. Failed to recognize a valid sequence or position in "NC_000001.10:100_200".',
                 ),
                 'errors' => array(),
             )),
@@ -1850,7 +1850,17 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'ins',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.',
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Failed to recognize a valid sequence or position in "NC123456.1:g.1_10".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.1_2insNC_123456.1:g.1_10', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Use square brackets for complex insertions.',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -500,6 +500,16 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'warnings' => array(),
                 'errors' => array(),
             )),
+            array('c.1_2ins50+10_*10-20inv', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
+            )),
             array('g.1_2ins[NC_123456.1:g.1_10]', array(
                 'position_start' => 1,
                 'position_end' => 2,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1852,6 +1852,19 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                     'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
                 ),
             )),
+            array('g.(1_100)dela[50]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "dela[50]" to "delA[50]".',
+                ),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
             array('g.(1_100)del50', array(
                 'position_start' => 1,
                 'position_end' => 100,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -822,6 +822,66 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.1AC[21_20]GT[10]', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'repeat',
+                'range' => false,
+                'warnings' => array(
+                    'WREPEATLENGTHFORMAT' => 'The repeat length format does not follow HGVS guidelines. Please rewrite "AC[21_20]" to "AC[(20_21)]".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.1AC[(20_21)]GT[10_10]', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'repeat',
+                'range' => false,
+                'warnings' => array(
+                    'WREPEATLENGTHFORMAT' => 'The repeat length format does not follow HGVS guidelines. Please rewrite "GT[10_10]" to "GT[10]".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.1AC[(20_21)]GT[(10_11)]', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'repeat',
+                'range' => false,
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                ),
+                'errors' => array(),
+            )),
+            array('g.1AC[(?_21)]GT[(10_?)]A[?]', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'repeat',
+                'range' => false,
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                ),
+                'errors' => array(),
+            )),
+            array('g.1AC[(??)]', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'repeat',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EREPEATLENGTHFORMAT' => 'The repeat length format does not follow HGVS guidelines.',
+                ),
+            )),
+            array('g.1_2AC[20]GT[10]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'repeat',
+                'range' => true,
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                ),
+                'errors' => array(),
+            )),
             array('g.1_2AN[20]UZ[10]', array(
                 'position_start' => 1,
                 'position_end' => 2,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2105,6 +2105,34 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                     'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
                 ),
             )),
+            array('g.(1_100)del(0_50)', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(
+                    // FIXME: We can't see the difference. The reason is that $nSuffixMinLength's default value is 0.
+                    //  So we think we couldn't parse the suffix.
+                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. When indicating an uncertain position like this, the length or sequence of the variant must be provided.',
+                ),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
+            array('g.(1_100)del(50_0)', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(50_0)" to "N[50]".',
+                ),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
             array('g.(1_100)del(30_50)', array(
                 'position_start' => 1,
                 'position_end' => 100,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -850,6 +850,28 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.123N=', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => '=',
+                'range' => false,
+                'warnings' => array(
+                    'WBASESGIVEN' => 'When using "=", please remove the original sequence before the "=".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.123U=', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => '=',
+                'range' => false,
+                'warnings' => array(
+                    'WBASESGIVEN' => 'When using "=", please remove the original sequence before the "=".',
+                ),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
+            )),
 
             // Unknown variants.
             array('c.?', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1059,6 +1059,18 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                     'EINVALIDREPEATLENGTH' => 'The sequence ANUZ does not fit in the given positions 1_2. Adjust your positions or the given sequences.',
                 ),
             )),
+            array('g.1_9AC[20]', array(
+                'position_start' => 1,
+                'position_end' => 9,
+                'type' => 'repeat',
+                'range' => true,
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
+                ),
+                'errors' => array(
+                    'EINVALIDREPEATLENGTH' => 'The given repeat unit AC does not fit in the given positions 1_9. Adjust your positions or the given sequences.',
+                ),
+            )),
             array('g.1_40AC[20]GT[10]', array(
                 'position_start' => 1,
                 'position_end' => 40,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1104,6 +1104,17 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.1_40AC[20]GT[10]A', array(
+                'position_start' => 1,
+                'position_end' => 40,
+                'type' => 'repeat',
+                'range' => true,
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
+                    'WSUFFIXFORMAT' => 'The part after "AC[20]GT[10]" does not follow HGVS guidelines. Please rewrite "AC[20]GT[10]A" to "AC[20]GT[10]A[1]".',
+                ),
+                'errors' => array(),
+            )),
 
             // Mosaicism and chimerism.
             array('g.123=/A>G', array(
@@ -2437,10 +2448,25 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'type' => 'repeat',
                 'range' => true,
                 'warnings' => array(
-                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
                     'WSUFFIXFORMAT' => 'The part after "ACT[20]" does not follow HGVS guidelines. Please rewrite "ACT[20]A" to "ACT[20]A[1]".',
                 ),
-                'errors' => array(),
+                'errors' => array(
+                    'EWRONGTYPE' =>
+                        'The repeat syntax can not be used for uncertain positions. Rewrite your variant description as a deletion or insertion, depending on whether the repeat contracted or expanded.',
+                ),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
+            array('g.(1_100)ACT[20]A[10]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'repeat',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(
+                    'EWRONGTYPE' => 'The repeat syntax can not be used for uncertain positions. Rewrite your variant description as a deletion or insertion, depending on whether the repeat contracted or expanded.',
+                ),
                 'messages' => array(
                     'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
                 ),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2022-10-26
- * For LOVD    : 3.0-29
+ * Modified    : 2023-08-30
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Loes Werkman <L.Werkman@LUMC.nl>
@@ -1589,7 +1589,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "50" to "N[50]".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "50" to "N[50]".',
                 ),
                 'errors' => array(),
                 'messages' => array(
@@ -1602,7 +1602,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30)" to "N[30]".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(30)" to "N[30]".',
                 ),
                 'errors' => array(),
                 'messages' => array(
@@ -1626,7 +1626,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(100)" to "N[100]".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(100)" to "N[100]".',
                     'WSUFFIXINVALIDLENGTH' =>
                         'The positions indicate a range equally long as the given length of the variant. Please remove the variant length and parentheses if the positions are certain, or adjust the positions or variant length.',
                 ),
@@ -1641,7 +1641,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30_30)" to "N[30]".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(30_30)" to "N[30]".',
                 ),
                 'errors' => array(),
                 'messages' => array(
@@ -1654,7 +1654,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30_50)" to "N[(30_50)]".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(30_50)" to "N[(30_50)]".',
                 ),
                 'errors' => array(),
                 'messages' => array(
@@ -1678,7 +1678,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(50_30)" to "N[(30_50)]".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(50_30)" to "N[(30_50)]".',
                 ),
                 'errors' => array(),
                 'messages' => array(
@@ -1691,7 +1691,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "N[30_50]" to "N[(30_50)]".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "N[30_50]" to "N[(30_50)]".',
                 ),
                 'errors' => array(),
                 'messages' => array(
@@ -1718,7 +1718,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "300" to "N[300]".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "300" to "N[300]".',
                 ),
                 'errors' => array(),
                 'messages' => array(
@@ -1731,7 +1731,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(300)" to "N[300]".',
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(300)" to "N[300]".',
                 ),
                 'errors' => array(),
                 'messages' => array(
@@ -1744,7 +1744,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'inv',
                 'range' => false,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30)" to "N[30]".',
+                    'WSUFFIXFORMAT' => 'The part after "inv" does not follow HGVS guidelines. Please rewrite "(30)" to "N[30]".',
                     'WSUFFIXINVALIDLENGTH' =>
                         'The positions indicate a range shorter than the given length of the variant.' .
                         ' Please adjust the positions if the variant length is certain, or remove the variant length.',
@@ -1759,7 +1759,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'inv',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30)" to "N[30]".',
+                    'WSUFFIXFORMAT' => 'The part after "inv" does not follow HGVS guidelines. Please rewrite "(30)" to "N[30]".',
                     'WSUFFIXINVALIDLENGTH' =>
                         'The positions indicate a range longer than the given length of the variant.' .
                         ' Please adjust the positions if the variant length is certain, or remove the variant length.',
@@ -1772,7 +1772,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'inv',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30)" to "N[30]".',
+                    'WSUFFIXFORMAT' => 'The part after "inv" does not follow HGVS guidelines. Please rewrite "(30)" to "N[30]".',
                 ),
                 'errors' => array(),
                 'messages' => array(
@@ -1785,7 +1785,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'inv',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The length of the variant is not formatted following the HGVS guidelines. Please rewrite "(30)" to "N[30]".',
+                    'WSUFFIXFORMAT' => 'The part after "inv" does not follow HGVS guidelines. Please rewrite "(30)" to "N[30]".',
                     'WSUFFIXINVALIDLENGTH' => 'The positions indicate a range smaller than the given length of the variant. Please adjust the positions or variant length.',
                 ),
                 'errors' => array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -749,6 +749,19 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.123deluinsG', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'delins',
+                'range' => false,
+                'warnings' => array(
+                    'WWRONGTYPE' => 'A deletion-insertion of one base to one base should be described as a substitution. Please rewrite "deluinsG" to "U>G".',
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters after "del".',
+                ),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
+            )),
             array('g.123delAinsGG', array(
                 'position_start' => 123,
                 'position_end' => 123,
@@ -2784,6 +2797,18 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.123DELAINST', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'delins',
+                'range' => false,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "DEL" to "del".',
+                    'WWRONGTYPE' =>
+                        'A deletion-insertion of one base to one base should be described as a substitution. Please rewrite "DELAINST" to "A>T".',
+                ),
+                'errors' => array(),
+            )),
             array('g.123delainsu', array(
                 'position_start' => 123,
                 'position_end' => 123,
@@ -2792,9 +2817,11 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'warnings' => array(
                     'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters after "del".',
                     'WWRONGTYPE' =>
-                        'A deletion-insertion of one base to one base should be described as a substitution. Please rewrite "delainsu" to "A>T".',
+                        'A deletion-insertion of one base to one base should be described as a substitution. Please rewrite "delainsu" to "A>U".',
                 ),
-                'errors' => array(),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
             )),
             array('g. 123_124insA', array(
                 'position_start' => 123,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2023-09-01
+ * Modified    : 2023-09-06
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1617,7 +1617,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'ins',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.',
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Only use square brackets for complex insertions.',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -513,7 +513,9 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'position_end' => 2,
                 'type' => 'ins',
                 'range' => true,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Please rewrite "U[5_10]" to "U[(5_10)]".',
+                ),
                 'errors' => array(
                     'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
                 ),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1715,6 +1715,17 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                     'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
                 ),
             )),
+            array('g.(1_100)delA[50]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
             array('g.(1_100)del50', array(
                 'position_start' => 1,
                 'position_end' => 100,
@@ -1824,6 +1835,19 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'range' => true,
                 'warnings' => array(
                     'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "N[30_50]" to "N[(30_50)]".',
+                ),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
+            array('g.(1_100)delA[30_50]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "A[30_50]" to "A[(30_50)]".',
                 ),
                 'errors' => array(),
                 'messages' => array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2023-09-08
+ * Modified    : 2023-09-11
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1706,6 +1706,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
             )),
 
             // Challenging insertions.
+            array('g.1_2ins10', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(
+                    'ESUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Do you mean to indicate inserted positions (e.g., "ins10_20") or an inserted fragment with an unknown sequence but a given length (e.g., "insN[10]")?',
+                ),
+            )),
             array('g.1_2ins(5_10)', array(
                 'position_start' => 1,
                 'position_end' => 2,
@@ -1835,16 +1845,6 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'errors' => array(),
             )),
             array('g.1_2insNC123456.1:g.1_10', array(
-                'position_start' => 1,
-                'position_end' => 2,
-                'type' => 'ins',
-                'range' => true,
-                'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.',
-                ),
-                'errors' => array(),
-            )),
-            array('g.1_2ins340', array(
                 'position_start' => 1,
                 'position_end' => 2,
                 'type' => 'ins',

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2023-08-30
+ * Modified    : 2023-09-01
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2549,7 +2549,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'dup',
                 'range' => false,
                 'warnings' => array(
-                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters.',
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "G." to "g.".',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1943,6 +1943,16 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.1_2ins(A)', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Please rewrite "(A)" to "A".',
+                ),
+                'errors' => array(),
+            )),
             array('g.1_2ins[NC_123456.1:g.1_10;A;123_125;TGCG]', array(
                 'position_start' => 1,
                 'position_end' => 2,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1724,12 +1724,52 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'warnings' => array(),
                 'errors' => array(),
             )),
+            array('g.1_2insN[5_10]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Please rewrite "N[5_10]" to "N[(5_10)]".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.1_2insN[?_10]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Please rewrite "N[?_10]" to "N[(?_10)]".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.1_2insN[5_?]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Please rewrite "N[5_?]" to "N[(5_?)]".',
+                ),
+                'errors' => array(),
+            )),
             array('g.1_2insN[?]', array(
                 'position_start' => 1,
                 'position_end' => 2,
                 'type' => 'ins',
                 'range' => true,
                 'warnings' => array(),
+                'errors' => array(),
+            )),
+            array('g.1_2insN[(5_5)]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Please rewrite "N[(5_5)]" to "N[5]".',
+                ),
                 'errors' => array(),
             )),
             array('g.1_2insN[(5_10)]', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3080,8 +3080,7 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'type' => 'delins',
                 'range' => false,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => // Adding a WWRONGCASE here is difficult; the code handling insertions is too complex and we'd need to then fix lovd_fixHGVS() again also.
-                        'The part after "delins" does not follow HGVS guidelines.', // Idem for the suggestion how to fix it. It's too complex right now and lovd_fixHGVS() easily handles it anyway.
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "delinsgagagauu" to "delinsGAGAGAUU".',
                 ),
                 'errors' => array(
                     'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2718,6 +2718,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'range' => true,
                 'warnings' => array(
                     'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "delgagagatt" to "delGAGAGATT".',
+                    'WSUFFIXGIVEN' => 'Nothing should follow "del".',
                 ),
                 'errors' => array(),
             )),
@@ -2727,8 +2728,8 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(
-                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters after "del".',
-                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "delgagagauu" to "delGAGAGATT".',
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "delgagagauu" to "delGAGAGAUU".',
+                    'WSUFFIXGIVEN' => 'Nothing should follow "del".',
                 ),
                 'errors' => array(
                     'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
@@ -2741,6 +2742,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'range' => true,
                 'warnings' => array(
                     'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "deln[8]" to "delN[8]".',
+                    'WSUFFIXGIVEN' => 'Nothing should follow "del".',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -309,6 +309,26 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.123N>U', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
+            )),
+            array('g.123U>Z', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U", "Z".',
+                ),
+            )),
 
             // Duplications.
             array('g.123dup', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -418,6 +418,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'warnings' => array(),
                 'errors' => array(),
             )),
+            array('g.1_2insa', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "insa" to "insA".',
+                ),
+                'errors' => array(),
+            )),
             array('g.1_2insN', array(
                 'position_start' => 1,
                 'position_end' => 2,
@@ -435,6 +445,24 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'errors' => array(
                     'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
                 ),
+            )),
+            array('g.1_2insa[10]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "insa[10]" to "insA[10]".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.1_2insA[10]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
             )),
             array('g.1_2insN[10]', array(
                 'position_start' => 1,
@@ -1629,12 +1657,14 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'warnings' => array(),
                 'errors' => array(),
             )),
-            array('g.1_2ins[NC_123456.1:g.1_10;U]', array(
+            array('g.1_2ins[NC_123456.1:g.1_10;a;U]', array(
                 'position_start' => 1,
                 'position_end' => 2,
                 'type' => 'ins',
                 'range' => true,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case.',
+                ),
                 'errors' => array(
                     'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
                 ),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2023-09-06
+ * Modified    : 2023-09-08
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1641,6 +1641,46 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.1_2insN[5]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
+            )),
+            array('g.1_2insN[?]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
+            )),
+            array('g.1_2insN[(5_10)]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
+            )),
+            array('g.1_2insN[(?_10)]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
+            )),
+            array('g.1_2insN[(5_?)]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
+            )),
             array('g.1_2ins[A]', array(
                 'position_start' => 1,
                 'position_end' => 2,
@@ -1940,6 +1980,17 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                     'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
                 ),
             )),
+            array('g.(1_100)delA[(30_50)]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
             array('g.(1_100)delA[?_50]', array(
                 'position_start' => 1,
                 'position_end' => 100,
@@ -1948,6 +1999,17 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'warnings' => array(
                     'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "A[?_50]" to "A[(?_50)]".',
                 ),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
+            array('g.(1_100)delA[(?_50)]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(),
                 'errors' => array(),
                 'messages' => array(
                     'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -490,6 +490,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'warnings' => array(),
                 'errors' => array(),
             )),
+            array('c.1_2ins50+10_*10-20', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(),
+            )),
             array('g.1_2ins[NC_123456.1:g.1_10]', array(
                 'position_start' => 1,
                 'position_end' => 2,
@@ -869,7 +879,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'delins',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The part after "delins" does not follow HGVS guidelines.',
+                    'WSUFFIXFORMAT' => 'The part after "delins" does not follow HGVS guidelines. The positions are not given in the correct order. Please verify your description and try again.',
                 ),
                 'errors' => array(),
             )),
@@ -1715,6 +1725,26 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'errors' => array(
                     'ESUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Do you mean to indicate inserted positions (e.g., "ins10_20") or an inserted fragment with an unknown sequence but a given length (e.g., "insN[10]")?',
                 ),
+            )),
+            array('g.1_2ins0_10', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(
+                    'ESUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. This variant description contains an invalid position: "0". Please verify your description and try again.',
+                ),
+            )),
+            array('g.1_2ins10_5', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. The positions are not given in the correct order. Please verify your description and try again.',
+                ),
+                'errors' => array(),
             )),
             array('g.1_2ins(5_10)', array(
                 'position_start' => 1,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -426,6 +426,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'warnings' => array(),
                 'errors' => array(),
             )),
+            array('g.1_2insU', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
+            )),
             array('g.1_2insN[10]', array(
                 'position_start' => 1,
                 'position_end' => 2,
@@ -1619,6 +1629,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'warnings' => array(),
                 'errors' => array(),
             )),
+            array('g.1_2ins[NC_123456.1:g.1_10;U]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
+            )),
             array('g.1_2ins[1_2;A]', array(
                 'position_start' => 1,
                 'position_end' => 2,
@@ -2637,7 +2657,9 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                     'WSUFFIXFORMAT' => // Adding a WWRONGCASE here is difficult; the code handling insertions is too complex and we'd need to then fix lovd_fixHGVS() again also.
                         'The part after "delins" does not follow HGVS guidelines.', // Idem for the suggestion how to fix it. It's too complex right now and lovd_fixHGVS() easily handles it anyway.
                 ),
-                'errors' => array(),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
             )),
             array('g.123delainst', array(
                 'position_start' => 123,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1001,6 +1001,17 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.1ac[(20_21)]gt[(10_11)]', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'repeat',
+                'range' => false,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "ac[(20_21)]gt[(10_11)]" to "AC[(20_21)]GT[(10_11)]".',
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
+                ),
+                'errors' => array(),
+            )),
             array('g.1AC[(?_21)]GT[(10_?)]A[?]', array(
                 'position_start' => 1,
                 'position_end' => 1,
@@ -1029,9 +1040,11 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'type' => 'repeat',
                 'range' => true,
                 'warnings' => array(
-                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
                 ),
-                'errors' => array(),
+                'errors' => array(
+                    'EINVALIDREPEATLENGTH' => 'The sequence ACGT does not fit in the given positions 1_2. Adjust your positions or the given sequences.',
+                ),
             )),
             array('g.1_2AN[20]UZ[10]', array(
                 'position_start' => 1,
@@ -1043,7 +1056,18 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(
                     'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U", "Z".',
+                    'EINVALIDREPEATLENGTH' => 'The sequence ANUZ does not fit in the given positions 1_2. Adjust your positions or the given sequences.',
                 ),
+            )),
+            array('g.1_40AC[20]GT[10]', array(
+                'position_start' => 1,
+                'position_end' => 40,
+                'type' => 'repeat',
+                'range' => true,
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                ),
+                'errors' => array(),
             )),
 
             // Mosaicism and chimerism.

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -187,6 +187,16 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'warnings' => array(),
                 'errors' => array(),
             )),
+            array('g.123a>c', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "a>c" to "A>C".',
+                ),
+                'errors' => array(),
+            )),
             array('g.123.>.', array(
                 'position_start' => 123,
                 'position_end' => 123,
@@ -373,6 +383,17 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'del',
                 'range' => false,
                 'warnings' => array(
+                    'WSUFFIXGIVEN' => 'Nothing should follow "del".',
+                ),
+                'errors' => array(),
+            )),
+            array('g.1DELA', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "DEL" to "del".',
                     'WSUFFIXGIVEN' => 'Nothing should follow "del".',
                 ),
                 'errors' => array(),
@@ -956,6 +977,19 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => '=',
                 'range' => false,
                 'warnings' => array(
+                    'WBASESGIVEN' => 'When using "=", please remove the original sequence before the "=".',
+                ),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "U".',
+                ),
+            )),
+            array('g.123u=', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => '=',
+                'range' => false,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "u=" to "U=".',
                     'WBASESGIVEN' => 'When using "=", please remove the original sequence before the "=".',
                 ),
                 'errors' => array(
@@ -2559,7 +2593,7 @@ class GetVariantInfoTest extends PHPUnit_Framework_TestCase
                 'type' => 'dup',
                 'range' => false,
                 'warnings' => array(
-                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please check the use of upper- and lowercase characters.',
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "DUP" to "dup".',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -32,7 +32,7 @@
 
 require_once 'src/inc-lib-init.php';
 
-class GetVariantInfoTest extends PHPUnit_Framework_TestCase
+class GetVariantInfoTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider dataProviderGetVariantInfo

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2023-09-11
+ * Modified    : 2024-05-01
  * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Loes Werkman <L.Werkman@LUMC.nl>
@@ -943,10 +943,11 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'type' => 'repeat',
                 'range' => false,
                 'warnings' => array(
-                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
-                    'WINVALIDREPEATLENGTH' => 'A repeat sequence of coding DNA should always have a length of (a multiple of) 3.',
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
                 ),
-                'errors' => array(),
+                'errors' => array(
+                    'EINVALIDREPEATLENGTH' => 'A repeat sequence of coding DNA should always have a length of (a multiple of) 3.',
+                ),
             )),
             array('g.1AC[20]', array(
                 'position_start' => 1,


### PR DESCRIPTION
### Improve the HGVS functions.
This is a lot of work put into one single branch, with commits from August 2023 to May 2024.
- Fix bug; Variant `c.100delATinsTT` was considered HGVS-compliant. Although warnings were thrown, a quick HGVS check returned true.
- Improve `lovd_fixHGVS()`, elegantly handle `delAinsAA` variants. Basically, any `delXinsX` variant is now first checked for matches between the REF and ALT bases, so that substitutions, insertions, duplications, or even inversions can be detected. Previously, the user was simply requested to drop the REF bases.
- Clarified some warnings mentioning the "length of the variant". That wasn't always clear, especially not when a sequence was given.
- Substitutions using invalid bases weren't recognized at all. Relaxed the regex to recognize the descriptions as variants, but then complain about the nucleotides being false.
- Wildtype variants weren't recognized when incorrect bases were used.
- Implement nucleotide validation for repeat syntax.
- Greatly improve support for the repeat syntax.
- Deletions of ranges can also be indicated with non-N nucleotides. Syntax like `delA[50]` wasn't supported, `N` was expected.
- Greatly improve support for deletions of ranges of nucleotides.
- Add better check for case issues in the variant prefix.
- Improve handling case issues in the variant type.
- Add check for invalid nucleotides to simple insertions.
- Warn if insertions are using square brackets when not needed.
- Add proper case checks for insertions.
- Add proper nucleotide checks for all insertion suffixes.
- Sync del and ins suffix checking code, simplify the latter.
- Remove the last U-specific check and replace it.
- While matching any text for a del suffix, don't match `ins`.
- Add a few tests of correct variant descriptions. This should help checking for false negatives.
- Continue checking the deletion suffix, even with a `WWRONGCASE`.
- Improve support for deletion suffixes containing question marks. The added test is not related to this specific change, but came about after comparing insertion and deletion tests.
- Improve handling case issues and invalid nucleotides in `delXinsX`.
- Rewrite all `delXinsY` variants to `X>Y` and check with `lovd_fixHGVS()`. Although we should move the code in `lovd_fixHGVS()` to a different function, for now, we'll rely on the existence of `lovd_fixHGVS()`. That function handles the substitution format quite well, and can suggest insertions, duplications, and even inversions. This way, we can provide very nice suggestions on how to rewrite `delXinsY` variants.
- Add insertion tests based on related del tests.
- Update `lovd_getVariantInfo()`; `ins10` now throws an `ESUFFIXFORMAT`. It's not fixable, so it's not a warning. We don't know if a position or length is meant, so we'll make no assumptions.
- Improve warning given for `ins(10)` type of variants. We still assume this is a length, but nonetheless we ask the user what they meant. `lovd_fixHGVS()` will still autocorrect this to a description using a length, e.g., `insN[10]`.
- Improve warnings for problems with inserted sequences with refseqs.
- Add a more advanced handling of position insertion validation.
- Rewrite part handling `ins(5_10)`, based on the `del(5_10)` code.
- Sync tests, add del tests related to new ins tests.
- Also an `ESUFFIXFORMAT` means it's not HGVS.
- Clean up processing of repeat syntax suffixes a bit.
- `WINVALIDREPEATLENGTH` should be `EINVALIDREPEATLENGTH`. Also, `WNOTSUPPORTED` should be edited when the variant description isn't correct.
- Add a `WNOTSUPPORTED` to repeat variants that have errors.
- Add a rudimentary check on the repeat length. Also, add more tests.
- Fix the incomplete check for cDNA repeat unit lengths.
- Improve checking of repeat unit lengths. Single-unit repeat descriptions are now validated against the given positions.
- Complete the validation of repeat unit lengths. We now handle any kind of combination of repeat unit lengths. They are compared to the given positions, and any combination of these repeats should precisely match the given positions.
- Handle repeat suffixes in case it's a sequence. They most likely then forgot the `[1]`.
- Repeat syntax is actually not allowed with uncertain positions. These should be deletions or insertions. Also, don't throw a `WNOTSUPPORTED` in this case.
- Handle `g.1_2ins(A)` format.
- Fix broken support for inversions in insertions.
- Conclude the code handling complex insertions. We (currently) have nothing else to support.
- Add a fixed test.
- Add a generic fixer in `fixHGVS()`, using `getVariantInfo()` output.
- Add tests for `lovd_fixHGVS()`.
- Add a generic fix for DNA variants with U bases.
- Improve fix for protein-style substitutions, like `c.A123C`. Lowercase bases and non-standard bases are now also recognized.

Also:
- Update PHPUnit; the older version just doesn't run anymore. This breaks all remote tests on Travis, but that doesn't work anymore anyway, and needs to be updated. We'll handle that problem later; this update at least allows us to run some tests locally.