### PR TITLE
Fix a query error related to a REGEXP

### DIFF
--- a/src/inc-lib-form.php
+++ b/src/inc-lib-form.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-21
- * Modified    : 2024-05-07
- * For LOVD    : 3.0-30
+ * Modified    : 2024-07-12
+ * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -501,7 +501,7 @@ function lovd_fetchDBID ($aData)
                 // Cache the DBIDs we saw to speed this up when we repeatedly ask for the DBIDs on the same chromosome.
                 $sSymbol = 'chr' . $aData['chromosome'];
                 $sSQL = 'SELECT IFNULL(RIGHT(MAX(`VariantOnGenome/DBID`), 6), 0) + 1 FROM ' . TABLE_VARIANTS . ' AS vog WHERE vog.chromosome = ? AND `VariantOnGenome/DBID` LIKE ? AND `VariantOnGenome/DBID` REGEXP ?';
-                $aArgs = array($aData['chromosome'], $sSymbol . '\_%', '^' . $sSymbol . '_[0-9]{6}$');
+                $aArgs = array($aData['chromosome'], $sSymbol . '\_%', '^' . preg_quote($sSymbol) . '_[0-9]{6}$');
                 if (isset($aDBIDsSeen[$aData['chromosome']])) {
                     $sSQL .= ' AND `VariantOnGenome/DBID` >= ?';
                     $aArgs[] = $aDBIDsSeen[$aData['chromosome']];
@@ -525,7 +525,7 @@ function lovd_fetchDBID ($aData)
                     SELECT IFNULL(RIGHT(MAX(`VariantOnGenome/DBID`), 6), 0) + 1
                     FROM ' . TABLE_VARIANTS . '
                     WHERE chromosome = ? AND `VariantOnGenome/DBID` REGEXP ?',
-                        array($aData['chromosome'], '^' . $sSymbol . '_[0-9]{6}$'))->fetchColumn();
+                        array($aData['chromosome'], '^' . preg_quote($sSymbol) . '_[0-9]{6}$'))->fetchColumn();
             }
             $sDBID = $sSymbol . '_' . sprintf('%06d', $nDBIDnewNumber);
         }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2024-05-20
- * For LOVD    : 3.0-30
+ * Modified    : 2024-07-12
+ * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -911,7 +911,7 @@ function lovd_getCurrentPageTitle ()
             $sTitle .= ' entry';
         }
         // For a target?
-        if (isset($_GET['target'])) {
+        if (!empty($_GET['target'])) {
             // $_GET['target'] should be checked already when we get here,
             //  but we take no chances.
             $ID = htmlspecialchars($_GET['target']);

--- a/src/reset_password.php
+++ b/src/reset_password.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-05-20
- * Modified    : 2022-11-22
- * For LOVD    : 3.0-29
+ * Modified    : 2024-07-12
+ * For LOVD    : 3.0-31
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               M. Kroon <m.kroon@lumc.nl>
@@ -65,7 +65,7 @@ if (!$_AUTH && $_CONF['allow_unlock_accounts']) {
                 array($_POST['username']))->fetchAllAssoc();
             if (!$zData) {
                 $zData = $_DB->q('SELECT * FROM ' . TABLE_USERS . ' WHERE email REGEXP ?',
-                    array("(^|\r\n)" . $_POST['username'] . "(\r\n|$)"))->fetchAllAssoc();
+                    array("(^|\r\n)" . preg_quote($_POST['username']) . "(\r\n|$)"))->fetchAllAssoc();
             }
         }
         if (!$zData || $zData == array(false)) {


### PR DESCRIPTION
### Fix a query error related to a `REGEXP`
- Fix a query error in the password reset feature, triggered when sending regex characters. This is not an SQL injection error as it doesn't let the user run malicious SQL, but it does break our query.
- Make sure the other `REGEXP` clauses are protected, too. These aren't known to cause any issues, and I haven't been able to trigger anything, but it's better to quote the input regardless to train myself to always quote whatever goes into a MySQL `REGEXP`.

Also:
- Fix an issue with the page title when creating a summary variant entry.