### PR TITLE
Fix and optimize the gene-specific Screenings VL.

### DIFF
--- a/src/class/object_screenings.php
+++ b/src/class/object_screenings.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2024-05-07
- * For LOVD    : 3.0-30
+ * Modified    : 2024-06-05
+ * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -147,6 +147,9 @@ class LOVD_Screening extends LOVD_Custom
                       ),
                  $this->buildViewList(),
                  array(
+                        'genes_searched' => array(
+                            'view' => false, // This is just used to filter the table for the /screenings/GENE view.
+                            'db'   => array('s2g.geneid', false, true)),
                         'genes' => array(
                                     'view' => array('Genes screened', 20),
                                     'db'   => array('genes', 'ASC', 'TEXT')),

--- a/src/individuals.php
+++ b/src/individuals.php
@@ -51,7 +51,7 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
     if (!empty($_PE[1])) {
         $sGene = $_DB->q('SELECT id FROM ' . TABLE_GENES . ' WHERE id = ?', array($_PE[1]))->fetchColumn();
         if ($sGene) {
-            lovd_isAuthorized('gene', $sGene); // To show non public entries.
+            lovd_isAuthorized('gene', $sGene); // To show non-public entries.
             $_GET['search_genes_searched'] = '="' . $sGene . '"';
         } else {
             // Command or gene not understood.

--- a/src/screenings.php
+++ b/src/screenings.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-03-18
- * Modified    : 2022-12-14
- * For LOVD    : 3.0-29
+ * Modified    : 2024-06-05
+ * For LOVD    : 3.0-31
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -51,11 +51,9 @@ if ((PATH_COUNT == 1 || (!empty($_PE[1]) && !ctype_digit($_PE[1]))) && !ACTION) 
     if (!empty($_PE[1])) {
         $sGene = $_DB->q('SELECT id FROM ' . TABLE_GENES . ' WHERE id = ?', array($_PE[1]))->fetchColumn();
         if ($sGene) {
-            // We need the authorization call if we would show the screenings with VARIANTS in gene X, not before!
-//            lovd_isAuthorized('gene', $sGene); // To show non public entries.
-
-            // FIXME; This doesn't work; searching for gene X also finds XYZ.
-            $_GET['search_genes'] = $sGene;
+            // Will show screenings from public individuals that have been linked to the selected gene.
+            // It won't check for screenings finding variants in the selected gene.
+            $_GET['search_genes_searched'] = '="' . $sGene . '"';
         } else {
             // Command or gene not understood.
             // FIXME; perhaps a HTTP/1.0 501 Not Implemented? If so, provide proper output (gene not found) and


### PR DESCRIPTION
### Fix and optimize the gene-specific Screenings VL.
Already during development, a FIXME had been added to fix this, but this was overlooked. The gene-specific Screenings VL was not filtering well and was actually filtering very inefficiently. Today, LOVD's MySQL was overloaded by repeated requests for gene-specific Screenings VLs.

Fixed both issues by adding a virtual column that allows for efficient and effective filtering on the gene symbol instead of a `LIKE` on the compound gene list, which caused a hefty query time with a temp table and a file sort. This is the same solution that had already been applied to the gene-specific Individuals VL.