### PR TITLE
Fix multiple issues

### DIFF
--- a/src/__function_list.txt
+++ b/src/__function_list.txt
@@ -57,7 +57,6 @@
 4.0.0 floor
 4.0.0 flush
 4.0.0 fopen
-4.0.0 foreach
 4.0.0 fputs
 4.0.0 fsockopen
 4.0.0 function_exists
@@ -67,7 +66,6 @@
 4.0.0 gethostbyaddr
 4.0.0 getimagesize
 4.0.0 get_magic_quotes_gpc
-4.0.0 get_object_vars
 4.0.0 gettimeofday
 4.0.0 gmdate
 4.0.0 header
@@ -75,7 +73,6 @@
 4.0.0 htmlspecialchars
 5.1.0 htmlspecialchars_decode
 5.0.0 http_build_query
-4.0.0 if
 4.0.0 ignore_user_abort
 4.0.0 implode
 4.0.0 in_array
@@ -93,7 +90,6 @@
 4.0.0 isset
 4.0.0 is_string
 4.0.0 is_writable
-4.0.0 join
 5.2.0 json_decode
 5.2.0 json_encode
 4.0.0 ksort
@@ -131,7 +127,6 @@
 4.0.0 register_shutdown_function
 4.0.0 rename
 4.0.0 reset
-4.0.0 return
 4.0.0 round
 4.0.0 rtrim
 4.0.0 serialize
@@ -179,7 +174,6 @@
 4.0.0 usleep
 4.0.0 utf8_encode
 4.0.0 var_dump
-4.0.0 while
 4.0.2 wordwrap
 
 5.0.0 file() with FILE_IGNORE_NEW_LINES.
@@ -194,10 +188,10 @@
 5.3.3 PDO::inTransaction() (already in use, but we check for it)
 5.4.0 JSON_PRETTY_PRINT is available (now I'm using it if available)
 5.4.0 Short array notation is available; array() => [].
-5.4.0 Array dereferencing; $sWord = explode(' ', $sSentence)[5]; now solved using list() or current().
+5.4.0 Array dereferencing; $sWord = explode(' ', $sSentence)[5]; now solved using list() or current(). (I've started to use this)
 5.5.0 foreach (... as list(...)) <- Using this already.
 5.6.0 Argument unpacking; array_merge(...$a) == array_merge($a[0], $a[1], $a[2]); now solved using call_user_func_array().
-7.0.0 Null coalescing operator available, e.g., ($a['missing_key'] ?? 'default_value'); <- Already in use in ajax/licenses.php and scripts/fix_position_fields.php.
+7.0.0 Null coalescing operator available, e.g., ($a['missing_key'] ?? 'default_value'); (Already in use in many places)
 7.1.0 Negative string array access, e.g., $s[-1] instead of substr($s, -1).
 7.3.0 setcookie() accepts an array for options, allowing us to set 'SameSite=Lax'. Otherwise, we'd need to directly send a header. That's complicated, so I'm not even trying now.
 7.4.0 Return value declaration for functions.
@@ -221,6 +215,7 @@ MySQL:
 4.1.00  BOOLEAN column type
 4.1. 1  VALUES() in: INSERT INTO ... ON DUPLICATE KEY UPDATE ... VALUES()
 4.1. 2  ENGINE (instead of TYPE) not really necessary but since we're at 4.1.1 already...
+5.0. 2  CREATE TRIGGER. I want to use this, but can't use this, because the LOVD user in general doesn't have the SUPER privilege and binary logging is on by default (which causes the SUPER requirement).
 8.0.00  REGEXP_REPLACE() - should make F&R so much easier to implement...
 =======-========
 4.1. 2  REQUIRED

--- a/src/ajax/licenses.php
+++ b/src/ajax/licenses.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-02-25
- * Modified    : 2023-02-02
- * For LOVD    : 3.0-29
+ * Modified    : 2024-05-20
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -184,7 +184,7 @@ function lovd_showLicense ()
 
 $aFields = array(
     'commercial' => array(
-        'Do you want to allow others to use your public data for commercial purposes?<BR><I>Selecting \'no\' prohibit uses primarily intended for or directed toward commercial advantage or monetary compensation.</I>',
+        'Do you want to allow others to use your public data for commercial purposes?<BR><I>Selecting \'no\' prohibits uses primarily intended for, or directed toward, commercial advantage or monetary compensation.</I>',
         'yes' => '<B>Yes.</B> Others can use my public data, even for commercial purposes.',
         'no' => '<B>No.</B> Others can not use my public data for commercial purposes.',
     ),

--- a/src/ajax/map_variants.php
+++ b/src/ajax/map_variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-01-15
- * Modified    : 2024-05-07
+ * Modified    : 2024-05-17
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -296,13 +296,14 @@ if (!empty($_GET['variantid'])) {
                              'FROM ' . TABLE_VARIANTS . ' AS vog, (' .
                                  'SELECT chromosome, position_g_start ' .
                                  'FROM ' . TABLE_VARIANTS . ' ' .
-                                 'WHERE mapping_flags & ' . MAPPING_ALLOW . ' AND NOT mapping_flags & ' . (MAPPING_NOT_RECOGNIZED | MAPPING_DONE | MAPPING_IN_PROGRESS) . ' AND position_g_start IS NOT NULL AND position_g_start != 0 ' .
+                                 'WHERE mapping_flags & ' . MAPPING_ALLOW . ' AND NOT mapping_flags & ' . (MAPPING_NOT_RECOGNIZED | MAPPING_DONE | MAPPING_IN_PROGRESS) .
+                                 '  AND position_g_start IS NOT NULL AND position_g_start NOT IN (0, 1) AND position_g_end != 4294967295 ' .
                                  (empty($aArgs)? '' : 'AND chromosome = ? AND position_g_start >= ? ') .
                                  ($_SESSION['mapping']['todo'] > 10000? '' : 'ORDER BY RAND() ') .
                                  'LIMIT 1' .
                              ') AS first ' .
-                             'WHERE vog.chromosome = first.chromosome AND vog.position_g_start BETWEEN first.position_g_start AND first.position_g_start + ' . $nRange . ' ' .
-                                 'AND vog.mapping_flags & ' . MAPPING_ALLOW . ' AND NOT vog.mapping_flags & ' . (MAPPING_NOT_RECOGNIZED | MAPPING_DONE | MAPPING_IN_PROGRESS) . ' ' .
+                             'WHERE vog.chromosome = first.chromosome AND vog.position_g_start BETWEEN first.position_g_start AND first.position_g_start + ' . $nRange .
+                             '  AND vog.position_g_end != 4294967295 AND vog.mapping_flags & ' . MAPPING_ALLOW . ' AND NOT vog.mapping_flags & ' . (MAPPING_NOT_RECOGNIZED | MAPPING_DONE | MAPPING_IN_PROGRESS) . ' ' .
                              'ORDER BY vog.position_g_start ' .
                              'LIMIT ' . $nMaxVariants,
                              $aArgs)->fetchAllAssoc();

--- a/src/ajax/map_variants.php
+++ b/src/ajax/map_variants.php
@@ -177,7 +177,7 @@ if (!isset($_SESSION['mapping']['total_todo'])) {
     $_SESSION['mapping']['total_todo'] = 0;
 }
 // 0.5 sec for 1M variants. Add index to mapping_flags and/or position_g_start to speed up?
-$_SESSION['mapping']['todo'] = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' WHERE mapping_flags & ' . MAPPING_ALLOW . ' AND NOT mapping_flags & ' . (MAPPING_NOT_RECOGNIZED | MAPPING_DONE) . ' AND position_g_start IS NOT NULL AND position_g_start != 0')->fetchColumn();
+$_SESSION['mapping']['todo'] = $_DB->q('SELECT COUNT(*) FROM ' . TABLE_VARIANTS . ' WHERE mapping_flags & ' . MAPPING_ALLOW . ' AND NOT mapping_flags & ' . (MAPPING_NOT_RECOGNIZED | MAPPING_DONE) . ' AND position_g_start IS NOT NULL AND position_g_start NOT IN (0, 1) AND position_g_end != 4294967295')->fetchColumn();
 if ($_SESSION['mapping']['todo'] > $_SESSION['mapping']['total_todo']) {
     // We didn't have a total set yet, or more variants were added in the process that now need to be mapped as well.
     $_SESSION['mapping']['total_todo'] = $_SESSION['mapping']['todo'];

--- a/src/api.php
+++ b/src/api.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-11-08
- * Modified    : 2024-04-02
+ * Modified    : 2024-05-17
  * For LOVD    : 3.0-30
  *
  * Supported URIs:
@@ -198,7 +198,7 @@ if ($sDataType == 'variants') {
                   LEFT OUTER JOIN ' . TABLE_SCR2VAR . ' AS s2v ON (vog.id = s2v.variantid)
                   LEFT OUTER JOIN ' . TABLE_SCREENINGS . ' AS s ON (s2v.screeningid = s.id)
                   LEFT OUTER JOIN ' . TABLE_INDIVIDUALS . ' AS i ON (s.individualid = i.id)') . '
-                WHERE t.geneid = ? AND vog.statusid >= ? AND vog.position_g_start != 0 AND vog.position_g_start IS NOT NULL' .
+                WHERE t.geneid = ? AND vog.statusid >= ? AND vog.position_g_start IS NOT NULL AND vog.position_g_start NOT IN (0,1) AND vog.position_g_end != 4294967295' .
                    (!$bQueryPMID? '' : ' AND (`' . implode('` LIKE "%:' . $nPMID . '}%" OR `', $aPMIDCols) . '` LIKE "%:' . $nPMID . '}%") ') . '
                 GROUP BY vog.`VariantOnGenome/DNA` ORDER BY vog.position_g_start, vog.position_g_end', array($sSymbol, STATUS_MARKED))->fetchAllAssoc();
             $n = count($aData);

--- a/src/class/api.ga4gh.php
+++ b/src/class/api.ga4gh.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2021-04-22
- * Modified    : 2024-05-07
+ * Modified    : 2024-05-20
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1403,7 +1403,7 @@ class LOVD_API_GA4GH
                             (SELECT
                                GROUP_CONCAT(
                                  CONCAT(
-                                   t.geneid, "##", t.id_ncbi, "##", REPLACE(vot.`VariantOnTranscript/DNA`, "||", "|"), "##", vot.`VariantOnTranscript/RNA`, "##", t.id_protein_ncbi, "##", vot.`VariantOnTranscript/Protein`)
+                                   t.geneid, "##", t.id_ncbi, "##", REPLACE(vot.`VariantOnTranscript/DNA`, "||", "|"), "##", IFNULL(vot.`VariantOnTranscript/RNA`, "r.(?)"), "##", t.id_protein_ncbi, "##", IFNULL(vot.`VariantOnTranscript/Protein`, "p.?"))
                                  SEPARATOR "$$")
                              FROM ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot
                                INNER JOIN ' . TABLE_TRANSCRIPTS . ' AS t ON (vot.transcriptid = t.id)

--- a/src/class/graphs.php
+++ b/src/class/graphs.php
@@ -633,8 +633,6 @@ class LOVD_Graphs
                 $sType = ';';
             } elseif (strpos($sProteinDescription, '=') !== false) {
                 $sType = 'silent';
-            } elseif (!$sProteinDescription || $sProteinDescription == '-' || strpos($sProteinDescription, '?') !== false) {
-                $sType = '';
             } elseif (strpos($sProteinDescription, 'fs') !== false) {
                 $sType = 'frameshift';
             } elseif (preg_match('/[\*X]/', $sProteinDescription)) {
@@ -662,6 +660,7 @@ class LOVD_Graphs
             } elseif (preg_match('/dup/', $sProteinDescription)) {
                 $sType = 'inframedup';
             } else {
+                // This includes empty protein changes (non-coding transcripts), '-', and 'p.?'.
                 $sType = '';
             }
 

--- a/src/class/graphs.php
+++ b/src/class/graphs.php
@@ -471,11 +471,15 @@ class LOVD_Graphs
         $aTypes =
             array(
                 ''       => array('Unknown', '#000'),
+                ';'      => array('Compound', '#600'),
+                '='      => array('No change', '#0AC'),
                 'del'    => array('Deletions', '#A00'),
                 'delins' => array('Deletion-Insertions', '#95F'),
                 'dup'    => array('Duplications', '#F90'),
                 'ins'    => array('Insertions', '#090'),
-                'inv'    => array('Inversions', '#0AC'),
+                'inv'    => array('Inversions', '#969'),
+                'met'    => array('Methylation', '#FD6'),
+                'repeat' => array('Repeat', '#69F'),
                 'subst'  => array('Substitutions', '#00C'),
             );
 
@@ -507,6 +511,12 @@ class LOVD_Graphs
             }
         } else {
             // Using list of variant IDs.
+        }
+
+        // Map '?' to ''.
+        if (isset($aData['?'])) {
+            $aData[''] += $aData['?'];
+            unset($aData['?']);
         }
 
         // Format $aData.

--- a/src/class/graphs.php
+++ b/src/class/graphs.php
@@ -339,10 +339,10 @@ class LOVD_Graphs
         $aTypes =
             array(
                 '5UTR'     => array('5\'UTR', '#F90'),        // Orange.
-                'start'    => array('Start codon', '#600'),   // Dark dark red.
+                'start'    => array('Start codon', '#600'),   // Dark, dark red.
                 'coding'   => array('Coding', '#00C'),        // Blue.
                 'splice'   => array('Splice region', '#A00'), // Dark red.
-                'intron'   => array('Intron', '#0AC'),        // Light blue.
+                'intron'   => array('Intron', '#0AC'),        // Teal.
                 '3UTR'     => array('3\'UTR', '#090'),        // Green.
                 'multiple' => array('Multiple', '#95F'),      // Purple.
                 ''         => array('Unknown', '#000'),       // Black.
@@ -470,17 +470,17 @@ class LOVD_Graphs
         // Keys need to be renamed.
         $aTypes =
             array(
-                ''       => array('Unknown', '#000'),
-                ';'      => array('Compound', '#600'),
-                '='      => array('No change', '#0AC'),
-                'del'    => array('Deletions', '#A00'),
-                'delins' => array('Deletion-Insertions', '#95F'),
-                'dup'    => array('Duplications', '#F90'),
-                'ins'    => array('Insertions', '#090'),
-                'inv'    => array('Inversions', '#969'),
-                'met'    => array('Methylation', '#FD6'),
-                'repeat' => array('Repeat', '#69F'),
-                'subst'  => array('Substitutions', '#00C'),
+                ''       => array('Unknown', '#000'),             // Black.
+                ';'      => array('Compound', '#600'),            // Dark, dark red.
+                '='      => array('No change', '#0AC'),           // Teal.
+                'del'    => array('Deletions', '#A00'),           // Dark red.
+                'delins' => array('Deletion-Insertions', '#95F'), // Purple.
+                'dup'    => array('Duplications', '#F90'),        // Orange.
+                'ins'    => array('Insertions', '#090'),          // Green.
+                'inv'    => array('Inversions', '#969'),          // Darker purple.
+                'met'    => array('Methylation', '#FD6'),         // Light yellow.
+                'repeat' => array('Repeat', '#69F'),              // Light blue.
+                'subst'  => array('Substitutions', '#00C'),       // Blue.
             );
 
         if (!is_array($Data)) {
@@ -590,17 +590,17 @@ class LOVD_Graphs
         // Keys need to be renamed.
         $aTypes =
             array(
-                'frameshift'    => array('Frameshifts', '#FD6'),
-                'inframedel'    => array('In frame deletions', '#A00'),
-                'inframedelins' => array('In frame indels', '#95F'),
-                'inframedup'    => array('In frame duplications', '#F90'),
-                'inframeins'    => array('In frame insertions', '#090'),
-                'missense'      => array('Missense changes', '#00C'),
-                'no_protein'    => array('No protein produced', '#69F'),
-                'silent'        => array('Silent changes', '#0AC'),
-                'stop'          => array('Stop changes', '#969'),
-                ';'             => array('Compound', '#600'),
-                ''              => array('Unknown', '#000'),
+                'frameshift'    => array('Frameshifts', '#FD6'),                  // Light yellow.
+                'inframedel'    => array('In frame deletions', '#A00'),           // Dark red.
+                'inframedelins' => array('In frame deletion-insertions', '#95F'), // Purple.
+                'inframedup'    => array('In frame duplications', '#F90'),        // Orange.
+                'inframeins'    => array('In frame insertions', '#090'),          // Green.
+                'missense'      => array('Missense changes', '#00C'),             // Blue.
+                'no_protein'    => array('No protein produced', '#69F'),          // Light blue.
+                'silent'        => array('Silent changes', '#0AC'),               // Teal.
+                'stop'          => array('Stop changes', '#969'),                 // Darker purple.
+                ';'             => array('Compound', '#600'),                     // Dark, dark red.
+                ''              => array('Unknown', '#000'),                      // Black.
             );
 
         if (!is_array($Data)) {

--- a/src/class/graphs.php
+++ b/src/class/graphs.php
@@ -596,9 +596,10 @@ class LOVD_Graphs
                 'inframedup'    => array('In frame duplications', '#F90'),
                 'inframeins'    => array('In frame insertions', '#090'),
                 'missense'      => array('Missense changes', '#00C'),
-                'no_protein'    => array('No protein produced', '#600'),
+                'no_protein'    => array('No protein produced', '#69F'),
                 'silent'        => array('Silent changes', '#0AC'),
                 'stop'          => array('Stop changes', '#969'),
+                ';'             => array('Compound', '#600'),
                 ''              => array('Unknown', '#000'),
             );
 
@@ -628,7 +629,9 @@ class LOVD_Graphs
             // However, make sure that the 'fs' check is always done before the missense and the stop-check, to prevent false positives.
             // Also, del, dup and ins checks must be done before missense checks.
             // The missense check is done a bit later, after more simper comparisons.
-            if (strpos($sProteinDescription, '=') !== false) {
+            if (strpos($sProteinDescription, ';') !== false || strpos($sProteinDescription, ',') !== false) {
+                $sType = ';';
+            } elseif (strpos($sProteinDescription, '=') !== false) {
                 $sType = 'silent';
             } elseif (!$sProteinDescription || $sProteinDescription == '-' || strpos($sProteinDescription, '?') !== false) {
                 $sType = '';

--- a/src/class/graphs.php
+++ b/src/class/graphs.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-11
- * Modified    : 2023-02-01
- * For LOVD    : 3.0-29
+ * Modified    : 2024-05-20
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               David Baux <david.baux@inserm.fr>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -472,7 +472,7 @@ class LOVD_Graphs
             array(
                 ''       => array('Unknown', '#000'),
                 'del'    => array('Deletions', '#A00'),
-                'delins' => array('Indels', '#95F'),
+                'delins' => array('Deletion-Insertions', '#95F'),
                 'dup'    => array('Duplications', '#F90'),
                 'ins'    => array('Insertions', '#090'),
                 'inv'    => array('Inversions', '#0AC'),
@@ -906,7 +906,7 @@ if ($_CURRDB->colExists('Variant/RNA')) {
             $aCounts['complex'] += $nCount;
             $_SESSION['variant_statistics'][$_SESSION['currdb']]['RNA_complex'][] = $nVariantid;
         } elseif (preg_match($sDelIns, $sRNA)) {
-            // variant is an indel
+            // variant is a deletion-insertion
             $aCounts['delins'] += $nCount;
             $_SESSION['variant_statistics'][$_SESSION['currdb']]['RNA_delins'][] = $nVariantid;
         } elseif (preg_match($sInv, $sRNA)) {

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -738,7 +738,7 @@ class LOVD_Gene extends LOVD_Object
                         lovd_getExternalSource($sSource,
                             ($sType == 'id' || $sSource == 'genetests'? $zData[$sColID] :
                                 rawurlencode($zData['id'])), true) . '" target="_blank">' .
-                        ($sType == 'id'? $zData[$sColID] : rawurlencode($zData['id'])) . '</A>';
+                        ($sType == 'id'? ($sSource == 'hgnc'? 'HGNC:' : '') . $zData[$sColID] : $zData['id']) . '</A>';
                 } else {
                     $zData[$sColID . '_'] = '';
                 }

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2024-04-16
+ * Modified    : 2024-05-21
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -195,6 +195,9 @@ class LOVD_Gene extends LOVD_Object
                 'id_' => array(
                     'view' => array('Symbol', 100),
                     'db'   => array('g.id', 'ASC', true)),
+                'id_hgnc_' => array(
+                    'view' => array('HGNC ID', 85),
+                    'db' => array('CONCAT("HGNC:", g.id_hgnc)', 'ASC', true)), // 'CONCAT("HGNC:", g.id_hgnc)' allows for searching for HGNC:..., but kills the sorting, numeric searching, etc.
                 'name' => array(
                     'view' => array('Gene', 300),
                     'db'   => array('g.name', 'ASC', true)),
@@ -513,6 +516,7 @@ class LOVD_Gene extends LOVD_Object
         $zData = parent::prepareData($zData, $sView);
 
         if ($sView == 'list') {
+            $zData['id_hgnc_'] = (!$zData['id_hgnc']? '' : 'HGNC:' . $zData['id_hgnc']);
             $zData['updated_date_'] = substr($zData['updated_date'], 0, 10);
         } else {
             $zData['imprinting_'] = $_SETT['gene_imprinting'][$zData['imprinting']];

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2024-05-07
+ * Modified    : 2024-05-20
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1036,7 +1036,7 @@ function lovd_getCurrentPageTitle ()
             list($sVOG, $sVOT) =
                 $_DB->q('
                     SELECT CONCAT(c.`' . $_CONF['refseq_build'] . '_id_ncbi`, ":", vog.`VariantOnGenome/DNA`) AS VOG_DNA,
-                        CONCAT(t.geneid, "(", t.id_ncbi, "):", vot.`VariantOnTranscript/DNA`) AS VOT_DNA
+                        CONCAT(t.id_ncbi, ":", vot.`VariantOnTranscript/DNA`, " (", t.geneid, ")") AS VOT_DNA
                     FROM ' . TABLE_VARIANTS . ' AS vog
                       INNER JOIN ' . TABLE_CHROMOSOMES . ' AS c ON (vog.chromosome = c.name)
                       LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vog.id = vot.id)

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1036,7 +1036,9 @@ function lovd_getCurrentPageTitle ()
             list($sVOG, $sVOT) =
                 $_DB->q('
                     SELECT CONCAT(c.`' . $_CONF['refseq_build'] . '_id_ncbi`, ":", vog.`VariantOnGenome/DNA`) AS VOG_DNA,
-                        CONCAT(t.id_ncbi, ":", vot.`VariantOnTranscript/DNA`, " (", t.geneid, ")") AS VOT_DNA
+                      IF((vot.position_c_start_intron IS NOT NULL AND vot.position_c_start_intron != 0) OR (vot.position_c_end_intron IS NOT NULL AND vot.position_c_end_intron != 0),
+                        CONCAT(c.`' . $_CONF['refseq_build'] . '_id_ncbi`, "(", t.id_ncbi, "):", vot.`VariantOnTranscript/DNA`, " (", t.geneid, ")"),
+                        CONCAT(t.id_ncbi, ":", vot.`VariantOnTranscript/DNA`, " (", t.geneid, ")")) AS VOT_DNA
                     FROM ' . TABLE_VARIANTS . ' AS vog
                       INNER JOIN ' . TABLE_CHROMOSOMES . ' AS c ON (vog.chromosome = c.name)
                       LEFT OUTER JOIN ' . TABLE_VARIANTS_ON_TRANSCRIPTS . ' AS vot ON (vog.id = vot.id)

--- a/src/scripts/fetch_frequencies.php
+++ b/src/scripts/fetch_frequencies.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2013-08-11
- * Modified    : 2023-02-03
- * For LOVD    : 3.0-29
+ * Modified    : 2024-05-17
+ * For LOVD    : 3.0-30
  *
- * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -48,7 +48,8 @@ $nToFetch = $_DB->q('
     SELECT COUNT(*)
     FROM ' . TABLE_VARIANTS . '
     WHERE average_frequency IS NULL AND chromosome IS NOT NULL AND position_g_start IS NOT NULL
-      AND position_g_start != 0 AND position_g_end IS NOT NULL AND position_g_end != 0')->fetchColumn();
+      AND position_g_start NOT IN (0,1) AND position_g_end != 4294967295
+      ')->fetchColumn();
 if (!$nToFetch) {
     print('All done.');
     $_T->printFooter();
@@ -68,7 +69,7 @@ while ($nDone < $nToFetch && $sVariants) {
         SELECT chromosome, position_g_start, position_g_end, `VariantOnGenome/DNA` AS DNA
         FROM ' . TABLE_VARIANTS . '
         WHERE average_frequency IS NULL AND chromosome IS NOT NULL AND position_g_start IS NOT NULL
-          AND position_g_start != 0 AND position_g_end IS NOT NULL AND position_g_end != 0
+          AND position_g_start NOT IN (0,1) AND position_g_end != 4294967295
         LIMIT ' . $nLimit)->fetchAllAssoc();
     if ($aVariants === array()) {
         // No results.

--- a/src/variants.php
+++ b/src/variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-21
- * Modified    : 2024-05-07
+ * Modified    : 2024-05-20
  * For LOVD    : 3.0-30
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1747,7 +1747,7 @@ if (PATH_COUNT == 2 && $_PE[1] == 'upload' && ACTION == 'create') {
                         exit('</BODY></HTML>');
 
                     } elseif (preg_match('#^[ACGT]+(?:/[ACGT]+)?$#', $aVariant['sampleGenotype'])) {
-                        // All indels, from VCF (VCF-like columns only, though).
+                        // All deletion-insertions, from VCF (VCF-like columns only, though).
                         $aFieldsVariantOnGenome[0]['position_g_start'] = $aVariant['position'];
                         $aFieldsVariantOnGenome[0]['position_g_end'] = $aVariant['position'] + strlen($aVariant['referenceBase']) - 1;
 
@@ -2388,10 +2388,6 @@ if (PATH_COUNT == 2 && $_PE[1] == 'upload' && ACTION == 'create') {
                    array('', '', 'print', '<B>File selection</B>'),
                    'hr',
                    array('File type', '', 'print', ($_GET['type'] == 'VCF'? 'Variant Call Format (VCF) version >= 4.0' : 'SeattleSeq Annotation file')));
-    if ($_GET['type'] == 'SeattleSeq') {
-        array_push($aForm,
-                   array('', '', 'note', 'Files with \'SeattleSeq Annotation original allele columns\' created from indel-only VCF files are <B>not supported</B>.'));
-    }
     array_push($aForm,
                    array('Select the file to import', '', 'file', 'variant_file', 25),
                    array('', 'Current file size limits:<BR>LOVD: ' . ($nMaxSizeLOVD/(1024*1024)) . 'M<BR>PHP (upload_max_filesize): ' . ini_get('upload_max_filesize') . '<BR>PHP (post_max_size): ' . ini_get('post_max_size'), 'note', 'The maximum file size accepted is ' . round($nMaxSize/pow(1024, 2), 1) . ' MB' . ($nMaxSize == $nMaxSizeLOVD? '' : ', due to restrictions on this server. Move your mouse over the help icon on the left to see the server configuration. If you wish to have it increased, contact the server\'s system administrator') . '.'),


### PR DESCRIPTION
### Fix multiple issues.
- Fix issues with the mapper and variants with unknown positions. Variants with unknown positions get mapped to a large range internally. This causes issues with the variant mapper that is looking for overlapping transcripts with impossible positions.
- Also don't count these variants as variants that need mapping.
- Remove these variants also from the BED file export.
- Don't fetch frequencies for this type of variants.
- Handle NULL values for RNA and Protein fields in the GA4GH API.
- Remove all uses of "indel", it's a confusing term now. Nowadays, people often interpret it as a deletion or insertion, while we used it as "deletion-insertion". The HGVS nomenclature no longer uses the term for that reason.
- Add more DNA variant types to be recognized.
- Add the compound protein change type.
- Fix that `p.0?` wasn't recognized as "no_protein". The use of a question mark was no different from using parentheses to indicate uncertainty. So we can just label it the same as `p.0` gets labeled.
- Document colors used in the graphs.
- Fixed a typo.
- Variant titles used the GENE(NM):c format, which is not valid. Changed it to NM:c (GENE), which is valid. The (GENE) part is merely annotation, and NM:c is valid HGVS syntax.
- Fully fix the variant title for intronic variants. Intronic variants can't be described by just the NM, since the intronic sequence isn't included in the NM reference sequence. So, for intronic variants, use the NC(NM) reference sequence format.
- Also fix the API to use NC(NM) instead of NM for intronic variants.
- Add the HGNC ID column to the genes VL.
- Add the HGNC: prefix to the HGNC ID in the VE, as well.
- Update the function list. I haven't added functions, but cleaned the list a bit and updated some notes on features that I now use that are newer as well as features that I would like to start using.