### PR TITLE
Rename GeneTests to NIH GTR

### DIFF
--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -5,7 +5,7 @@
 % To convert the manual to an html file use: pdf2htmlEX --zoom 1.3 --embed-css 2 manual.pdf
 
 %%%%% SETTINGS FOR THE TITLE PAGE %%%%%
-\setLOVDversion{3.0-30}
+\setLOVDversion{3.0-31}
 \title{LOVD 3.0 user manual \\\vskip 0.2cm Build \LOVDversion}
 \author{Ivo F.A.C. Fokkema \\ Daan Asscheman}
 \setpointercolor{red}
@@ -1682,7 +1682,7 @@ When properly configured, LOVD will add links to the Ensembl, NCBI and UCSC geno
 
 \subsection{Links to information sources}
 Here you can add links to other resources that will be displayed on the gene's LOVD gene homepage,
- such as Entrez Gene, OMIM, HGMD or GeneTests, but you can also add links to any website you want.
+ such as Entrez Gene, OMIM, HGMD, or NIH GTR, but you can also add links to any website you want.
 \begin{description}
   \item[Homepage URL] \hfill \\
   If you have a separate homepage about this gene, you can specify the URL here.
@@ -1703,8 +1703,8 @@ Here you can add links to other resources that will be displayed on the gene's L
   If you wish to include a link from the gene homepage to the gene's page on the HGMD site, enable this checkbox.
   \item[Provide link to GeneCards] \hfill \\
   If you wish to include a link from the gene homepage to the gene's page on the GeneCards site, enable this checkbox.
-  \item[Provide link to GeneTests] \hfill \\
-  If you wish to include a link from the gene homepage to the gene's page on the GeneTests site, enable this checkbox.
+  \item[Provide link to NIH GTR] \hfill \\
+  If you wish to include a link from the gene homepage to the gene's page on the NIH Genetic Testing Registry (GTR) site, enable this checkbox.
   \item[This gene has a human-readable reference sequence] \hfill \\
   Although GenBank files are the official reference sequence, they are not very readable for humans.
   If you have a human-readable format of your reference sequence online, please select the type here; ``Coding DNA'' or ``Genomic''.
@@ -1815,7 +1815,7 @@ If you do not like this behavior, simply move your mouse over a tab, and select 
 %This overview allows you for instance to quickly check if a certain variant is already included in the database (even if it's not yet public) or the amount of entries associated with a certain reference.
 %
 %The "Links to other resources" table can contain any number of links to external sources, as configured by the gene's curator(s).
-%Examples of external sources that LOVD can link to easily are Entrez Gene, OMIM, UniProtKB, HGMD, GeneCards and GeneTests.
+%Examples of external sources that LOVD can link to easily are Entrez Gene, OMIM, UniProtKB, HGMD, GeneCards, and NIH GTR.
 
 
 

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2010-12-15
- * Modified    : 2024-05-21
- * For LOVD    : 3.0-30
+ * Modified    : 2024-08-01
+ * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -169,7 +169,7 @@ class LOVD_Gene extends LOVD_Object
                         'disease_omim_' => 'OMIM - Diseases',
                         'show_hgmd_' => 'HGMD',
                         'show_genecards_' => 'GeneCards',
-                        'show_genetests_' => 'GeneTests',
+                        'show_genetests_' => 'NIH Genetic Testing Registry',
                         'show_orphanet_' => 'Orphanet',
                       );
         if (!$_SETT['customization_settings']['genes_show_meta_data']) {
@@ -451,7 +451,7 @@ class LOVD_Gene extends LOVD_Object
                         array('OMIM Gene ID', '', 'print', ($zData['id_omim']?: 'Not Available')),
                         array('Provide link to HGMD', 'Do you want a link to this gene\'s entry in the Human Gene Mutation Database added to the homepage?', 'checkbox', 'show_hgmd'),
                         array('Provide link to GeneCards', 'Do you want a link to this gene\'s entry in the GeneCards database added to the homepage?', 'checkbox', 'show_genecards'),
-                        array('Provide link to GeneTests', 'Do you want a link to this gene\'s entry in the GeneTests database added to the homepage?', 'checkbox', 'show_genetests'),
+                        array('Provide link to NIH GTR', 'Do you want a link to this gene\'s entry in the NIH Genetic Testing Registry (GTR) database added to the homepage?', 'checkbox', 'show_genetests'),
                         array('Provide link to Orphanet', 'Do you want a link to this gene\'s entry in the Orphanet database added to the homepage?', 'checkbox', 'show_orphanet'),
                         array('This gene has a human-readable reference sequence', '', 'select', 'refseq', 1, $aSelectRefseq, 'No', false, false),
                         array('', '', 'note', 'Although GenBank files are the official reference sequence, they are not very readable for humans. If you have a human-readable format of your reference sequence online, please select the type here.'),
@@ -730,7 +730,7 @@ class LOVD_Gene extends LOVD_Object
             foreach ($aExternal as $sColID) {
                 list($sType, $sSource) = explode('_', $sColID, 2);
                 if (!empty($zData[$sColID])) {
-                    // For IDs and the GeneTests link, use the IDs for the URL, otherwise use the gene symbol;
+                    // For IDs and the GTR ("GeneTests", uses NCBI ID) link, use the IDs for the URL, otherwise use the gene symbol;
                     //  for IDs, use the IDs in the visible part of the link, otherwise use the gene symbol.
                     // FIXME: Note that id_pubmed_gene now uses the gene symbol in the visible part of the link (code below this block);
                     //  it would be good if we'd standardize that.

--- a/src/class/object_genes.php
+++ b/src/class/object_genes.php
@@ -731,20 +731,16 @@ class LOVD_Gene extends LOVD_Object
                 list($sType, $sSource) = explode('_', $sColID, 2);
                 if (!empty($zData[$sColID])) {
                     // For IDs and the GTR ("GeneTests", uses NCBI ID) link, use the IDs for the URL, otherwise use the gene symbol;
-                    //  for IDs, use the IDs in the visible part of the link, otherwise use the gene symbol.
-                    // FIXME: Note that id_pubmed_gene now uses the gene symbol in the visible part of the link (code below this block);
-                    //  it would be good if we'd standardize that.
+                    //  for IDs except the PubMed link, use the IDs in the visible part of the link, otherwise use the gene symbol.
                     $zData[$sColID . '_'] = '<A href="' .
                         lovd_getExternalSource($sSource,
                             ($sType == 'id' || $sSource == 'genetests'? $zData[$sColID] :
                                 rawurlencode($zData['id'])), true) . '" target="_blank">' .
-                        ($sType == 'id'? ($sSource == 'hgnc'? 'HGNC:' : '') . $zData[$sColID] : $zData['id']) . '</A>';
+                        ($sType == 'id' && $sSource != 'pubmed_gene'? ($sSource == 'hgnc'? 'HGNC:' : '') . $zData[$sColID] : $zData['id']) . '</A>';
                 } else {
                     $zData[$sColID . '_'] = '';
                 }
             }
-            // The link to PubMed articles showed the Entrez Gene ID, which might be misinterpreted as a number of articles. Replaced by Gene Symbol.
-            $zData['id_pubmed_gene_'] = str_replace($zData['id_entrez'] . '</A>', $zData['id'] . '</A>', $zData['id_pubmed_gene_']);
 
             // Disclaimer.
             $sYear = substr($zData['created_date'], 0, 4);


### PR DESCRIPTION
### Rename GeneTests to NIH GTR
This is an external rename of the resource; internally, the resource continues to be named "GeneTests". The reason for this is twofold: Firstly, renaming the internal fields is more work and requires a database migration, while LOVD users wouldn't know the difference. Secondly, this will change the format of the Gene data files, which may break other processes. As such, we're only updating the interface.

- Rename GeneTests to NIH Genetic Testing Registry (GTR) on the Gene homepage and the Gene data entry form. 
- Update relevant parts of the manual.

Also:
- Resolve an old FIXME while we're at it, located in the same code block we were already editing.

Closes #657.
