### PR TITLE
Fix various issues

### DIFF
--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -49,13 +49,13 @@ LOVD 3.0 extends this idea to also provide patient-centered data storage and sto
 
 LOVD was developed approaching the ``LSDB-in-a-Box'' idea for the easy creation and maintenance of a fully web-based gene sequence variant database,
 that is platform-in\-de\-pen\-dent and uses PHP and MySQL open source software only.
-The design of the database follows the recommendations of the \href{http://www.hgvs.org/}{Human Genome Variation Society} (HGVS)
+The design of the database follows the recommendations of the \href{https://www.hgvs.org/}{Human Genome Variation Society} (HGVS)
 and focuses on the collection and display of DNA sequence variants, but it has fully implemented methods for storing complete clinical data as well.
 The open LOVD setup also facilitates functional extensions with scripts written by the community.
 \vskip \baselineskip
 
 The development of (then nameless) LOVD started in late 2002, while it was first officially released in January, 2004.
-Before that LOVD was only in use by the \href{http://www.DMD.nl/}{Leiden Muscular Dystrophy pages},
+Before that LOVD was only in use by the \href{https://www.DMD.nl/}{Leiden Muscular Dystrophy pages},
 as a not-so-modular system with lots of characteristics specific for that website only.
 With the official release of LOVD in 2004 the system had become much more dynamic and customizing LOVD was made easy mostly by editing text-files.
 
@@ -96,7 +96,7 @@ greatly reducing the amount of work required by curators to get LOVD set up for 
 
 LOVD 3.0 reached beta stage in January 2012, and the first stable release was in December of that year.
 Currently, the latest release is \LOVDversion.
-Keep an eye on our \href{http://www.lovd.nl/3.0/news}{news page} for the latest information on LOVD 3.0 development.
+Keep an eye on our \href{https://www.lovd.nl/3.0/news}{news page} for the latest information on LOVD 3.0 development.
 \vskip \baselineskip
 
 \begin{infotable}
@@ -502,9 +502,9 @@ A suitable server with the necessary software installed is available at virtuall
 If you don't want to run LOVD on a server but rather want to have it running on your computer,
  we can recommend the \href{https://www.apachefriends.org/}{XAMPP} package,
  which installs all needed software on your computer regardless of whether it's Linux, Windows or Mac.
-For Windows users, a working alternative is the \href{http://www.wampserver.com/en/}{WampServer} package.
+For Windows users, a working alternative is the \href{https://www.wampserver.com/en/}{WampServer} package.
 Also, at the time of this writing, we are offering free server space if you need to set up an LOVD.
-\href{http://www.LOVD.nl/3.0/faq/server_space}{See our website} for more information.
+\href{https://www.LOVD.nl/3.0/faq/server_space}{See our website} for more information.
 In that case you don't need to install anything and you can skip this chapter.
 \vskip \baselineskip
 
@@ -518,7 +518,7 @@ Also, you'll need to install a properly configured Mail Transfer Agent for sendi
  (such as registration information).\\
 LOVD may work with other database platforms, but we are not developing for other database backends.
 You are welcome to try other database backends and report the results to us, but we can't provide any support for it.
-For more information, see the \href{http://lovd.nl/3.0/faq/software}{FAQ about software needed}.
+For more information, see the \href{https://lovd.nl/3.0/faq/software}{FAQ about software needed}.
 \vskip \baselineskip
 
 Before installing LOVD, be sure you have the required credentials for
@@ -531,7 +531,7 @@ If you are installing LOVD on a remote server, be sure to have the
 
 
 \subsection{Download \& Extract}
-To download LOVD, go to the \href{http://www.LOVD.nl/3.0/}{LOVD website} and click on the ``Download'' tab.
+To download LOVD, go to the \href{https://www.LOVD.nl/3.0/}{LOVD website} and click on the ``Download'' tab.
 You can download LOVD in two formats; GZIPped TARball and ZIP archive.
 The first format is common for Unix and Linux systems while the ZIP archive is popular on the Windows platform.
 Usually you will be able to open both formats.
@@ -577,11 +577,11 @@ The mod\_rewrite rules in the .htaccess file require ``FileInfo'' enabled in Apa
 \vspace{1em} % vspace doesn't introduce new \par, therefore no \noindent is needed
 
 More information about .htaccess files:\\
-\url{http://httpd.apache.org/docs/2.0/howto/htaccess.html}
+\url{https://httpd.apache.org/docs/2.0/howto/htaccess.html}
 \vspace{1em} % vspace doesn't introduce new \par, therefore no \noindent is needed
 
 More information about AllowOverride:\\
-\url{http://httpd.apache.org/docs/2.0/mod/core.html\#allowoverride}
+\url{https://httpd.apache.org/docs/2.0/mod/core.html#allowoverride}
 \vskip \baselineskip
 
 \textbf{If you use a different webserver}, make sure to configure it to deny access to the config.ini.php file.
@@ -836,7 +836,7 @@ or move your mouse over the ``Setup'' tab and click the ``LOVD system settings''
 
 \subsection{Connection settings (optional)}
 Some networks have no access to the outside world except through a so-called proxy server
- (\href{http://en.wikipedia.org/wiki/Proxy_server#Forward_proxies}{more info on WikiPedia}).
+ (\href{https://en.wikipedia.org/wiki/Proxy_server}{more info on WikiPedia}).
 If this applies to the network this server is installed on, please fill in the proxy server information here.
 \begin{description}
   \item[Proxy server host name] \hfill \\
@@ -878,8 +878,8 @@ We use this information to see how many LOVDs there are worldwide, which version
   No specific information is sent, just the numbers.
   \hypertarget{item:include_in_listing}{}
   \item[Include in the global LOVD listing] \hfill \\
-  On our website, we keep a \href{http://www.lovd.nl/3.0/public_list}{list of public LOVD installations}.
-  This list is also feeding our \href{http://www.lovd.nl/LSDBs}{worldwide LSDB list},
+  On our website, we keep a \href{https://www.lovd.nl/3.0/public_list}{list of public LOVD installations}.
+  This list is also feeding our \href{https://www.lovd.nl/LSDBs}{worldwide LSDB list},
    through which submitters can locate databases for a specific gene to submit data to.
   If you enable the ``Include in the global LOVD listing'' setting,
    your LOVD installation will send us all the information we need to build these lists:
@@ -1282,8 +1282,8 @@ The registration form is protected using a \emph{reCAPTCHA} module, which makes 
 \end{wrapfigure}
 To register a new submitter account, click the ``Register as submitter'' link on the top right corner of the screen, next to the ``Log in'' link.
 First, you are asked to provide an ORCID ID, if you have one.
-\href{http://about.orcid.org/}{ORCID} provides a persistent digital identifier that distinguishes you from every other researcher and,
- through integration in key research workflows such as manuscript and grant submission,
+\href{https://info.orcid.org/what-is-orcid/}{ORCID} provides a persistent digital identifier that distinguishes you
+ from every other researcher and, through integration in key research workflows such as manuscript and grant submission,
  supports automated linkages between you and your professional activities ensuring that your work is recognized.
 If you don't have an ORCID ID yet, you can get one created by using the \href{https://orcid.org/register}{register} link also given on the page.
 If you don't want to register at ORCID at this time, click the ``I don't have an ORCID ID \guillemotright'' button to continue to the registration page.
@@ -1360,7 +1360,8 @@ To prevent unauthorized use of your account, we implemented a security feature t
 
 
 \subsection{Registration authentication}
-To prevent automatic submission of the registration form, we implemented a \href{http://www.google.com/recaptcha}{reCAPTCHA} module.
+To prevent automatic submission of the registration form,
+ we implemented a \href{https://www.google.com/recaptcha/about/}{reCAPTCHA} module.
 In the provided text field, type the two words you see in the image.
 This will proof that you are a human and not a computer.
 \vskip \baselineskip
@@ -1594,7 +1595,7 @@ Creating a new gene database in LOVD is largely automated.
 Click the ``Create a new gene entry'' option of the ``Genes'' tab dropdown menu, or the ``Create a new gene database'' link in the setup area.
 Fill in the HGNC ID or the gene symbol of the gene you want to create, and click ``Continue \guillemotright''.
 LOVD will check if the gene already exists in this LOVD installation, and if the gene symbol or HGNC ID is correct.
-For this, it contacts the \href{http://www.genenames.org/}{HGNC website}.
+For this, it contacts the \href{https://www.genenames.org/}{HGNC website}.
 If the gene symbol you used has been replaced by a new one, or if LOVD can find genes for which the given symbol is an alias,
  LOVD will report back the official symbol(s).
 
@@ -1687,8 +1688,10 @@ Here you can add links to other resources that will be displayed on the gene's L
   Here you can provide links to other resources on the internet that you would like to link to,
    such as other gene variant databases, or websites with more information about diagnostics.
   If you want to include more than one link, put every link on a new line in this field.
-  If you do not want to include a title for this link, simply paste the full URL in this field, such as ``http://DMD.LOVD.nl/''.
-  If you do want to include a title, use the format ``Description <URL>'', such as ``Other LOVDs on this gene <http://DMD.LOVD.nl/>''.
+  If you do not want to include a title for this link, simply paste the full URL in this field,
+   such as ``https://DMD.LOVD.nl/''.
+  If you do want to include a title, use the format ``Description <URL>'',
+   such as ``Other LOVDs on this gene <https://DMD.LOVD.nl/>''.
   \item[HGNC ID] \hfill \\
   This information has been filled in for you, and can't be changed.
   \item[Entrez Gene (Locuslink) ID] \hfill \\
@@ -4063,7 +4066,7 @@ Examples of possibilities are searching on a gene symbol, getting the list of av
 Even though LOVD3 is not gene-based like LOVD2 was, we have decided to keep the same
  gene-centered design of the API to make sure LOVD2 and LOVD3 can be queried alike.
 The output it creates is either an Atom 1.0 feed with the LOVD information in plain text, or a
- \href{http://www.json.org/}{JSON} file.
+ \href{https://www.json.org/json-en.html}{JSON} file.
 
 A more advanced API will be included in LOVD3 later, allowing the querying of variants genome-wide
  and getting more detailed information out of LOVD, such as patient and phenotype data.
@@ -4099,13 +4102,13 @@ Since 3.0-22, the LOVD2-style API allows for JSON data to be returned.
 The original format, also still available in 3.0-22, is an Atom feed, and is still the standard.
 When searching for genes, an Atom feed is returned with zero or more entries.
 When requesting a specific entry, just the Atom entry is returned.
-The Atom format is described in detail on \href{http://en.wikipedia.org/wiki/Atom_(standard)}{Wikipedia}.
+The Atom format is described in detail on \href{https://en.wikipedia.org/wiki/Atom_(web_standard)}{Wikipedia}.
 
 The content of the Atom entries is in plain text, with headers and values separated by a colon (:).
 Other formats as a `payload' of the Atom entries are not available.
 
 The new LOVD3 API (release date unavailable) will probably support multiple formats, such as
- \href{http://www.varioml.org/}{VarioML} and \href{http://www.json.org/}{JSON},
+ \href{https://www.varioml.org/}{VarioML} and \href{https://www.json.org/json-en.html}{JSON},
  and will not support Atom feeds, since this API serves a different purpose.
 
 \subsubsection{Genes}
@@ -4118,8 +4121,8 @@ The new LOVD3 API (release date unavailable) will probably support multiple form
   <title>
     Results for your query of the database
   </title>
-  <link rel="alternate" type="text/html" href="http://databases.lovd.nl/shared/"/>
-  <link rel="self" type="application/atom+xml" href="http://databases.lovd.nl/shared/api/rest/genes"/>
+  <link rel="alternate" type="text/html" href="https://databases.lovd.nl/shared/"/>
+  <link rel="self" type="application/atom+xml" href="https://databa...lovd.nl/shared/api/rest/genes"/>
   <updated>2018-04-17T20:15:10+02:00</updated>
   <id>tag:databases.lovd.nl,2012-05-02:web01:shared/REST_api</id>
   <generator uri="http://www.LOVD.nl/" version="3.0-21">
@@ -4128,8 +4131,8 @@ The new LOVD3 API (release date unavailable) will probably support multiple form
   <rights>Copyright (c), the curators of this database</rights>
   <entry xmlns="http://www.w3.org/2005/Atom">
     <title>IVD</title>
-    <link rel="alternate" type="text/html" href="http://databases.lovd.nl/shared/genes/IVD"/>
-    <link rel="self" type="application/atom+xml" href="http://d...lovd.nl/shared/api/rest/genes/IVD"/>
+    <link rel="alternate" type="text/html" href="https://databases.lovd.nl/shared/genes/IVD"/>
+    <link rel="self" type="application/atom+xml" href="https://...lovd.nl/shared/api/rest/genes/IVD"/>
     <id>tag:databases.lovd.nl,2011-04-05:IVD</id>
     <author>
       <name>Gerard C.P. Schaafsma</name>
@@ -4158,7 +4161,7 @@ The new LOVD3 API (release date unavailable) will probably support multiple form
     Example LOVD API output, in the default Atom format.
     The longest line has been shortened to fit this page.
     This example output of a search on gene symbol returns the IVD gene and its basic information.
-    Source: \href{http://databases.lovd.nl/shared/api/rest/genes?search_symbol=IVD}
+    Source: \href{https://databases.lovd.nl/shared/api/rest/genes?search_symbol=IVD}
      {LOVD3 shared installation}.}
   \end{shaded}
 \end{figure}
@@ -4231,8 +4234,8 @@ The JSON data shows all transcripts.
   <title>
     Results for your query of the IVD gene database
   </title>
-  <link rel="alternate" type="text/html" href="http://databases.lovd.nl/shared/"/>
-  <link rel="self" type="application/atom+xml" href="http://...lovd.nl/shared/api/rest/variants/IVD"/>
+  <link rel="alternate" type="text/html" href="https://databases.lovd.nl/shared/"/>
+  <link rel="self" type="application/atom+xml" href="https://...ovd.nl/shared/api/rest/variants/IVD"/>
   <updated>2017-08-07T13:40:16+02:00</updated>
   <id>tag:databases.lovd.nl,2012-05-02:web01:shared/REST_api</id>
   <generator uri="http://www.LOVD.nl/" version="3.0-21">
@@ -4241,8 +4244,8 @@ The JSON data shows all transcripts.
   <rights>Copyright (c), the curators of this database</rights>
   <entry xmlns="http://www.w3.org/2005/Atom">
     <title>IVD:c.860G&gt;A</title>
-    <link rel="alternate" type="text/html" href="http://...?search_VariantOnGenome/DBID=IVD_000001"/>
-    <link rel="self" type="application/atom+xml" href="http://.../api/rest/variants/IVD/0000000563"/>
+    <link rel="alternate" type="text/html" href="https://...?search_VariantOnGenome/DBID=IVD_000001"/>
+    <link rel="self" type="application/atom+xml" href="https://.../api/rest/variants/IVD/0000000563"/>
     <id>tag:databases.lovd.nl,2011-04-06:IVD/0000000563</id>
     <author>
       <name>Gerard C.P. Schaafsma</name>
@@ -4268,7 +4271,7 @@ The JSON data shows all transcripts.
     Example LOVD API output, in the default Atom format.
     The three longest lines have been shortened to fit this page.
     This example output of a search on DB ID returns one variant in the IVD gene and its basic information.
-    Source: \href{http://databases.lovd.nl/shared/api/rest/variants/IVD?search_Variant/DBID=IVD_000001}
+    Source: \href{https://databases.lovd.nl/shared/api/rest/variants/IVD?search_Variant/DBID=IVD_000001}
      {LOVD3 shared installation}.}
   \end{shaded}
 \end{figure}
@@ -4308,7 +4311,7 @@ The JSON data shows all transcripts.
      returns all transcripts associated with the variant in question, storing the data in an array.
      The genomic position is formatted slightly differently.
     Source:
-     \href{http://databases.lovd.nl/shared/api/rest/variants/IVD?search_Variant/DBID=IVD_000001&format=application/json}
+    \href{https://databases.lovd.nl/shared/api/rest/variants/IVD?search_Variant/DBID=IVD_000001&format=application/json}
      {LOVD3 shared installation}.}
   \end{shaded}
 \end{figure}
@@ -4346,30 +4349,31 @@ To obtain JSON output, add the `\texttt{format=application/json}' flag to all UR
 \subsubsection{Genes}
 \begin{description}
   \item[Listing of all genes in the database]\hfill \\
-  \href{http://databases.lovd.nl/shared/api/rest.php/genes}{http://databases.lovd.nl/shared/api/rest.php/genes}
+  \href{https://databases.lovd.nl/shared/api/rest.php/genes}{https://databases.lovd.nl/shared/api/rest.php/genes}
   \item[Searching on the gene symbol] (full match only)\hfill \\
-  \href{http://databases.lovd.nl/shared/api/rest.php/genes?search_symbol=IVD}
-    {http://databases.lovd.nl/shared/api/rest.php/genes?search\_symbol=IVD}
+  \href{https://databases.lovd.nl/shared/api/rest.php/genes?search_symbol=IVD}
+    {https://databases.lovd.nl/shared/api/rest.php/genes?search\_symbol=IVD}
   \item[Showing only one specific gene entry]\hfill \\
-  \href{http://databases.lovd.nl/shared/api/rest.php/genes/IVD}{http://databases.lovd.nl/shared/api/rest.php/genes/IVD}
+  \href{https://databases.lovd.nl/shared/api/rest.php/genes/IVD}
+    {https://databases.lovd.nl/shared/api/rest.php/genes/IVD}
   \item[Searching on the genomic position]\hfill \\
   \emph{Chromosome only:}\\
-  \href{http://databases.lovd.nl/shared/api/rest.php/genes?search_position=chr15}
-    {http://databases.lovd.nl/shared/api/rest.php/genes?search\_position=chr15}\\
+  \href{https://databases.lovd.nl/shared/api/rest.php/genes?search_position=chr15}
+    {https://databases.lovd.nl/shared/api/rest.php/genes?search\_position=chr15}\\
   \emph{Chromosomal location:}\\
-  \href{http://databases.lovd.nl/shared/api/rest.php/genes?search_position=chr15:40705600}
-       {http://databases.lovd.nl/shared/api/rest.php/genes?search\_position=chr15:40705600}\\
+  \href{https://databases.lovd.nl/shared/api/rest.php/genes?search_position=chr15:40705600}
+       {https://databases.lovd.nl/shared/api/rest.php/genes?search\_position=chr15:40705600}\\
   \emph{Chromosomal range, exact match} (only match genes having exactly this range)\\
-  \href{http://databases.lovd.nl/shared/api/rest.php/genes?search_position=chr15:40697686_40713512&position_match=exact}
-       {http://databases.lovd.nl/shared/api/rest.php/genes?\\
+  \href{https://databases.lovd.nl/shared/api/rest.php/genes?search_position=chr15:40697686_40713512&position_match=exact}
+       {https://databases.lovd.nl/shared/api/rest.php/genes?\\
        \phantom{..........}search\_position=chr15:40697686\_40713512\&position\_match=exact}\\
   \emph{Chromosomal range, exclusive match} (only match genes completely within this range)\\
-  \href{http://databases.lovd.nl/shared/api/rest.php/genes?search_position=chr15:40657686_40762512&position_match=exclusive}
-       {http://databases.lovd.nl/shared/api/rest.php/genes?\\
+  \href{https://databases.lovd.nl/shared/api/rest.php/genes?search_position=chr15:40657686_40762512&position_match=exclusive}
+       {https://databases.lovd.nl/shared/api/rest.php/genes?\\
        \phantom{..........}search\_position=chr15:40657686\_40762512\&position\_match=exclusive}\\
   \emph{Chromosomal range, partial match} (match any gene overlapping the given region)\\
-  \href{http://databases.lovd.nl/shared/api/rest.php/genes?search_position=chr15:40657686_40762512&position_match=partial}
-       {http://databases.lovd.nl/shared/api/rest.php/genes?\\
+  \href{https://databases.lovd.nl/shared/api/rest.php/genes?search_position=chr15:40657686_40762512&position_match=partial}
+       {https://databases.lovd.nl/shared/api/rest.php/genes?\\
        \phantom{..........}search\_position=chr15:40657686\_40762512\&position\_match=partial}
 \end{description}
 \clearpage
@@ -4377,39 +4381,39 @@ To obtain JSON output, add the `\texttt{format=application/json}' flag to all UR
 \subsubsection{Variants}
 \begin{description}
   \item[Listing of all variant entries in a certain gene]\hfill \\
-  \href{http://databases.lovd.nl/shared/api/rest.php/variants/IVD}
-       {http://databases.lovd.nl/shared/api/rest.php/variants/IVD}
+  \href{https://databases.lovd.nl/shared/api/rest.php/variants/IVD}
+       {https://databases.lovd.nl/shared/api/rest.php/variants/IVD}
   \item[Searching on the DNA position]\hfill \\
   \emph{Coding DNA or genomic position, exact match only}\\
-  \href{http://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_position=c.157}
-       {http://databases.lovd.nl/shared/api/rest.php/variants/IVD?search\_position=c.157}\\
+  \href{https://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_position=c.157}
+       {https://databases.lovd.nl/shared/api/rest.php/variants/IVD?search\_position=c.157}\\
        This does not allow for partial matches, so variant c.157\_158del is not matched.
        c.157 will match c.157+? and c.157\_158 will match c.157+?\_158-?.
        However, c.157 does not match c.157+5.
        Searching on genomic locations can be achieved using g. as a prefix.\\
        \small{
-       \href{http://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_position=g.40699840}
-            {http://databases.lovd.nl/shared/api/rest.php/variants/IVD?search\_position=g.40699840}}\\
+       \href{https://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_position=g.40699840}
+            {https://databases.lovd.nl/shared/api/rest.php/variants/IVD?search\_position=g.40699840}}\\
   \emph{Genomic position only, exclusive match (only match variants completely within this range)}\\
-  \href{http://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_position=g.40710300_40710410&position_match=exclusive}
-       {http://databases.lovd.nl/shared/api/rest.php/variants/IVD?\\
+  \href{https://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_position=g.40710300_40710410&position_match=exclusive}
+       {https://databases.lovd.nl/shared/api/rest.php/variants/IVD?\\
        \phantom{..........}search\_position=g.40710300\_40710410\&position\_match=exclusive}\\
   \emph{Genomic position only, partial match (match any variant overlapping the given region)}\\
-  \href{http://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_position=g.40710300_40710410&position_match=partial}
-       {http://databases.lovd.nl/shared/api/rest.php/variants/IVD?\\
+  \href{https://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_position=g.40710300_40710410&position_match=partial}
+       {https://databases.lovd.nl/shared/api/rest.php/variants/IVD?\\
        \phantom{..........}search\_position=g.40710300\_40710410\&position\_match=partial}
   \item[Searching on the DNA field]\hfill \\
-  \href{http://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_Variant/DNA=c.157C\%3ET}
-       {http://databases.lovd.nl/shared/api/rest.php/variants/IVD?\\
+  \href{https://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_Variant/DNA=c.157C\%3ET}
+       {https://databases.lovd.nl/shared/api/rest.php/variants/IVD?\\
        \phantom{..........}search\_Variant/DNA=c.157C\%3ET}\\
        This does not allow for partial matches, but c.(157C>T) or c.157C>T? will also match.
   \item[Searching on the DBID field]\hfill \\
-  \href{http://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_Variant/DBID=IVD_000001}
-       {http://databases.lovd.nl/shared/api/rest.php/variants/IVD?\\
+  \href{https://databases.lovd.nl/shared/api/rest.php/variants/IVD?search_Variant/DBID=IVD_000001}
+       {https://databases.lovd.nl/shared/api/rest.php/variants/IVD?\\
        \phantom{..........}search\_Variant/DBID=IVD\_000001}
   \item[Showing only one specific variant entry (internal ID only)]\hfill \\
-  \href{http://databases.lovd.nl/shared/api/rest.php/variants/IVD/0000001350}
-       {http://databases.lovd.nl/shared/api/rest.php/variants/IVD/0000001350}
+  \href{https://databases.lovd.nl/shared/api/rest.php/variants/IVD/0000001350}
+       {https://databases.lovd.nl/shared/api/rest.php/variants/IVD/0000001350}
 \end{description}
 
 
@@ -4417,8 +4421,8 @@ To obtain JSON output, add the `\texttt{format=application/json}' flag to all UR
 \subsection{World-wide LOVD quering service}
 There is also a world-wide LOVD query API that allows you to query a genomic location to find out
  whether there is a variant reported in any public LOVD installation that has registered at
- \href{http://lovd.nl/3.0/public_list}{LOVD.nl}.
-Please \href{http://www.lovd.nl/3.0/contact}{contact us directly} for more information on that API.
+ \href{https://lovd.nl/3.0/public_list}{LOVD.nl}.
+Please \href{https://www.lovd.nl/3.0/contact}{contact us directly} for more information on that API.
 \clearpage
 
 
@@ -4443,8 +4447,8 @@ Note that this API was introduced in LOVD 3.0-18, but was only fully functional 
 
 
 \subsection{The submission format}
-The format used by the submission API is a JSON implementation of the \href{http://varioml.org/}{VarioML format}.
-For an example file, please see \url{http://LOVD.nl/3.0/submission_api_format.json}.
+The format used by the submission API is a JSON implementation of the \href{https://varioml.org/}{VarioML format}.
+For an example file, please see \url{https://LOVD.nl/3.0/submission_api_format.json}.
 Since Vario\-ML is originally an XML format, all XML attributes have been prefixed by an `\texttt{@}' character,
  and text nodes are stored in `\texttt{\#text}' elements.
 The JSON format allows for multiple individuals to be submitted at once;
@@ -4457,7 +4461,7 @@ JSON officially can't contain comments so a JSON parser might fail on the exampl
 Do note that not all fields that may be configured in LOVD3 will be representable (yet) in this format.
 All fields currently supported are present in the example file (see above).
 If you have more data that you'd like to submit using this format,
- please \href{http://www.LOVD.nl/3.0/contact?question}{contact us}.
+ please \href{https://www.LOVD.nl/3.0/contact?question}{contact us}.
 We aim to map as many LOVD3 fields as possible to VarioML.
 
 
@@ -4717,8 +4721,8 @@ If an update is available, detailed information is presented:
   \item[Release info:]
   Information on the changes that have been done in this release.
   Please note that this is usually only a very short list of updates.
-  A more elaborate description can always be found in the \href{http://www.lovd.nl/3.0/news/}{news section} of the
-   LOVD website, and the full list can be found in the \href{http://www.lovd.nl/3.0/changelog.txt}{LOVD changelog}.
+  A more elaborate description can always be found in the \href{https://www.lovd.nl/3.0/news/}{news section} of the
+   LOVD website, and the full list can be found in the \href{https://www.lovd.nl/3.0/changelog.txt}{LOVD changelog}.
 \end{description}
 
 \noindent
@@ -4749,10 +4753,11 @@ If you choose to upgrade LOVD, follow these steps:
 \hypertarget{chap:troubleshooting}{}
 \chapter{Troubleshooting}
 In case you run into any kind of problem or when you have a question, we recommend you first check in the manual to see if perhaps the answer can be found there.
-A newer version of the manual may be available online, on \href{http://www.lovd.nl/3.0/docs/}{the LOVD website}.
+A newer version of the manual may be available online, on \href{https://www.lovd.nl/3.0/docs/}{the LOVD website}.
 If that doesn't resolve your problem or answer your question, please follow the following steps:
 \begin{itemize}
-  \item Check the \href{http://www.lovd.nl/3.0/faq}{Frequently Asked Questions} on our website to see if that provides you any answers.
+  \item Check the \href{https://www.lovd.nl/3.0/faq}{Frequently Asked Questions}
+   on our website to see if that provides you any answers.
   \item If you're sure the problem you are having is an LOVD bug,
    or if you'd like to request a new feature or change of an existing LOVD feature,
    please \href{https://github.com/LOVDnl/LOVD3/issues/new/choose}{use our bug tracking system} to report your issue.

--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -165,7 +165,7 @@ Note that search terms are case-insensitive and that wildcards such as * are tre
 You can use different operators to specify your search request:
 \vskip 0.5\baselineskip % This page is too crammed but if I don't do this, everything below goes to hell.
 \noindent
-\begin{tabular}{>{\bfseries}p{2.5cm} p{2.6cm} p{10.6cm}}
+\begin{tabular}{>{\bfseries}p{2.6cm} p{2.6cm} p{10.5cm}}
   Operator & \textbf{Example} & \textbf{Matches}\\ \hline \hline
   & Arg & Results containing `Arg'.\\ \hline
   space & Arg Ser & Results containing both `Arg' and `Ser'.\\ \hline
@@ -1280,13 +1280,16 @@ The registration form is protected using a \emph{reCAPTCHA} module, which makes 
     Available from: LOVD 3.0 Build 01
   \end{leftbar}
 \end{wrapfigure}
-To register a new submitter account, click the ``Register as submitter'' link on the top right corner of the screen, next to the ``Log in'' link.
+To register a new submitter account, click the ``Register as submitter'' link on the top right corner of the screen,
+ next to the ``Log in'' link.
 First, you are asked to provide an ORCID ID, if you have one.
 \href{https://info.orcid.org/what-is-orcid/}{ORCID} provides a persistent digital identifier that distinguishes you
  from every other researcher and, through integration in key research workflows such as manuscript and grant submission,
  supports automated linkages between you and your professional activities ensuring that your work is recognized.
-If you don't have an ORCID ID yet, you can get one created by using the \href{https://orcid.org/register}{register} link also given on the page.
-If you don't want to register at ORCID at this time, click the ``I don't have an ORCID ID \guillemotright'' button to continue to the registration page.
+If you don't have an ORCID ID yet,
+ you can get one created by using the \href{https://orcid.org/register}{register} link also given on the page.
+If you don't want to register at ORCID at this time,
+ click the ``I don't have an ORCID ID \guillemotright'' button to continue to the registration page.
 If you do have an ORCID ID, fill it in and click the ``Continue \guillemotright'' button.
 Your ORCID ID will be verified, and the associated data is shown on the screen.
 If this data is correct, click ``Yes, this is correct \guillemotright'' to continue to the registration page.
@@ -1368,7 +1371,8 @@ This will proof that you are a human and not a computer.
 
 After completing the form, press the ``Register'' button.
 LOVD sends you a confirmation of your registered information through email.
-If the ``Forward messages to database admin'' setting in the \hyperlink{sec:system_settings}{LOVD system settings} is enabled,
+If the ``Forward messages to database admin''
+ setting in the \hyperlink{sec:system_settings}{LOVD system settings} is enabled,
  the database administrator also receives a copy of your data.
 
 
@@ -1592,16 +1596,19 @@ This chapter describes how to create, edit and delete gene databases in LOVD.
   \end{leftbar}
 \end{wrapfigure}
 Creating a new gene database in LOVD is largely automated.
-Click the ``Create a new gene entry'' option of the ``Genes'' tab dropdown menu, or the ``Create a new gene database'' link in the setup area.
+Click the ``Create a new gene entry'' option of the ``Genes'' tab dropdown menu,
+ or the ``Create a new gene database'' link in the setup area.
 Fill in the HGNC ID or the gene symbol of the gene you want to create, and click ``Continue \guillemotright''.
 LOVD will check if the gene already exists in this LOVD installation, and if the gene symbol or HGNC ID is correct.
 For this, it contacts the \href{https://www.genenames.org/}{HGNC website}.
-If the gene symbol you used has been replaced by a new one, or if LOVD can find genes for which the given symbol is an alias,
- LOVD will report back the official symbol(s).
+If the gene symbol you used has been replaced by a new one,
+ or if LOVD can find genes for which the given symbol is an alias, LOVD will report back the official symbol(s).
 
 \begin{infotable}
-Unfortunately, due to some problems on the side of the NCBI, we are unable to handle variants on the mitochondrial genome at this time.
-NCBI does not handle the MT genes by their official names, and doesn't allow for automatic retrieval of reference sequences for the MT genes.
+Unfortunately, due to some problems on the side of the NCBI,
+ we are unable to handle variants on the mitochondrial genome at this time.
+NCBI does not handle the MT genes by their official names,
+ and doesn't allow for automatic retrieval of reference sequences for the MT genes.
 When the NCBI has fixed this problem, we will implement support for MT genes.
 \end{infotable}
 
@@ -1703,10 +1710,12 @@ Here you can add links to other resources that will be displayed on the gene's L
   \item[Provide link to GeneCards] \hfill \\
   If you wish to include a link from the gene homepage to the gene's page on the GeneCards site, enable this checkbox.
   \item[Provide link to NIH GTR] \hfill \\
-  If you wish to include a link from the gene homepage to the gene's page on the NIH Genetic Testing Registry (GTR) site, enable this checkbox.
+  If you wish to include a link from the gene homepage to the gene's page on the
+   NIH Genetic Testing Registry (GTR) site, enable this checkbox.
   \item[This gene has a human-readable reference sequence] \hfill \\
   Although GenBank files are the official reference sequence, they are not very readable for humans.
-  If you have a human-readable format of your reference sequence online, please select the type here; ``Coding DNA'' or ``Genomic''.
+  If you have a human-readable format of your reference sequence online,
+   please select the type here; ``Coding DNA'' or ``Genomic''.
   \pagebreak[4] % Break the page here (up to 4; 4 is very persistent)
   \item[Human-readable reference sequence location] \hfill \\
 % TODO: add link to refseq parser section in manual.
@@ -4752,7 +4761,8 @@ If you choose to upgrade LOVD, follow these steps:
 
 \hypertarget{chap:troubleshooting}{}
 \chapter{Troubleshooting}
-In case you run into any kind of problem or when you have a question, we recommend you first check in the manual to see if perhaps the answer can be found there.
+In case you run into any kind of problem or when you have a question,
+ we recommend you first check in the manual to see if perhaps the answer can be found there.
 A newer version of the manual may be available online, on \href{https://www.lovd.nl/3.0/docs/}{the LOVD website}.
 If that doesn't resolve your problem or answer your question, please follow the following steps:
 \begin{itemize}

--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -99,13 +99,9 @@ Currently, the latest release is \LOVDversion.
 Keep an eye on our \href{http://www.lovd.nl/3.0/news}{news page} for the latest information on LOVD 3.0 development.
 \vskip \baselineskip
 
-Wherever you see ``he'' or ``his'' written in this manual, it should read ``he or she'' and ``his or her'' respectively.
-
 \begin{infotable}
 Please note that this manual is work in progress.
-Since LOVD 3.0 is still under development and the development is the focus of our efforts, many features in LOVD 3.0 are not yet described in this manual.
-Also, features described in this manual may become inaccurate or even incorrect in later versions of LOVD 3.0.
-Please bear with us while we finish this manual.
+Since LOVD is under continuous development and the development is the focus of our efforts, many features in LOVD 3.0 are not yet described in this manual.
 \end{infotable}
 
 

--- a/doc/tex/manual.tex
+++ b/doc/tex/manual.tex
@@ -4757,10 +4757,10 @@ A newer version of the manual may be available online, on \href{http://www.lovd.
 If that doesn't resolve your problem or answer your question, please follow the following steps:
 \begin{itemize}
   \item Check the \href{http://www.lovd.nl/3.0/faq}{Frequently Asked Questions} on our website to see if that provides you any answers.
-  \item If not, check the \href{https://humgenprojects.lumc.nl/trac/LOVD3/discussion}{LOVD forum} to see if that helps you.
-  \item If not, please submit your question to the \href{https://humgenprojects.lumc.nl/trac/LOVD3/discussion/forum/1}{LOVD3 support forum}.
-  \item If you're sure the problem you are having is an LOVD bug, please \href{https://humgenprojects.lumc.nl/trac/LOVD3/report/1}{use our bug tracking system} to report your issue.
-  \item Only in case you don't want to publicly put your problem or question on the forum or bug tracking system, you can contact us also directly through \href{http://www.lovd.nl/3.0/contact}{the website}.
+  \item If you're sure the problem you are having is an LOVD bug,
+   or if you'd like to request a new feature or change of an existing LOVD feature,
+   please \href{https://github.com/LOVDnl/LOVD3/issues/new/choose}{use our bug tracking system} to report your issue.
+  \item Otherwise, you can contact us also directly through \href{https://www.lovd.nl/3.0/contact}{the website}.
 \end{itemize}
 \end{document}
 

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -24,6 +24,7 @@
    MT genes, we are creating fake transcripts since MT genes don't have them.
    Select transcripts are labeled as such to make it easier to select the right
    transcript.
+   Closes #521: "Load MANE transcript info from HGNC".
    Closes #639: "Use VV for the creation of all transcripts".
  * Removed the LRG functionality from LOVD. It will still be recognized, but new
    genes can't be linked to LRGs anymore.

--- a/src/class/template.php
+++ b/src/class/template.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-03-27
- * Modified    : 2024-01-25
- * For LOVD    : 3.0-30
+ * Modified    : 2024-09-12
+ * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -363,7 +363,8 @@ class LOVD_Template
 
         }
         print('  Powered by <A href="' . $_SETT['upstream_URL'] . $_STAT['tree'] . '/" target="_blank">LOVD v.' . $_STAT['tree'] . '</A> Build ' . $_STAT['build'] . '<BR>' . "\n" .
-              '  LOVD' . (LOVD_plus? '+' : '') . ' software &copy;2004-2024 <A href="http://www.lumc.nl/" target="_blank">Leiden University Medical Center</A>' . "\n");
+              '  LOVD' . (LOVD_plus? '+' : '') . ' software &copy;2004-2024 <A href="http://www.lumc.nl/" target="_blank">Leiden University Medical Center</A><BR>' . "\n" .
+              '  Database contents &copy; by their respective submitters and curators<BR>' . "\n");
 ?>
     </TD>
     <TD width="42" align="right">

--- a/src/docs/index.php
+++ b/src/docs/index.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-11-27
- * Modified    : 2024-05-30
- * For LOVD    : 3.0-30
+ * Modified    : 2024-09-10
+ * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -51,7 +51,7 @@ if (PATH_COUNT == 1 && !ACTION) {
     } else {
         print('      Currently available is the LOVD 3.0 user manual, in PDF and HTML formats.<BR>' .
               '      <UL>' . "\n" .
-              '        <LI>LOVD manual 3.0-30 (<A href="docs/LOVD_manual_3.0.pdf" target="_blank"><B>PDF</B>, 88 pages, 1.5Mb</A>) (<A href="docs/manual.html" target="_blank"><B>HTML</B>, single file, 5.2Mb</A>) - last updated May 30th 2024</LI></UL>' . "\n\n");
+              '        <LI>LOVD manual 3.0-31 (<A href="docs/LOVD_manual_3.0.pdf" target="_blank"><B>PDF</B>, 88 pages, 1.5Mb</A>) (<A href="docs/manual.html" target="_blank"><B>HTML</B>, single file, 5.2Mb</A>) - last updated September 10th 2024</LI></UL>' . "\n\n");
     }
 
     $_T->printFooter();

--- a/src/install/index.php
+++ b/src/install/index.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2022-11-22
- * For LOVD    : 3.0-29
+ * Modified    : 2024-09-10
+ * For LOVD    : 3.0-31
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
  *               Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -137,7 +137,8 @@ if ($_GET['step'] == 0 && defined('NOT_INSTALLED')) {
     // Check for PHP version, PHP functions, MySQL version.
     $sPHPVers = str_replace('_', '-', PHP_VERSION) . '-';
     $sPHPVers = substr($sPHPVers, 0, strpos($sPHPVers, '-'));
-    $bPHP = ($sPHPVers >= $aRequired['PHP']);
+    // Compare each version section separately, to make sure LOVD knows that 10.0.0 is higher than 5.3.0.
+    $bPHP = (explode('.', $sPHPVers) >= explode('.', $aRequired['PHP']));
     $sPHP = '<IMG src="gfx/mark_' . (int) $bPHP . '.png" alt="" width="11" height="11">&nbsp;PHP : ' . $sPHPVers . ' (' . $aRequired['PHP'] . ' required)';
 
     // Check for certain PHP functions from optional libraries, such as mbstring and SSL.
@@ -162,7 +163,8 @@ if ($_GET['step'] == 0 && defined('NOT_INSTALLED')) {
 
     $sMySQLVers = str_replace('_', '-', $_DB->getServerInfo()) . '-';
     $sMySQLVers = substr($sMySQLVers, 0, strpos($sMySQLVers, '-'));
-    $bMySQL = ($sMySQLVers >= $aRequired['MySQL']);
+    // Compare each version section separately, to make sure LOVD knows that 10.0.0 is higher than 4.1.2.
+    $bMySQL = (explode('.', $sMySQLVers) >= explode('.', $aRequired['MySQL']));
     $sMySQL = '<IMG src="gfx/mark_' . (int) $bMySQL . '.png" alt="" width="11" height="11">&nbsp;MySQL : ' . $sMySQLVers . ' (' . $aRequired['MySQL'] . ' required)';
 
     // Check for InnoDB support.

--- a/src/scripts/refseq_parser.php
+++ b/src/scripts/refseq_parser.php
@@ -1764,7 +1764,7 @@ if ($_GET['step'] == 3) {
                         $sPrntFinl .= $c_prnt;
 
                         // Create number at the right of the sequence.
-                        if ($l_prnt[0] != '*') {
+                        if (substr($l_prnt, 0, 1) != '*') {
                             // Maybe this is a weird check. Will there ever be no $c_prnt?
                             $l_prnt = ($c_prnt? $l_prnt+1 : $l_prnt);
                         } elseif ($c_prnt) {
@@ -1892,7 +1892,7 @@ if ($_GET['step'] == 3) {
                     if (isset($n_break)) {
                         $n_break = LENGTH_LINE - $n_break;
                         $i -= $n_break;
-                        if ($l_prnt[1] == '*') {
+                        if (substr($l_prnt, 0, 1) == '*') {
                             $l_prnt = (substr($l_prnt, 1) - $n_break);
                         } else {
                             $l_prnt = '*0';

--- a/src/scripts/refseq_parser.php
+++ b/src/scripts/refseq_parser.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2012-06-29
- * Modified    : 2022-11-22
- * For LOVD    : 3.0-29
+ * Modified    : 2024-09-10
+ * For LOVD    : 3.0-31
  *
- * Copyright   : 2004-2022 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               Gerard C.P. Schaafsma <G.C.P.Schaafsma@LUMC.nl>
  *               Ivar C. Lugtenburg <I.C.Lugtenburg@LUMC.nl>
@@ -734,7 +734,7 @@ if ($_GET['step'] == 2) {
                             $sPreSpaces = str_repeat(' ', (LENGTH_LINE - $nLeftover));
                             if (strlen($sPreSpaces) > strlen($nPreceedNumber)) {// + 3) {// +3 because of the extra space
                                 // Determine if there is enough room for the preceeding nucleotide number
-                                $sPreSpaces = @str_repeat(' ', (LENGTH_LINE - $nLeftover - 3 - strlen($nPreceedNumber)));
+                                $sPreSpaces = str_repeat(' ', max((LENGTH_LINE - $nLeftover - 3 - strlen($nPreceedNumber)), 0));
                                 fputs($fIntron, $sPreSpaces . 'g.1' . str_repeat(' ', strlen($nPreceedNumber)) . substr($sLinemarkBack, -$nLeftover) . '    g.' . $nLeftover . "\n");// Print the line with the 10th position marks (dots)
                                 fputs($fIntron, $sPreSpaces . 'c.' . $nPreceedNumber . ' ' . substr($sUpstream, 0, $nLeftover) . '    c.' . -($nLineMultFactor*LENGTH_LINE + 1) . "\n\n");
                             } else {

--- a/src/scripts/refseq_parser.php
+++ b/src/scripts/refseq_parser.php
@@ -715,30 +715,30 @@ if ($_GET['step'] == 2) {
                         // print the first line
                         $sPreSpaces = str_repeat(' ', (LENGTH_LINE - $nLeftover));// Spaces before the leftover part to be added
                         if ($lUpstream <= LENGTH_LINE) {
-                            // First line is also last line of upstream sequence
-                            // Determine the preceeding nucleotide number
+                            // First line is also last line of upstream sequence.
+                            // Determine the preceding nucleotide number.
                             $nPreceedNumber = -($nLineMultFactor*LENGTH_LINE) - strlen(substr($sUpstream, 0, $lUpstream - $nExonNuclsToAdd)) - strlen(substr($sUpstream, $lUpstream - $nExonNuclsToAdd, $nExonNuclsToAdd));
                             if (strlen($sPreSpaces) > strlen($nPreceedNumber) + 3) {// +3 because of the extra space and c.
-                                // There is enough room for the preceeding nucleotide number
+                                // There is enough room for the preceding nucleotide number.
                                 fputs($fIntron, $sPreSpaces . 'g.1' . str_repeat(' ', strlen($nPreceedNumber)) . substr($sLinemarkBack, LENGTH_LINE - $lUpstream, $lUpstream - $nExonNuclsToAdd) . '   ' . substr($sLinemarkBack,  -$nExonNuclsToAdd, $nExonNuclsToAdd) . '  g.' . $nLeftover . "\n");
                                 fputs($fIntron, $sPreSpaces . 'c.' . $nPreceedNumber . ' ' . substr($sUpstream, 0, $lUpstream - $nExonNuclsToAdd) . ' \\ ' . substr($sUpstream, $lUpstream - $nExonNuclsToAdd, $nExonNuclsToAdd) . '  c.' . -($nLineMultFactor*LENGTH_LINE + 1) . "\n\n");
                             } else {
-                                // No preceeding nucleotide number will be printed
+                                // No preceding nucleotide number will be printed.
                                 fputs($fIntron, $sPreSpaces . substr($sLinemarkBack, LENGTH_LINE - $lUpstream, $lUpstream - $nExonNuclsToAdd) . '   ' . substr($sLinemarkBack,  -$nExonNuclsToAdd, $nExonNuclsToAdd) . '  g.' . $nLeftover . "\n");
                                 fputs($fIntron, $sPreSpaces . substr($sUpstream, 0, $lUpstream - $nExonNuclsToAdd) . ' \\ ' . substr($sUpstream, $lUpstream - $nExonNuclsToAdd, $nExonNuclsToAdd) . '  c.' . -($nLineMultFactor*LENGTH_LINE + 1) . "\n\n");
                             }
                         } else {
-                            // First line is not the last line
-                            // Determine the preceeding nucleotide number
+                            // First line is not the last line.
+                            // Determine the preceding nucleotide number.
                             $nPreceedNumber = -($nLineMultFactor*LENGTH_LINE) - strlen(substr($sUpstream, 0, $nLeftover));
                             $sPreSpaces = str_repeat(' ', (LENGTH_LINE - $nLeftover));
-                            if (strlen($sPreSpaces) > strlen($nPreceedNumber)) {// + 3) {// +3 because of the extra space
-                                // Determine if there is enough room for the preceeding nucleotide number
+                            if (strlen($sPreSpaces) > strlen($nPreceedNumber)) {
+                                // Determine if there is enough room for the preceding nucleotide number.
                                 $sPreSpaces = str_repeat(' ', max((LENGTH_LINE - $nLeftover - 3 - strlen($nPreceedNumber)), 0));
                                 fputs($fIntron, $sPreSpaces . 'g.1' . str_repeat(' ', strlen($nPreceedNumber)) . substr($sLinemarkBack, -$nLeftover) . '    g.' . $nLeftover . "\n");// Print the line with the 10th position marks (dots)
                                 fputs($fIntron, $sPreSpaces . 'c.' . $nPreceedNumber . ' ' . substr($sUpstream, 0, $nLeftover) . '    c.' . -($nLineMultFactor*LENGTH_LINE + 1) . "\n\n");
                             } else {
-                                // No preceeding nucleotide number will be printed
+                                // No preceding nucleotide number will be printed.
                                 fputs($fIntron, $sPreSpaces . substr($sLinemarkBack, -$nLeftover) . '    g.' . $nLeftover . "\n");// Print the line with the 10th position marks (dots)
                                 fputs($fIntron, $sPreSpaces . substr($sUpstream, 0, $nLeftover) . '    c.' . -($nLineMultFactor*LENGTH_LINE + 1) . "\n\n");
                             }

--- a/src/scripts/refseq_parser.php
+++ b/src/scripts/refseq_parser.php
@@ -809,7 +809,7 @@ if ($_GET['step'] == 2) {
                             if (strlen($sPreSpaces) > (strlen($aExonEnds[$nIntron]) + strlen($nStart2 - 1) + 1)) {
                                 // 2009-02-27; 2.0-16; by Gerard
                                 $x = LENGTH_LINE - $lLeftover - strlen($aExonEnds[$nIntron]) - strlen($nStart2 - 1) - 4;
-                                fputs($fIntron, substr($sPreSpaces, 0, (LENGTH_LINE - $lLeftover - strlen($aExonEnds[$nIntron]) - strlen($nStart2 - 1) - 4)) . 'g.' . ($nGenomicNumberIntron - $lLeftover + 1) . substr($sPreSpaces, 0, ($sPreSpaces - $x - strlen($nGenomicNumberIntron - $lLeftover + 1) - 2)) . substr($sLinemarkBack, -$lLeftover) . '  g.' . $nGenomicNumberIntron . "\n");// + strlen( + 2
+                                fputs($fIntron, substr($sPreSpaces, 0, (LENGTH_LINE - $lLeftover - strlen($aExonEnds[$nIntron]) - strlen($nStart2 - 1) - 4)) . 'g.' . ($nGenomicNumberIntron - $lLeftover + 1) . substr($sPreSpaces, 0, (strlen($sPreSpaces) - $x - strlen($nGenomicNumberIntron - $lLeftover + 1) - 2)) . substr($sLinemarkBack, -$lLeftover) . '  g.' . $nGenomicNumberIntron . "\n");// + strlen( + 2
                                 fputs($fIntron, substr($sPreSpaces, 0, (LENGTH_LINE - $lLeftover - strlen($aExonEnds[$nIntron]) - strlen($nStart2 - 1) - 4)) . 'c.' . ($aExonEnds[$nIntron] < 0? $aExonEnds[$nIntron] : $aExonEnds[$nIntron] + 1) . ($nStart2) . '  ');
                             } else {
                                 fputs($fIntron, $sPreSpaces . substr($sLinemarkBack, -$lLeftover) . '  g.' . $nGenomicNumberIntron . "\n");


### PR DESCRIPTION
### Fix various issues.
- Fix broken version check in the installer. LOVD wasn't installable on MySQL 10 due to LOVD thinking that '10.0.1' was smaller than '4.1.2'. Fixed this for both the PHP and MySQL version comparisons by exploding the version into parts.
- Remove broken links to old support material from the manual.
- Remove some more old stuff from the manual.
- Updated all links in the manual. Changed http to https where appropriate, and updated some URLs.
- Fix some other small issues in the manual source code.
- Update manual stats.
- Fix issues in the refseq parser:
  - Fix `str_repeat()` called with a negative count.
  - Fix `sum()` that included a string of spaces. I _assume_ that a `strlen()` of that string was meant, but the code is mega old and messy. The result looks OK for me, but I haven't tested all possible outputs. This script is not worth the time required to test all changes thoroughly.
  - Use `substr()` instead of `[0]` as `$l_prnt` can be string or an int. I'm actually not sure why `$l_prnt[1]` was used. I'm pretty sure, by looking at the code, that only the first character of `$l_prnt` could be an asterisk. But again, this script is not worth the time required to test everything thoroughly.
  - Fix typos in comments.
- Added forgotten issue to the changelog that got closed, too.
- Clarify that the database contents are copyrighted, too.

Also:
- Update the rate limiting view; adding some useful data. Also, adjusting the column widths.