### PR TITLE
Improve the HGVS-related functions

### DIFF
--- a/src/ajax/check_HGVS.php
+++ b/src/ajax/check_HGVS.php
@@ -4,10 +4,10 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-09-06
- * Modified    : 2023-06-23
- * For LOVD    : 3.0-30
+ * Modified    : 2024-10-02
+ * For LOVD    : 3.0-31
  *
- * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *               L. Werkman <L.Werkman@LUMC.nl>
  *
@@ -244,17 +244,23 @@ foreach ($aVariants as $sVariant => $aVariant) {
 
             if ($aVV && ($aVV['errors'] || $aVV['warnings'])) {
                 // Warnings or errors have occurred.
-                $aVariant['is_hgvs'] = false;
-                $aVariant['VV'] = array_merge(
-                    $aVariant['VV'],
-                    array_map(
-                        function ($sValue)
-                        {
-                            return 'VariantValidator: ' . htmlspecialchars($sValue);
-                        },
-                        array_merge($aVV['errors'], $aVV['warnings'])
-                    )
-                );
+                // If all we got was a WNOTSUPPORTED, handle it differently. It looked HGVS, VV can't validate, let's accept it.
+                if (empty($aVV['errors']) && array_keys($aVV['warnings']) == array('WNOTSUPPORTED')) {
+                    // All good, actually. VV can't be used.
+                    $aVariant['VV']['WNOTSUPPORTED'] = $aVV['warnings']['WNOTSUPPORTED'];
+                } else {
+                    $aVariant['is_hgvs'] = false;
+                    $aVariant['VV'] = array_merge(
+                        $aVariant['VV'],
+                        array_map(
+                            function ($sValue)
+                            {
+                                return 'VariantValidator: ' . htmlspecialchars($sValue);
+                            },
+                            array_merge($aVV['errors'], $aVV['warnings'])
+                        )
+                    );
+                }
             }
         }
 

--- a/src/ajax/check_HGVS.php
+++ b/src/ajax/check_HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-09-06
- * Modified    : 2024-10-02
+ * Modified    : 2024-10-30
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -248,6 +248,9 @@ foreach ($aVariants as $sVariant => $aVariant) {
                 if (empty($aVV['errors']) && array_keys($aVV['warnings']) == array('WNOTSUPPORTED')) {
                     // All good, actually. VV can't be used.
                     $aVariant['VV']['WNOTSUPPORTED'] = $aVV['warnings']['WNOTSUPPORTED'];
+                } elseif (empty($aVV['warnings']) && array_keys($aVV['errors']) == array('EREFSEQ')) {
+                    // The RefSeq threw an error, but that doesn't necessarily mean that it's invalid. VV can't be used.
+                    $aVariant['VV']['WNOTSUPPORTED'] = "VariantValidator couldn't find the reference sequence used. This does not necessarily mean the variant description is invalid, but we can't validate it to be sure. Please double-check the used reference sequence.";
                 } else {
                     $aVariant['is_hgvs'] = false;
                     $aVariant['VV'] = array_merge(

--- a/src/ajax/check_HGVS.php
+++ b/src/ajax/check_HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2011-09-06
- * Modified    : 2024-10-30
+ * Modified    : 2024-11-01
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -121,7 +121,7 @@ foreach ($aVariants as $sVariant => $aVariant) {
         (
             empty($aVariant['variant_info']['warnings'])
             ||
-            array_keys($aVariant['variant_info']['warnings']) == array('WNOTSUPPORTED')
+            empty(array_diff(array_keys($aVariant['variant_info']['warnings']), ['WNOTSUPPORTED', 'WREFERENCENOTSUPPORTED']))
         )
     );
     // But compensate for ENOTSUPPORTED.
@@ -182,7 +182,7 @@ foreach ($aVariants as $sVariant => $aVariant) {
             (
                 empty($aVariant['fixed_variant_variant_info']['warnings'])
                 ||
-                array_keys($aVariant['fixed_variant_variant_info']['warnings']) == array('WNOTSUPPORTED')
+                empty(array_diff(array_keys($aVariant['variant_info']['warnings']), ['WNOTSUPPORTED', 'WREFERENCENOTSUPPORTED']))
             )
         );
 
@@ -198,12 +198,12 @@ foreach ($aVariants as $sVariant => $aVariant) {
 
     $aVariant['VV'] = array();
     if ($bVV) {
-        if (!empty($aVariant['variant_info'])
-            && !empty($aVariant['variant_info']['errors']['ENOTSUPPORTED'])) {
+        if (!empty($aVariant['variant_info']['errors']['ENOTSUPPORTED'])) {
             $aVariant['VV']['ENOTSUPPORTED'] = 'This variant description is not currently supported by VariantValidator.';
-        } elseif (!empty($aVariant['variant_info'])
-            && !empty($aVariant['variant_info']['warnings']['WNOTSUPPORTED'])) {
+        } elseif (!empty($aVariant['variant_info']['warnings']['WNOTSUPPORTED'])) {
             $aVariant['VV']['WNOTSUPPORTED'] = 'This variant description is not currently supported by VariantValidator.';
+        } elseif (!empty($aVariant['variant_info']['warnings']['WREFERENCENOTSUPPORTED'])) {
+            $aVariant['VV']['WNOTSUPPORTED'] = 'This reference sequence type is not currently supported by VariantValidator.';
         } elseif (!$aVariant['is_hgvs']) {
             $aVariant['VV']['EFAIL'] = 'Please first correct the variant description to run VariantValidator.';
         } elseif (!$aVariant['has_refseq']) {

--- a/src/ajax/check_HGVS.php
+++ b/src/ajax/check_HGVS.php
@@ -182,7 +182,7 @@ foreach ($aVariants as $sVariant => $aVariant) {
             (
                 empty($aVariant['fixed_variant_variant_info']['warnings'])
                 ||
-                empty(array_diff(array_keys($aVariant['variant_info']['warnings']), ['WNOTSUPPORTED', 'WREFERENCENOTSUPPORTED']))
+                empty(array_diff(array_keys($aVariant['fixed_variant_variant_info']['warnings']), ['WNOTSUPPORTED', 'WREFERENCENOTSUPPORTED']))
             )
         );
 

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -160,10 +160,15 @@ class LOVD_VV
             // EUNCERTAINPOSITIONS error.
             $aData['errors']['EUNCERTAINPOSITIONS'] = 'VariantValidator does not currently support variant descriptions with uncertain positions.';
         } elseif (preg_match(
-            '/^A more recent version of the selected reference sequence (.+) is available \((.+)\):/',
-            $sFault, $aRegs)) {
+            '/^(?:TranscriptVersionWarning: )?A more recent version of the selected reference sequence (.+) is available(?: for genome build .+)? \((.+)\)/',
+            $sFault, $aRegs) || strpos($sFault, 'TranscriptVersionWarning:') === 0) {
             // This is not that important, but we won't completely discard it, either.
-            $aData['messages']['IREFSEQUPDATED'] = 'Reference sequence ' . $aRegs[1] . ' can be updated to ' . $aRegs[2] . '.';
+            if ($aRegs) {
+                $aData['messages']['IREFSEQUPDATED'] = 'Reference sequence ' . $aRegs[1] . ' can be updated to ' . $aRegs[2] . '.';
+            } else {
+                // The description changed again, but we found the warning code at least.
+                $aData['messages']['IREFSEQUPDATED'] = 'The reference sequence used can be updated.';
+            }
         } elseif (preg_match(
             '/^The following versions of the requested transcript are available in our database: (.+)$/',
             $sFault, $aRegs)) {

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2024-07-03
+ * Modified    : 2024-10-29
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -145,7 +145,9 @@ class LOVD_VV
             // ESYNTAX error.
             // But, hang on. It's very possible that we do support this variant, but VV does not.
             // This doesn't mean the description is bad. If we have valid variant info, we think it's good.
-            if ($aVariantInfo && empty($aVariantInfo['errors']) && empty($aVariantInfo['warnings'])) {
+            // E.g.: "NM_000088.3:c.589?: char 17: expected one of =, _, con, copy, del, dup, ins, inv, or a digit".
+            if ($aVariantInfo && empty($aVariantInfo['errors'])
+                && (empty($aVariantInfo['warnings']) || !array_diff(array_keys($aVariantInfo['warnings']), ['WNOTSUPPORTED']))) {
                 $aData['warnings']['WNOTSUPPORTED'] =
                     'Although this variant seems to be a valid HGVS description, this syntax is currently not supported for mapping and validation.';
             } else {

--- a/src/class/variant_validator.php
+++ b/src/class/variant_validator.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-03-09
- * Modified    : 2024-10-29
+ * Modified    : 2024-10-30
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -138,7 +138,7 @@ class LOVD_VV
             || strpos($sFault, 'No transcript definition for') !== false
             || strpos($sFault, 'is not in our database. Please check the transcript') !== false) {
             // EREFSEQ error.
-            $aData['errors']['EREFSEQ'] = $sFault;
+            $aData['errors']['EREFSEQ'] = rtrim($sFault, '.') . '.';
         } elseif (substr($sFault, 0, 5) == 'char '
             || $sFault == 'insertion length must be 1'
             || strpos($sFault, ' must be provided ') !== false) {

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2895,6 +2895,25 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                         $nSuffixMinLength :
                         '(' . $nSuffixMinLength . '_' . $nSuffixMaxLength . ')') . ']".';
 
+            } elseif (preg_match('/^([A-Z]+)\[\(([0-9]+|\?)\)\]$/', strtoupper($aVariant['suffix']), $aRegs)) {
+                // g.(100_200)delN[(50)].
+                $bCaseOK = ($aVariant['suffix'] == strtoupper($aVariant['suffix']));
+                list(, $sSequence, $nSuffixLength) = $aRegs;
+                $nSuffixMinLength = $nSuffixLength;
+
+                // Check if only correct bases have been used.
+                $sUnknownBases = preg_replace(
+                    '/' . $_LIBRARIES['regex_patterns']['bases']['ref'] . '+/',
+                    '',
+                    $sSequence
+                );
+                if ($sUnknownBases) {
+                    $aResponse['errors']['EINVALIDNUCLEOTIDES'] = 'This variant description contains invalid nucleotides: "' . implode('", "', str_split($sUnknownBases)) . '".';
+                }
+                $aResponse['warnings']['WSUFFIXFORMAT'] =
+                    'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
+                    ' Please rewrite "' . $aVariant['suffix'] . '" to "' . $sSequence . '[' . $nSuffixLength . ']".';
+
             } elseif (preg_match('/^([A-Z]+)\[(([0-9]+|\?)_([0-9]+|\?))\]$/', strtoupper($aVariant['suffix']), $aRegs)) {
                 // g.(100_200)delN[50_60].
                 $bCaseOK = ($aVariant['suffix'] == strtoupper($aVariant['suffix']));

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3397,7 +3397,11 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
         $sFixedVariant = $sPrefix . '.' . $sVariant;
         $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant, false);
         if ($aVariant) {
-            $aVariant['warnings']['WPREFIXMISSING'] = 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "' . $sPrefix . '."). Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".';
+            // Make sure this warning comes first. If the fixed variant has warnings as well, these need to come later.
+            $aVariant['warnings'] = array_merge(
+                ['WPREFIXMISSING' => 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "' . $sPrefix . '."). Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".'],
+                $aVariant['warnings']
+            );
             return $aVariant;
         }
     }
@@ -3411,7 +3415,11 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
         $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant);
         if ($aVariant) {
             $aVariant['type'] = ''; // Note, we're not sure about the substitution.
-            $aVariant['errors']['EINVALID'] = 'This variant description seems incomplete. Did you mean to write a substitution? Substitutions are written like "' . $sFixedVariant . '".';
+            // Make sure this error comes first. If the fixed variant has errors as well, these need to come later.
+            $aVariant['errors'] = array_merge(
+                ['EINVALID' => 'This variant description seems incomplete. Did you mean to write a substitution? Substitutions are written like "' . $sFixedVariant . '".'],
+                $aVariant['errors']
+            );
             return $aVariant;
         }
     }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2024-10-30
+ * Modified    : 2024-10-31
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -40,7 +40,7 @@ $_LIBRARIES = array(
             'alt' => '[ACGTMRWSYKVHDBN]',
         ),
         'refseq' => array(
-            'basic' => '/^[A-Z_.t0-9()-]+$/',
+            'basic' => '/^[A-Z_.tv0-9()-]+$/',
             'strict'  =>
                 '/^([NX][CGMRTW]_[0-9]{6}\.[0-9]+' .
                 '|[NX][MR]_[0-9]{9}\.[0-9]+' .

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3421,6 +3421,20 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
                 $aVariant['warnings']
             );
             return $aVariant;
+
+        } elseif (preg_match('/^[cgmn][0-9(-]/', $sVariant)) {
+            // Variant actually does have a prefix, but not a period, e.g., c100A>T.
+            // Add the period and try again.
+            $sFixedVariant = $sVariant[0] . '.' . substr($sVariant, 1);
+            $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant, false);
+            if ($aVariant) {
+                // Make sure this warning comes first. If the fixed variant has warnings as well, these need to come later.
+                $aVariant['warnings'] = array_merge(
+                    ['WPREFIXFORMAT' => 'This variant description seems incomplete. Molecule types in variant descriptions should be followed by a period (e.g., "' . $sVariant[0] . '."). Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".'],
+                    $aVariant['warnings']
+                );
+                return $aVariant;
+            }
         }
     }
 

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2024-11-01
+ * Modified    : 2024-11-04
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -3571,6 +3571,20 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
                 $aVariant['warnings']
             );
             return $aVariant;
+
+        } elseif (preg_match('/^[cgmn]:/', $sVariant)) {
+            // Variant actually does have a prefix, but a colon instead of a period, e.g., c:100A>T.
+            // Add the period and try again.
+            $sFixedVariant = $sVariant[0] . '.' . substr($sVariant, 2);
+            $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant, false);
+            if ($aVariant) {
+                // Make sure this warning comes first. If the fixed variant has warnings as well, these need to come later.
+                $aVariant['warnings'] = array_merge(
+                    ['WPREFIXFORMAT' => 'This is not a valid HGVS description. Molecule types in variant descriptions should be followed by a period (e.g., "' . $sVariant[0] . '."). Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".'],
+                    $aVariant['warnings']
+                );
+                return $aVariant;
+            }
 
         } elseif (preg_match('/^[cgmn][0-9(-]/', $sVariant)) {
             // Variant actually does have a prefix, but not a period, e.g., c100A>T.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3602,6 +3602,23 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
         }
     }
 
+    if (preg_match('/^([cgmn]\.)\[(.+)\]$/', $sVariant, $aMatches) && strpos($aMatches[2], ';') === false) {
+        // E.g., c.[100A>C]. Perhaps from people trying out the allele notation? There is no ';' in there, though.
+        // We don't currently handle the allele notation, so lovd_getVariantInfo() doesn't know what to do with this.
+        // Just remove the square brackets and try again.
+        $sFixedVariant =
+            $aMatches[1] . $aMatches[2];
+        $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant);
+        if ($aVariant) {
+            // Make sure this error comes first. If the fixed variant has errors as well, these need to come later.
+            $aVariant['warnings'] = array_merge(
+                ['WWRONGTYPE' => 'The allele syntax with square brackets is meant for multiple variants. Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".',],
+                $aVariant['warnings']
+            );
+            return $aVariant;
+        }
+    }
+
     if (preg_match('/^([cgmn]\.[0-9*-]+)([A-Z])$/i', $sVariant, $aMatches)) {
         // E.g., c.100A. Assuming this is a substitution, but we don't have the original base.
         $sFixedVariant =

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3417,6 +3417,26 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
         }
     }
 
+    // Sometimes, RS numbers are sent. This block can be used for other IDs as well.
+    if (preg_match('/^(rs)[0-9]+$/', $sVariant, $aMatches)) {
+        // E.g., rs123456.
+        // Sad to see that we need to replicate the $aResponse array, but I don't think I have a better way to obtain it.
+        return [
+            'position_start' => 0,
+            'position_end'   => 0,
+            'type'           => '',
+            'range'          => false,
+            'warnings'       => [],
+            'errors'         => [
+                'EINVALID' => 'This is not a valid HGVS description; it looks like ' .
+                    ([
+                        'rs' => 'a dbSNP',
+                    ][$aMatches[1]] ?? 'some variant') .
+                    ' identifier. Please provide a variant description following the HGVS nomenclature.',
+            ],
+        ];
+    }
+
     // Add support for VCF-like variant descriptions. Ignore spacing.
     // Matches "1:123456:A:C" (note, the chromosome has been cut off as the reference sequence) and "1-123456-A-C" (still has the chromosome).
     if (preg_match(

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3397,7 +3397,7 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
         $sFixedVariant = $sPrefix . '.' . $sVariant;
         $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant, false);
         if ($aVariant) {
-            $aVariant['errors']['EPREFIXMISSING'] = 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "' . $sPrefix . '."). Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".';
+            $aVariant['warnings']['WPREFIXMISSING'] = 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "' . $sPrefix . '."). Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".';
             return $aVariant;
         }
     }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3405,7 +3405,7 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
     global $_LIBRARIES, $_SETT;
 
     // First, try to pick up a protein notation that we sometimes receive.
-    if (preg_match('/^(p\.)?([A-Z]|[A-Z][a-z]{2})([0-9]+)([A-Z]|[A-Z][a-z]{2})$/', $sVariant, $aMatches)) {
+    if (preg_match('/^(p\.)?\(?([A-Z]|[A-Z][a-z]{2})([0-9]+)([A-Z]|[A-Z][a-z]{2})\)?$/', $sVariant, $aMatches)) {
         // Double-check if this couldn't be a DNA description.
         if ($aMatches[1] // p. prefix given.
             || strlen($aMatches[2]) > 1 || !in_array(strtoupper($aMatches[2]), ['A', 'C', 'G', 'T']) // Three-letter amino-acid code or non-DNA nucleotide.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2024-10-31
+ * Modified    : 2024-11-01
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1457,14 +1457,22 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     ' NCBI RefSeq and Ensembl IDs require version numbers when used in variant descriptions.';
 
             } elseif (preg_match('/^([NX][MR]_[0-9]{6,9}\.[0-9]+)\((N[CGTW]_[0-9]{6}\.[0-9]+)\)$/', $sReferenceSequence, $aRegs)) {
+                // NM(NC) that should be swapped.
                 $aResponse['warnings']['WREFERENCEFORMAT'] =
                     'The genomic and transcript reference sequence IDs have been swapped.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[2] . '(' . $aRegs[1] . ')".';
 
             } elseif (preg_match('/^([NX][MR]_[0-9]{6,9}\.[0-9]+)\(([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)\)$/', $sReferenceSequence, $aRegs)) {
+                // NM(GENE) that should lose the gene.
                 $aResponse['warnings']['WREFERENCEFORMAT'] =
                     'The reference sequence ID should not include a gene symbol.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '".';
+
+            } elseif (preg_match('/^([A-Z][A-Za-z0-9#@-]*)\(([NX][MR]_[0-9]{6,9}\.[0-9]+)\)$/', $sReferenceSequence, $aRegs)) {
+                // GENE(NM) that should be just NM.
+                $aResponse['warnings']['WREFERENCEFORMAT'] =
+                    'The reference sequence ID should not include a gene symbol.' .
+                    ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[2] . '".';
 
             } elseif (preg_match('/([NX][CGMRTW])-?([0-9]+)/', $sReferenceSequence, $aRegs)) {
                 // The user forgot the underscore or used a hyphen.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1724,7 +1724,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
         if ($aVariant) {
             foreach ($aVariant as $sKey => $Value) {
                 if (is_array($Value)) {
-                    $aResponse[$sKey] = array_merge($aResponse[$sKey], $Value);
+                    $aResponse[$sKey] = array_merge(($aResponse[$sKey] ?? []), $Value);
                 } else {
                     $aResponse[$sKey] = $Value;
                 }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3408,6 +3408,46 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
 
 
 
+function lovd_guessVariantPrefix ($sReferenceSequence, $sVariant)
+{
+    // Try to guess what variant prefix (molecule type) would fit this variant
+    //  description by checking the reference sequence and the variant.
+    // This assumes no prefix is given in the variant description.
+    // This is far from perfect, but an educated guess is good enough.
+
+    $aPrefixesByRefSeq = (lovd_getVariantPrefixesByRefSeq($sReferenceSequence) ?? []);
+    if ($aPrefixesByRefSeq) {
+        // When we have a single match, return that.
+        // When we have multiple matches, we will never be able to prove that it may be the second option.
+        // We could prove that something is c. and not n., but not the reverse.
+        // Therefore, make our lives easier and just return the first (g. or c.).
+        return $aPrefixesByRefSeq[0];
+
+    } elseif (preg_match('/(^|[^0-9])[*-][0-9]/', $sVariant)) {
+        // There seems to be an UTR position mentioned.
+        return 'c';
+
+    } elseif (preg_match('/[0-9][+-][0-9]/', $sVariant)) {
+        // There seems to be an intronic position mentioned.
+        // This can be c. or n., but we'll default to c.
+        return 'c';
+
+    } elseif (preg_match('/([0-9]+)/', $sVariant, $aRegs)
+        && $aRegs[1] < 1000) {
+        // The first number in the variant description is lower than 1000.
+        // Most likely to be a coding variant.
+        return 'c';
+
+    } else {
+        // Larger numbers and everything else will be 'g'.
+        return 'g';
+    }
+}
+
+
+
+
+
 function lovd_hideEmail ($s)
 {
     // Function kindly provided by Ileos.nl in the interest of Open Source.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2009-10-19
- * Modified    : 2024-10-29
+ * Modified    : 2024-10-30
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -3419,6 +3419,24 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
             $aVariant['errors'] = array_merge(
                 ['EINVALID' => 'This variant description seems incomplete. Did you mean to write a substitution? Substitutions are written like "' . $sFixedVariant . '".'],
                 $aVariant['errors']
+            );
+            return $aVariant;
+        }
+    }
+
+    if (preg_match('/^([cgmn]\.)([A-Z])([0-9*-]+)([A-Z])$/i', $sVariant, $aMatches)) {
+        // E.g., c.A100T. Assuming this is a substitution.
+        $sFixedVariant =
+            $aMatches[1] .
+            $aMatches[3] .
+            strtoupper($aMatches[2]) . '>' .
+            strtoupper($aMatches[4]);
+        $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant);
+        if ($aVariant) {
+            // Make sure this error comes first. If the fixed variant has errors as well, these need to come later.
+            $aVariant['warnings'] = array_merge(
+                ['WINVALID' => 'This is not a valid HGVS description. Did you mean to write a substitution? Please rewrite "' . $aMatches[0] . '" to "' . $sFixedVariant . '".'],
+                $aVariant['warnings']
             );
             return $aVariant;
         }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3417,8 +3417,8 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
         }
     }
 
-    // Sometimes, RS numbers are sent. This block can be used for other IDs as well.
-    if (preg_match('/^(rs)[0-9]+$/', $sVariant, $aMatches)) {
+    // Sometimes, variant identifiers are sent.
+    if (preg_match('/^(rs|RCV|SCV|VCV)?[0-9]+(\.[0-9]+)?$/i', $sVariant, $aMatches)) {
         // E.g., rs123456.
         // Sad to see that we need to replicate the $aResponse array, but I don't think I have a better way to obtain it.
         return [
@@ -3431,7 +3431,10 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
                 'EINVALID' => 'This is not a valid HGVS description; it looks like ' .
                     ([
                         'rs' => 'a dbSNP',
-                    ][$aMatches[1]] ?? 'some variant') .
+                        'RCV' => 'a ClinVar reference',
+                        'SCV' => 'a ClinVar submission',
+                        'VCV' => 'a ClinVar variation',
+                    ][($aMatches[1] ?? '')] ?? 'some variant') .
                     ' identifier. Please provide a variant description following the HGVS nomenclature.',
             ],
         ];

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1728,6 +1728,11 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
             $aResponse['position_end_intron'] = 0;
             $aResponse['position_start_intron'] = 0;
         }
+
+        // None of these can be handled by VV. If we add that information here, LOVD won't try.
+        $aResponse['warnings']['WNOTSUPPORTED'] =
+            'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.';
+
         // For unknown variants (c.?), the type is set to NULL.
         // Otherwise, the type is ether '=' or '0'.
         $aResponse['type'] = substr(rtrim($aVariant['complete'], '?'), -1);

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1445,9 +1445,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
         } else {
             // The user seems to have tried to add a reference sequence, but it
             //  was not formatted correctly. We will return errors or warnings accordingly.
-            if ($bCheckHGVS) {
-                return false;
-            }
+
             // Check for missing version. We don't want to yet define another pattern.
             // Just check if it helps to add a version number.
             if (lovd_isValidRefSeq(preg_replace('/([0-9]{6})([()]|$)/', '$1.1$2', $sReferenceSequence))) {
@@ -1522,10 +1520,22 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     'Protein reference sequences are not supported.' .
                     ' Please submit a DNA variant using a DNA reference sequence.';
 
+            } elseif (preg_match('/^([A-Z][0-9]{5}|[A-Z]{2}[0-9]{6})(\.[0-9]+)$/', $sReferenceSequence)) {
+                // These are valid GenBank identifiers, but these are not supported by VV.
+                // It's too early to tell if the rest of the syntax is OK, though.
+                $aResponse['warnings']['WREFERENCENOTSUPPORTED'] =
+                    'Currently, variant descriptions using "' . $sReferenceSequence . '" are not yet supported.' .
+                    ' This does not necessarily mean the description is not valid HGVS.' .
+                    ' Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.';
+
             } else {
                 $aResponse['errors']['EREFERENCEFORMAT'] =
                     'The reference sequence could not be recognised.' .
                     ' Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.';
+            }
+
+            if ($bCheckHGVS) {
+                return (isset($aResponse['warnings']['WREFERENCENOTSUPPORTED']));
             }
         }
     }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3394,23 +3394,24 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
         // Variant doesn't have a prefix, e.g., 100A>T.
         // Figure out its most likely prefix, and test if we're at least getting an array back.
         $sPrefix = lovd_guessVariantPrefix($sReferenceSequence, $sVariant);
-        $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sPrefix . '.' . $sVariant, false);
+        $sFixedVariant = $sPrefix . '.' . $sVariant;
+        $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant, false);
         if ($aVariant) {
-            $aVariant['errors']['EPREFIXMISSING'] = 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "' . $sPrefix . '."). Please rewrite "' . $sVariant . '" to "' . $sPrefix . '.' . $sVariant . '".';
+            $aVariant['errors']['EPREFIXMISSING'] = 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "' . $sPrefix . '."). Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".';
             return $aVariant;
         }
     }
 
     if (preg_match('/^([cgmn]\.[0-9*-]+)([A-Z])$/i', $sVariant, $aMatches)) {
         // E.g., c.100A. Assuming this is a substitution, but we don't have the original base.
-        $sVariant =
+        $sFixedVariant =
             $aMatches[1] .
             (strtoupper($aMatches[2]) == 'A'? 'T' : 'A') . '>' .
             strtoupper($aMatches[2]);
-        $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sVariant);
+        $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant);
         if ($aVariant) {
             $aVariant['type'] = ''; // Note, we're not sure about the substitution.
-            $aVariant['errors']['EINVALID'] = 'This variant description seems incomplete. Did you mean to write a substitution? Substitutions are written like "' . $sVariant . '".';
+            $aVariant['errors']['EINVALID'] = 'This variant description seems incomplete. Did you mean to write a substitution? Substitutions are written like "' . $sFixedVariant . '".';
             return $aVariant;
         }
     }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3391,7 +3391,7 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
     //  provide a fix, it should return data instead.
 
     // First, try to pick up a protein notation that we sometimes receive.
-    if (preg_match('/^(p\.)?([A-Z]|[A-Z]{3})([0-9]+)([A-Z]|[A-Z]{3})$/i', $sVariant, $aMatches)) {
+    if (preg_match('/^(p\.)?([A-Z]|[A-Z][a-z]{2})([0-9]+)([A-Z]|[A-Z][a-z]{2})$/', $sVariant, $aMatches)) {
         // Double-check if this couldn't be a DNA description.
         if ($aMatches[1] // p. prefix given.
             || strlen($aMatches[2]) > 1 || !in_array(strtoupper($aMatches[2]), ['A', 'C', 'G', 'T']) // Three-letter amino-acid code or non-DNA nucleotide.

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3397,7 +3397,7 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
     //  meant for invalid descriptions. It is also similar to lovd_fixHGVS() in
     //  that it tries to figure out what the user meant, but it doesn't HAVE to
     //  provide a fix, it should return data instead.
-    global $_LIBRARIES;
+    global $_LIBRARIES, $_SETT;
 
     // First, try to pick up a protein notation that we sometimes receive.
     if (preg_match('/^(p\.)?([A-Z]|[A-Z][a-z]{2})([0-9]+)([A-Z]|[A-Z][a-z]{2})$/', $sVariant, $aMatches)) {
@@ -3435,6 +3435,13 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
             // But since we fixed the variant already, there shouldn't be any other issues, so we just overwrite everything.
             $aVariant['warnings'] = ['WINVALID' => 'This is not a valid HGVS description; it looks like a VCF-based description. Please rewrite "' . ($sReferenceSequence? $sReferenceSequence . ':' : '') . $sVariant . '" to "' . $sFixedVariant . '".'];
             $aVariant['errors'] = ['EREFSEQMISSING' => 'You indicated this variant is located on chromosome ' . $sChromosome . '. However, the HGVS nomenclature does not include chromosomes in variant descriptions, they are represented by reference sequences. Therefore, please provide a reference sequence for this chromosome.'];
+            if (!empty($_SETT['human_builds'])) {
+                foreach (array_slice(array_keys($_SETT['human_builds']), -2) as $sBuild) {
+                    if (!empty($_SETT['human_builds'][$sBuild]['ncbi_sequences'][$sChromosome])) {
+                        $aVariant['errors']['EREFSEQMISSING'] .= ' For ' . $sBuild . '/' . $_SETT['human_builds'][$sBuild]['ncbi_name'] . ', use ' . $_SETT['human_builds'][$sBuild]['ncbi_sequences'][$sChromosome] . '.';
+                    }
+                }
+            }
             return $aVariant;
         }
     }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1898,6 +1898,9 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
 
     } elseif ($aVariant['type'] == '?') {
         $aResponse['type'] = NULL;
+        // Throw a WNOTSUPPORTED. We are currently not sure if this variant is valid, as the refseq or the positions can still be a problem.
+        $aResponse['warnings']['WNOTSUPPORTED'] =
+            'This syntax is currently not supported for mapping and validation.';
 
     } else {
         $aResponse['type'] = $aVariant['type'];

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -2674,6 +2674,24 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                                     '(' . $nSuffixMinLength . '_' . $nSuffixMaxLength . ')') . ']")?';
                         }
 
+                    } elseif (preg_match('/^([A-Z]+)\[\(([0-9]+|\?)\)\]$/', strtoupper($sInsertion), $aRegs)) {
+                        // c.1_2insN[(10)].
+                        $bCaseOK = ($sInsertion == strtoupper($sInsertion));
+                        list(, $sSequence, $nSuffixLength) = $aRegs;
+
+                        // Check if only correct bases have been used.
+                        $sUnknownBases = preg_replace(
+                            '/' . $_LIBRARIES['regex_patterns']['bases']['alt'] . '+/',
+                            '',
+                            $sSequence
+                        );
+                        if ($sUnknownBases) {
+                            $aResponse['errors']['EINVALIDNUCLEOTIDES'] = 'This variant description contains invalid nucleotides: "' . implode('", "', str_split($sUnknownBases)) . '".';
+                        }
+                        $aResponse['warnings']['WSUFFIXFORMAT'] =
+                            'The part after "' . $aVariant['type'] . '" does not follow HGVS guidelines.' .
+                            ' Please rewrite "' . $sInsertion . '" to "' . $sSequence . '[' . $nSuffixLength . ']".';
+
                     } elseif (preg_match('/^([A-Z]+)\[(([0-9]+|\?)_([0-9]+|\?))\]$/', strtoupper($sInsertion), $aRegs)) {
                         // c.1_2insN[10_20].
                         $bCaseOK = ($sInsertion == strtoupper($sInsertion));

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1461,6 +1461,11 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     'The genomic and transcript reference sequence IDs have been swapped.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[2] . '(' . $aRegs[1] . ')".';
 
+            } elseif (preg_match('/^([NX][MR]_[0-9]{6,9}\.[0-9]+)\(([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)\)$/', $sReferenceSequence, $aRegs)) {
+                $aResponse['warnings']['WREFERENCEFORMAT'] =
+                    'The reference sequence ID should not include a gene symbol.' .
+                    ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . '".';
+
             } elseif (preg_match('/([NX][CGMRTW])-?([0-9]+)/', $sReferenceSequence, $aRegs)) {
                 // The user forgot the underscore or used a hyphen.
                 $aResponse['warnings']['WREFERENCEFORMAT'] =

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1534,8 +1534,8 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     ' Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.';
             }
 
-            if ($bCheckHGVS) {
-                return (isset($aResponse['warnings']['WREFERENCENOTSUPPORTED']));
+            if ($bCheckHGVS && !isset($aResponse['warnings']['WREFERENCENOTSUPPORTED'])) {
+                return false;
             }
         }
     }

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1504,6 +1504,11 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                     'Ensembl reference sequence IDs require 11 digits.' .
                     ' Please rewrite "' . $aRegs[0] . '" to "' . $aRegs[1] . str_pad($aRegs[2], 11, '0', STR_PAD_LEFT) . '.' . $aRegs[3] . '".';
 
+            } elseif (preg_match('/^NP_[0-9]+/', $sReferenceSequence)) {
+                $aResponse['errors']['EREFERENCEFORMAT'] =
+                    'Protein reference sequences are not supported.' .
+                    ' Please submit a DNA variant using a DNA reference sequence.';
+
             } else {
                 $aResponse['errors']['EREFERENCEFORMAT'] =
                     'The reference sequence could not be recognised.' .

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1519,7 +1519,7 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
     preg_match(
         '/^([cgmn])\.' .                         // 1.  Prefix.
 
-        '([?=0]$|(' .                            // 2. '?' or '=' (e.g. c.=).
+        '((?:[?=0]|0\?)$|(' .                    // 2. '?', '=', '0', or '0?' (e.g., c.0?).
         '(\({1,2})?' .              // 4=(       // 4.  Opening parentheses.
         '([-*]?[0-9]+|\?)' .                     // 5.  (Earliest) start position.
         '([-+]([0-9]+|\?))?' .                   // 6.  (Earliest) intronic start position.
@@ -1730,8 +1730,9 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
         }
         // For unknown variants (c.?), the type is set to NULL.
         // Otherwise, the type is ether '=' or '0'.
-        $aResponse['type'] = substr($aVariant['complete'], -1);
-        if ($aResponse['type'] == '?') {
+        $aResponse['type'] = substr(rtrim($aVariant['complete'], '?'), -1);
+        if ($aResponse['type'] == '.') {
+            // 'c.?' etc, I trimmed the '?' off to recognize 'c.0?'.
             $aResponse['type'] = NULL;
 
         } elseif ($aResponse['type'] == '=') {

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -1413,20 +1413,22 @@ function lovd_getVariantInfo ($sVariant, $sTranscriptID = '', $bCheckHGVS = fals
                 if ($bCheckHGVS) {
                     return false;
                 }
-                $aResponse['errors']['EWRONGREFERENCE'] =
-                    'The given reference sequence (' . $sReferenceSequence . ') does not match the DNA type (' . $sVariant[0] . ').' .
-                    ' For variants on ' . $sReferenceSequence . ', please use the ' . implode('. or ', $aPrefixesByRefSeq) . '. prefix.';
-                switch ($sVariant[0]) {
-                    case 'c':
-                    case 'n':
-                        $aResponse['errors']['EWRONGREFERENCE'] .=
-                            ' For ' . $sVariant[0] . '. variants, please use a ' . ($sVariant[0] == 'c'? '' : 'non-') . 'coding transcript reference sequence.';
-                        break;
-                    case 'g':
-                    case 'm':
-                        $aResponse['errors']['EWRONGREFERENCE'] .=
-                            ' For ' . $sVariant[0] . '. variants, please use a ' . ($sVariant[0] == 'g'? 'genomic' : 'mitochondrial') . ' reference sequence.';
-                        break;
+                if ($sVariant[1] == '.' && !ctype_digit($sVariant[0])) {
+                    $aResponse['errors']['EWRONGREFERENCE'] =
+                        'The given reference sequence (' . $sReferenceSequence . ') does not match the DNA type (' . $sVariant[0] . ').' .
+                        ' For variants on ' . $sReferenceSequence . ', please use the ' . implode('. or ', $aPrefixesByRefSeq) . '. prefix.';
+                    switch ($sVariant[0]) {
+                        case 'c':
+                        case 'n':
+                            $aResponse['errors']['EWRONGREFERENCE'] .=
+                                ' For ' . $sVariant[0] . '. variants, please use a ' . ($sVariant[0] == 'c'? '' : 'non-') . 'coding transcript reference sequence.';
+                            break;
+                        case 'g':
+                        case 'm':
+                            $aResponse['errors']['EWRONGREFERENCE'] .=
+                                ' For ' . $sVariant[0] . '. variants, please use a ' . ($sVariant[0] == 'g'? 'genomic' : 'mitochondrial') . ' reference sequence.';
+                            break;
+                    }
                 }
 
             } elseif (!preg_match('/^(N[CGTW]|LRG)/', $sReferenceSequence)

--- a/src/inc-lib-init.php
+++ b/src/inc-lib-init.php
@@ -3603,19 +3603,33 @@ function lovd_guessVariantInfo ($sReferenceSequence, $sVariant)
     }
 
     if (preg_match('/^([cgmn]\.)\[(.+)\]$/', $sVariant, $aMatches) && strpos($aMatches[2], ';') === false) {
-        // E.g., c.[100A>C]. Perhaps from people trying out the allele notation? There is no ';' in there, though.
-        // We don't currently handle the allele notation, so lovd_getVariantInfo() doesn't know what to do with this.
-        // Just remove the square brackets and try again.
-        $sFixedVariant =
-            $aMatches[1] . $aMatches[2];
-        $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant);
-        if ($aVariant) {
-            // Make sure this error comes first. If the fixed variant has errors as well, these need to come later.
-            $aVariant['warnings'] = array_merge(
-                ['WWRONGTYPE' => 'The allele syntax with square brackets is meant for multiple variants. Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".',],
-                $aVariant['warnings']
-            );
-            return $aVariant;
+        if (strpos($aMatches[2], ',') !== false) {
+            // E.g., c.[100A>C,101del]. This should have used a semicolon.
+            $sFixedVariant = str_replace(',', ';', $sVariant);
+            $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant);
+            if ($aVariant) {
+                // Make sure this error comes first. If the fixed variant has errors as well, these need to come later.
+                $aVariant['warnings'] = array_merge(
+                    ['WALLELEFORMAT' => 'The allele syntax uses semicolons (;) to separate variants, not commas. Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".',],
+                    $aVariant['warnings']
+                );
+                return $aVariant;
+            }
+
+        } else {
+            // E.g., c.[100A>C]. Perhaps from people trying out the allele notation? There is no ';' in there, though.
+            // We don't currently handle the allele notation, so lovd_getVariantInfo() doesn't know what to do with this.
+            // Just remove the square brackets and try again.
+            $sFixedVariant = $aMatches[1] . $aMatches[2];
+            $aVariant = lovd_getVariantInfo(($sReferenceSequence? $sReferenceSequence . ':' : '') . $sFixedVariant);
+            if ($aVariant) {
+                // Make sure this error comes first. If the fixed variant has errors as well, these need to come later.
+                $aVariant['warnings'] = array_merge(
+                    ['WWRONGTYPE' => 'The allele syntax with square brackets is meant for multiple variants. Please rewrite "' . $sVariant . '" to "' . $sFixedVariant . '".',],
+                    $aVariant['warnings']
+                );
+                return $aVariant;
+            }
         }
     }
 

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2024-05-23
- * For LOVD    : 3.0-30
+ * Modified    : 2024-10-29
+ * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Daan Asscheman <D.Asscheman@LUMC.nl>
@@ -85,31 +85,7 @@ function lovd_fixHGVS ($sVariant, $sType = '')
         if (in_array(strtolower($sVariant[0]), array('c', 'g', 'm', 'n'))) {
             $sType = strtolower($sVariant[0]);
         } else {
-            if (preg_match('/[0-9][+-][0-9]/', $sVariant)) {
-                // Variant doesn't have a prefix either, *and* there seems to be an
-                //  intronic position mentioned.
-                $sType = 'c';
-            } elseif ($sReference) {
-                // If can't get it from the variant, but we do have a refseq,
-                //  let that one do the talking!
-                if (preg_match('/^[NX]R_[0-9]/', $sReference)) {
-                    $sType = 'n';
-                } elseif (preg_match('/^(ENST|LRG_[0-9]+t|[NX]M_)[0-9]/', $sReference)) {
-                    $sType = 'c';
-                } elseif (preg_match('/^NC_(001807|012920)/', $sReference)) {
-                    $sType = 'm';
-                } else {
-                    $sType = 'g';
-                }
-            } elseif (preg_match('/([0-9]+)/', $sVariant, $aRegs)
-                && $aRegs[1] < 1000) {
-                // The first number in the variant description is lower than 1000.
-                // Most likely to be a coding variant.
-                $sType = 'c';
-            } else {
-                // Fine, we default to 'g'.
-                $sType = 'g';
-            }
+            $sType = lovd_guessVariantPrefix(rtrim($sReference, ':'), $sVariant);
         }
     }
 
@@ -266,7 +242,7 @@ function lovd_fixHGVS ($sVariant, $sType = '')
         } else {
             // If the prefix does not equal the expected type, we can be sure
             //  to try and add in the type instead. Perhaps the user accidentally
-            //  wrote down a 'g.' in the transcript field.
+            //  wrote down a 'g.' in the cDNA field.
             return lovd_fixHGVS($sReference . $sType . substr($sVariant, 1), $sType);
         }
 

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2016-01-22
- * Modified    : 2024-10-29
+ * Modified    : 2024-10-30
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -99,6 +99,9 @@ function lovd_fixHGVS ($sVariant, $sType = '')
     if (substr($sVariant, 0, 2) == $sType . ',') {
         $sVariant[1] = '.';
     }
+
+    // Replace double periods with one.
+    $sVariant = preg_replace('/\.+/', '.', $sVariant);
 
     // More special characters arising from copying variants from PDFs. Some journals decide to use specialized fonts to
     //  create markup for normal characters, such as the > in a substitution. This is a terrible idea, as

--- a/src/inc-lib-variants.php
+++ b/src/inc-lib-variants.php
@@ -179,7 +179,9 @@ function lovd_fixHGVS ($sVariant, $sType = '')
     }
 
     // Add prefix in case it is missing.
-    if (!in_array(strtolower($sVariant[0]), array('c', 'g', 'm', 'n'))) {
+    if (!in_array(strtolower($sVariant[0]), array('c', 'g', 'm', 'n'))
+        // But don't do that when the variant looks like it's a VCF-like format.
+        && !preg_match('/^([0-9]{1,2}|[XYM])[:-]([0-9]+)[:-]/', $sVariant)) {
         return lovd_fixHGVS($sReference . $sType . ($sVariant[0] == '.'? '' : '.') . $sVariant, $sType);
     }
 

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2024-10-02
+ * Modified    : 2024-10-29
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -178,6 +178,8 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
 
             // Superfluous suffixes.
             array('c.123delA', 'c.123del'),
+            array('c.123del[A]', 'c.123del'),
+            array('c.123del(A)', 'c.123del'),
             array('c.123delAA', 'c.123delAA'), // Unfixable.
             array('g.123del1', 'g.123del'),
             array('g.123del2', 'g.123del2'), // Unfixable.

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2024-05-01
- * For LOVD    : 3.0-30
+ * Modified    : 2024-10-02
+ * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -68,6 +68,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g.1_5delinsACT', 'g.1_5delinsACT'),
             array('g.1ACT[20]', 'g.1ACT[20]'),
             array('g.123=', 'g.123='),
+            array('c.0', 'c.0'),
             array('c.?', 'c.?'),
             array('c.123?', 'c.123?'),
 
@@ -303,6 +304,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
 
             // UNFIXABLE VARIANTS.
             array('', ''),
+            array('g.0', 'g.0'),
             array('g.1delinsA', 'g.1delinsA'),
             array('c.1AC[20]', 'c.1AC[20]'),
             array('c.1_2A>G', 'c.1_2A>G'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2024-10-29
+ * Modified    : 2024-10-30
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -303,6 +303,9 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g.[123A>C;124A>C]', 'g.[123A>C;124A>C]'),
             array('g.[123A>C(;)124A>C]', 'g.[123A>C(;)124A>C]'),
             array('g.[123A>C];[124A>C]', 'g.[123A>C];[124A>C]'),
+
+            // Multiple issues fixed in once.
+            array('C123A', 'c.123C>A'),
 
 
 

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -76,12 +76,14 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
 
 
             // FIXABLE VARIANTS.
-            // Missing prefixes that will be added.
+            // Missing or broken prefixes that will be fixed.
             array('123dup', 'c.123dup'),
             array('123456dup', 'g.123456dup'),
             array('(123dup)', 'c.(123dup)'),
             array('.123dup', 'c.123dup'),
             array('c123dup', 'c.123dup'),
+            array('c,123dup', 'c.123dup'),
+            array('c..123dup', 'c.123dup'),
             array('123-5dup', 'c.123-5dup'),
             array('NC_123456.1(NM_123456.1):1del', 'NC_123456.1(NM_123456.1):c.1del'),
 
@@ -93,7 +95,6 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g. 123_124insA', 'g.123_124insA'),
             array(' g.123del', 'g.123del'),
             array(':g.123del', 'g.123del'),
-            array('g,123del', 'g.123del'),
             array('c.–123del', 'c.-123del'),
             array('c.123—5del', 'c.123-5del'),
             array('c,123del', 'c.123del'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -91,6 +91,8 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             // Whitespace, other typos, and copy/paste errors.
             array('g. 123_124insA', 'g.123_124insA'),
             array(' g.123del', 'g.123del'),
+            array(':g.123del', 'g.123del'),
+            array('g,123del', 'g.123del'),
             array('c.–123del', 'c.-123del'),
             array('c.123—5del', 'c.123-5del'),
             array('c,123del', 'c.123del'),
@@ -179,6 +181,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
 
             // Superfluous suffixes.
             array('c.123delA', 'c.123del'),
+            array('c.123dela', 'c.123del'),
             array('c.123del[A]', 'c.123del'),
             array('c.123del(A)', 'c.123del'),
             array('c.123delAA', 'c.123delAA'), // Unfixable.
@@ -319,6 +322,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g.1del<unknown>', 'g.1del<unknown>'),
             array('g.=', 'g.='),
             array('c.1insA', 'c.1insA'),
+            array('g.1_2ins10', 'g.1_2ins10'),
             array('c.0_1del', 'c.0_1del'),
             array('g.0_1del', 'g.0_1del'),
             array('c.1_2ins', 'c.1_2ins'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2024-10-30
+ * Modified    : 2024-10-31
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -286,6 +286,8 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             // Issues with reference sequences.
             array('NC_12345.1:g.1del', 'NC_012345.1:g.1del'),
             array('NM_123456.1(NC_123456.1):c.100del', 'NC_123456.1(NM_123456.1):c.100del'),
+            array('NM_123456.1(GENE):c.100del', 'NM_123456.1:c.100del'),
+            array('NM_123456.1(GENE_v001):c.100del', 'NM_123456.1:c.100del'),
             array('NM123456.1:c.100del', 'NM_123456.1:c.100del'),
             array('NM-123456.1:c.100del', 'NM_123456.1:c.100del'),
             array('NM_00123456.1:c.100del', 'NM_123456.1:c.100del'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -69,6 +69,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g.1ACT[20]', 'g.1ACT[20]'),
             array('g.123=', 'g.123='),
             array('c.0', 'c.0'),
+            array('c.0?', 'c.0?'),
             array('c.?', 'c.?'),
             array('c.123?', 'c.123?'),
 

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -315,6 +315,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g.[123A>C;124A>C]', 'g.[123A>C;124A>C]'),
             array('g.[123A>C(;)124A>C]', 'g.[123A>C(;)124A>C]'),
             array('g.[123A>C];[124A>C]', 'g.[123A>C];[124A>C]'),
+            array('g.[123A>C,124A>C]', 'g.[123A>C;124A>C]'),
 
             // Multiple issues fixed in once.
             array('C123A', 'c.123C>A'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -311,6 +311,9 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
 
             // Multiple issues fixed in once.
             array('C123A', 'c.123C>A'),
+            array('1:1234567:A:C', 'g.1234567A>C'),
+            array('1:1234567:AA:CC', 'g.1234567_1234568delinsCC'),
+            array('X-1234567-AA-ATA', 'g.1234567_1234568insT'),
 
 
 

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -96,6 +96,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g. 123_124insA', 'g.123_124insA'),
             array(' g.123del', 'g.123del'),
             array(':g.123del', 'g.123del'),
+            array('g.[123del]', 'g.123del'),
             array('c.–123del', 'c.-123del'),
             array('c.123—5del', 'c.123-5del'),
             array('c,123del', 'c.123del'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -211,7 +211,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('g.1_2insN[(10_5)]', 'g.1_2insN[(5_10)]'),
             array('g.1_2insA[(10_10)]', 'g.1_2insA[10]'),
             array('g.1_2insN[(10_10)]', 'g.1_2insN[10]'),
-            array('g.1_2insNC123456.1:g.1_10', 'g.1_2ins[NC_123456.1:g.1_10]'),
+            array('g.1_2insNC123456.1:1_10', 'g.1_2ins[NC_123456.1:g.1_10]'),
             array('c.1_2ins[NC_000001.10:100_(300_200);400_500]',
                   'c.1_2ins[NC_000001.10:g.100_(200_300);400_500]'),
             array('c.1_2ins[NC_000001.10:100_(300_200);(400_500)]',

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -82,6 +82,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('(123dup)', 'c.(123dup)'),
             array('.123dup', 'c.123dup'),
             array('123-5dup', 'c.123-5dup'),
+            array('NC_123456.1(NM_123456.1):1del', 'NC_123456.1(NM_123456.1):c.1del'),
 
             // Wrong prefix, the size of the positions indicates it's a range,
             //  and the range is fixed to a single position.

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2024-11-01
+ * Modified    : 2024-11-04
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -82,6 +82,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('(123dup)', 'c.(123dup)'),
             array('.123dup', 'c.123dup'),
             array('c123dup', 'c.123dup'),
+            array('c:123dup', 'c.123dup'),
             array('c,123dup', 'c.123dup'),
             array('c..123dup', 'c.123dup'),
             array('123-5dup', 'c.123-5dup'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -220,6 +220,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
                   'c.1_2ins[NC_000001.10:g.(100_200)_300]'),
             array('g.((1_5)ins(50))', 'g.((1_5)insN[50])'),
             array('g.1_2ins[ACT;(20)]', 'g.1_2ins[ACT;N[20]]'),
+            array('g.(100_200)delN[(50)]', 'g.(100_200)delN[50]'),
             array('g.(100_200)del50', 'g.(100_200)delN[50]'),
             array('g.(100_200)del(50_50)', 'g.(100_200)delN[50]'),
             array('g.(100_200)del(60_50)', 'g.(100_200)delN[(50_60)]'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -202,6 +202,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('c.1_2ins[A]', 'c.1_2insA'),
             array('c.1_2ins[N]', 'c.1_2insN'),
             array('c.1_2ins(20)', 'c.1_2insN[20]'),
+            array('c.1_2ins[(20)]', 'c.1_2insN[20]'),
             array('c.1_2ins(20_50)', 'c.1_2insN[(20_50)]'),
             array('c.1_2ins(50_20)', 'c.1_2insN[(20_50)]'),
             array('g.1_2insA[5_10]', 'g.1_2insA[(5_10)]'),

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -81,6 +81,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('123456dup', 'g.123456dup'),
             array('(123dup)', 'c.(123dup)'),
             array('.123dup', 'c.123dup'),
+            array('c123dup', 'c.123dup'),
             array('123-5dup', 'c.123-5dup'),
             array('NC_123456.1(NM_123456.1):1del', 'NC_123456.1(NM_123456.1):c.1del'),
 

--- a/tests/unit_tests/FixHGVS.php
+++ b/tests/unit_tests/FixHGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-05-07
- * Modified    : 2024-10-31
+ * Modified    : 2024-11-01
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -288,6 +288,7 @@ class FixHGVSTest extends PHPUnit\Framework\TestCase
             array('NM_123456.1(NC_123456.1):c.100del', 'NC_123456.1(NM_123456.1):c.100del'),
             array('NM_123456.1(GENE):c.100del', 'NM_123456.1:c.100del'),
             array('NM_123456.1(GENE_v001):c.100del', 'NM_123456.1:c.100del'),
+            array('GENE(NM_123456.1):c.100del', 'NM_123456.1:c.100del'),
             array('NM123456.1:c.100del', 'NM_123456.1:c.100del'),
             array('NM-123456.1:c.100del', 'NM_123456.1:c.100del'),
             array('NM_00123456.1:c.100del', 'NM_123456.1:c.100del'),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3346,6 +3346,18 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('c123A>C', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(
+                    'WPREFIXFORMAT' => 'This variant description seems incomplete. Molecule types in variant descriptions should be followed by a period (e.g., "c."). Please rewrite "c123A>C" to "c.123A>C".',
+                ),
+                'errors' => array(),
+            )),
         );
     }
 }

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3173,6 +3173,16 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.1_2ins[AA123456.1:g.1_100]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WREFERENCENOTSUPPORTED' => 'Currently, variant descriptions using "AA123456.1" are not yet supported. This does not necessarily mean the description is not valid HGVS. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.',
+                ),
+                'errors' => array(),
+            )),
 
             // Non-DNA input.
             array('R123L', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2247,6 +2247,19 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                     'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
                 ),
             )),
+            array('g.(1_100)delN[(10)]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "N[(10)]" to "N[10]".',
+                ),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
             array('g.(1_100)del(100)', array(
                 'position_start' => 1,
                 'position_end' => 100,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2755,6 +2755,18 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                     'EWRONGREFERENCE' => 'The given reference sequence (NC_123456.1(NM_123456.1)) does not match the DNA type (g). For variants on NC_123456.1(NM_123456.1), please use the c. prefix. For g. variants, please use a genomic reference sequence.',
                 ),
             )),
+            array('NC_123456.1(NM_123456.1):1del', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EPREFIXMISSING' => 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "c."). Please rewrite "1del" to "c.1del".',
+                ),
+            )),
             array('NC_123456.1(NM_123456.1):c.1-1del', array(
                 'position_start' => 1,
                 'position_end' => 1,
@@ -3211,6 +3223,19 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                     'WWHITESPACE' => 'This variant description contains one or more whitespace characters (spaces, tabs, etc). Please remove these.',
                 ),
                 'errors' => array(),
+            )),
+            array('123A', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => '',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EPREFIXMISSING' => 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "c."). Please rewrite "123A" to "c.123A".',
+                    'EINVALID' => 'This variant description seems incomplete. Did you mean to write a substitution? Substitutions are written like "c.123T>A".',
+                ),
             )),
             array('g.123A', array(
                 'position_start' => 123,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -387,6 +387,17 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.1dela', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WWRONGCASE' => 'This is not a valid HGVS description, due to characters being in the wrong case. Please rewrite "dela" to "delA".',
+                    'WSUFFIXGIVEN' => 'Nothing should follow "del".',
+                ),
+                'errors' => array(),
+            )),
             array('g.1DELA', array(
                 'position_start' => 1,
                 'position_end' => 1,
@@ -397,6 +408,18 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                     'WSUFFIXGIVEN' => 'Nothing should follow "del".',
                 ),
                 'errors' => array(),
+            )),
+            array('g.1delZ', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WSUFFIXGIVEN' => 'Nothing should follow "del".',
+                ),
+                'errors' => array(
+                    'EINVALIDNUCLEOTIDES' => 'This variant description contains invalid nucleotides: "Z".',
+                ),
             )),
             array('g.1del<unknown>', array(
                 'position_start' => 1,
@@ -1162,6 +1185,14 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end' => 123,
                 'type' => '=',
                 'range' => false,
+                'warnings' => array(),
+                'errors' => array(),
+            )),
+            array('g.123_125=', array(
+                'position_start' => 123,
+                'position_end' => 125,
+                'type' => '=',
+                'range' => true,
                 'warnings' => array(),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2762,10 +2762,10 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end_intron' => 0,
                 'type' => 'del',
                 'range' => false,
-                'warnings' => array(),
-                'errors' => array(
-                    'EPREFIXMISSING' => 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "c."). Please rewrite "1del" to "c.1del".',
+                'warnings' => array(
+                    'WPREFIXMISSING' => 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "c."). Please rewrite "1del" to "c.1del".',
                 ),
+                'errors' => array(),
             )),
             array('NC_123456.1(NM_123456.1):c.1-1del', array(
                 'position_start' => 1,
@@ -3231,9 +3231,10 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end_intron' => 0,
                 'type' => '',
                 'range' => false,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WPREFIXMISSING' => 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "c."). Please rewrite "123A" to "c.123A".',
+                ),
                 'errors' => array(
-                    'EPREFIXMISSING' => 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "c."). Please rewrite "123A" to "c.123A".',
                     'EINVALID' => 'This variant description seems incomplete. Did you mean to write a substitution? Substitutions are written like "c.123T>A".',
                 ),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2024-10-02
+ * Modified    : 2024-10-29
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2112,6 +2112,32 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'type' => 'del',
                 'range' => true,
                 'warnings' => array(),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
+            array('g.(1_100)del(A)', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "(A)" to "A".',
+                ),
+                'errors' => array(),
+                'messages' => array(
+                    'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',
+                ),
+            )),
+            array('g.(1_100)del[A]', array(
+                'position_start' => 1,
+                'position_end' => 100,
+                'type' => 'del',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines. Please rewrite "[A]" to "A".',
+                ),
                 'errors' => array(),
                 'messages' => array(
                     'IPOSITIONRANGE' => 'This variant description contains uncertain positions.',

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3396,6 +3396,16 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                     'EREFSEQMISSING' => 'You indicated this variant is located on chromosome X. However, the HGVS nomenclature does not include chromosomes in variant descriptions, they are represented by reference sequences. Therefore, please provide a reference sequence for this chromosome.',
                 ),
             )),
+            array('rs123456', array(
+                'position_start' => 0,
+                'position_end' => 0,
+                'type' => '',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALID' => 'This is not a valid HGVS description; it looks like a dbSNP identifier. Please provide a variant description following the HGVS nomenclature.',
+                ),
+            )),
         );
     }
 }

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2988,6 +2988,18 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                     'EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.',
                 ),
             )),
+            array('NP_123456.1:c.1del', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EREFERENCEFORMAT' => 'Protein reference sequences are not supported. Please submit a DNA variant using a DNA reference sequence.',
+                ),
+            )),
             array('NM_123456.1(NC_123456.1):c.100del', array(
                 'position_start' => 100,
                 'position_end' => 100,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2024-11-01
+ * Modified    : 2024-11-04
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -904,7 +904,7 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'range' => false,
                 'warnings' => array(
                     'WWRONGTYPE' => 'A conversion should be described as a deletion-insertion. Please rewrite "con" to "delins".',
-                    'WSUFFIXFORMAT' => 'The part after "con" does not follow HGVS guidelines. Failed to recognize a valid sequence or position in "NC_000001.10:100_200".',
+                    'WSUFFIXFORMAT' => 'The part after "con" does not follow HGVS guidelines. Please rewrite "100_200" to "g.100_200".',
                 ),
                 'errors' => array(),
             )),
@@ -2044,7 +2044,7 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'type' => 'ins',
                 'range' => true,
                 'warnings' => array(
-                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Failed to recognize a valid sequence or position in "NC123456.1:g.1_10".',
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Please rewrite "NC123456" to "NC_123456".',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3062,6 +3062,48 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'errors' => array(),
             )),
 
+            // Non-DNA input.
+            array('R123L', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALID' => 'This variant description looks like a protein description, while we are expecting DNA input. Please double-check your input.',
+                ),
+            )),
+            array('p.R123L', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALID' => 'This variant description looks like a protein description, while we are expecting DNA input. Please double-check your input.',
+                ),
+            )),
+            array('Arg123Leu', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALID' => 'This variant description looks like a protein description, while we are expecting DNA input. Please double-check your input.',
+                ),
+            )),
+            array('p.Arg123Leu', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALID' => 'This variant description looks like a protein description, while we are expecting DNA input. Please double-check your input.',
+                ),
+            )),
+
             // Other errors or problems.
             array('c.0', array( // Although mostly undocumented on the HGVS site, this indicates no transcript was generated.
                 'position_start' => 0,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -2711,6 +2711,18 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                     'ENOTSUPPORTED' => 'Currently, variant descriptions of combined variants are not yet supported. This does not necessarily mean the description is not valid HGVS. Please submit your variants separately.',
                 ),
             )),
+            array('g.[123A>C,124A>C]', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => ';',
+                'range' => false,
+                'warnings' => array(
+                    'WALLELEFORMAT' => 'The allele syntax uses semicolons (;) to separate variants, not commas. Please rewrite "g.[123A>C,124A>C]" to "g.[123A>C;124A>C]".',
+                ),
+                'errors' => array(
+                    'ENOTSUPPORTED' => 'Currently, variant descriptions of combined variants are not yet supported. This does not necessarily mean the description is not valid HGVS. Please submit your variants separately.',
+                ),
+            )),
             array('g.1_qterdel', array(
                 'position_start' => 0,
                 'position_end' => 0,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,8 +4,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2024-05-01
- * For LOVD    : 3.0-30
+ * Modified    : 2024-10-02
+ * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmers : M. Kroon <m.kroon@lumc.nl>
@@ -3019,6 +3019,26 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
             )),
 
             // Other errors or problems.
+            array('c.0', array( // Although mostly undocumented on the HGVS site, this indicates no transcript was generated.
+                'position_start' => 0,
+                'position_end' => 0,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => '0',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(),
+            )),
+            array('g.0', array(
+                'position_start' => 0,
+                'position_end' => 0,
+                'type' => '0',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EWRONGTYPE' => 'The 0-allele is used to indicate there is no expression of a given transcript. This can not be used for genomic variants.',
+                ),
+            )),
             array('G.123dup', array(
                 'position_start' => 123,
                 'position_end' => 123,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3406,6 +3406,16 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                     'EINVALID' => 'This is not a valid HGVS description; it looks like a dbSNP identifier. Please provide a variant description following the HGVS nomenclature.',
                 ),
             )),
+            array('VCV000009325.130', array(
+                'position_start' => 0,
+                'position_end' => 0,
+                'type' => '',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALID' => 'This is not a valid HGVS description; it looks like a ClinVar variation identifier. Please provide a variant description following the HGVS nomenclature.',
+                ),
+            )),
         );
     }
 }

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -60,7 +60,7 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
             && (empty($aOutput['warnings'])
                 || empty(array_diff(
                         array_keys($aOutput['warnings']),
-                        array('WNOTSUPPORTED', 'WPOSITIONLIMIT', 'WTRANSCRIPTFOUND', 'WDIFFERENTREFSEQ')))
+                        array('WDIFFERENTREFSEQ', 'WNOTSUPPORTED', 'WPOSITIONLIMIT', 'WREFERENCENOTSUPPORTED', 'WTRANSCRIPTFOUND')))
             )) {
             $bHGVS = true;
         } else {
@@ -3160,6 +3160,16 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'range' => false,
                 'warnings' => array(
                     'WREFERENCEFORMAT' => 'Ensembl reference sequence IDs require 11 digits. Please rewrite "ENSG1234567890.1" to "ENSG01234567890.1".',
+                ),
+                'errors' => array(),
+            )),
+            array('AA123456.1:g.1del', array(
+                'position_start' => 1,
+                'position_end' => 1,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCENOTSUPPORTED' => 'Currently, variant descriptions using "AA123456.1" are not yet supported. This does not necessarily mean the description is not valid HGVS. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1231,7 +1231,9 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end_intron' => 0,
                 'type' => NULL,
                 'range' => false,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'This syntax is currently not supported for mapping and validation.',
+                ),
                 'errors' => array(),
             )),
 

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3029,6 +3029,16 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'warnings' => array(),
                 'errors' => array(),
             )),
+            array('c.0?', array( // Although mostly undocumented on the HGVS site, this indicates probably no transcript was generated.
+                'position_start' => 0,
+                'position_end' => 0,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => '0',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(),
+            )),
             array('g.0', array(
                 'position_start' => 0,
                 'position_end' => 0,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3399,6 +3399,16 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.[123del]', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WWRONGTYPE' => 'The allele syntax with square brackets is meant for multiple variants. Please rewrite "g.[123del]" to "g.123del".',
+                ),
+                'errors' => array(),
+            )),
             array('123A', array(
                 'position_start' => 123,
                 'position_end' => 123,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2024-10-29
+ * Modified    : 2024-10-30
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -3247,6 +3247,31 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'errors' => array(
                     'EINVALID' => 'This variant description seems incomplete. Did you mean to write a substitution? Substitutions are written like "g.123T>A".',
                 ),
+            )),
+            array('C123A', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(
+                    'WPREFIXMISSING' => 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "c."). Please rewrite "C123A" to "c.C123A".',
+                    'WINVALID' => 'This is not a valid HGVS description. Did you mean to write a substitution? Please rewrite "c.C123A" to "c.123C>A".',
+                ),
+                'errors' => array(),
+            )),
+            array('c.C123A', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(
+                    'WINVALID' => 'This is not a valid HGVS description. Did you mean to write a substitution? Please rewrite "c.C123A" to "c.123C>A".',
+                ),
+                'errors' => array(),
             )),
         );
     }

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -1150,7 +1150,9 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end' => 0,
                 'type' => '=',
                 'range' => false,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                ),
                 'errors' => array(
                     'EMISSINGPOSITIONS' => 'When using "=", please provide the position(s) that are unchanged.',
                 ),
@@ -1217,7 +1219,9 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end_intron' => 0,
                 'type' => NULL,
                 'range' => false,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                ),
                 'errors' => array(),
             )),
             array('c.123?', array(
@@ -3026,7 +3030,9 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end_intron' => 0,
                 'type' => '0',
                 'range' => false,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                ),
                 'errors' => array(),
             )),
             array('c.0?', array( // Although mostly undocumented on the HGVS site, this indicates probably no transcript was generated.
@@ -3036,7 +3042,9 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end_intron' => 0,
                 'type' => '0',
                 'range' => false,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                ),
                 'errors' => array(),
             )),
             array('g.0', array(
@@ -3044,7 +3052,9 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'position_end' => 0,
                 'type' => '0',
                 'range' => false,
-                'warnings' => array(),
+                'warnings' => array(
+                    'WNOTSUPPORTED' => 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.',
+                ),
                 'errors' => array(
                     'EWRONGTYPE' => 'The 0-allele is used to indicate there is no expression of a given transcript. This can not be used for genomic variants.',
                 ),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3448,6 +3448,18 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('c:123A>C', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(
+                    'WPREFIXFORMAT' => 'This is not a valid HGVS description. Molecule types in variant descriptions should be followed by a period (e.g., "c."). Please rewrite "c:123A>C" to "c.123A>C".',
+                ),
+                'errors' => array(),
+            )),
             array('c123A>C', array(
                 'position_start' => 123,
                 'position_end' => 123,

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3212,6 +3212,16 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.123A', array(
+                'position_start' => 123,
+                'position_end' => 123,
+                'type' => '',
+                'range' => false,
+                'warnings' => array(),
+                'errors' => array(
+                    'EINVALID' => 'This variant description seems incomplete. Did you mean to write a substitution? Substitutions are written like "g.123T>A".',
+                ),
+            )),
         );
     }
 }

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3183,6 +3183,17 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+            array('g.1_2ins[AA123456.1:1_100]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WREFERENCENOTSUPPORTED' => 'Currently, variant descriptions using "AA123456.1" are not yet supported. This does not necessarily mean the description is not valid HGVS. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.',
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Please rewrite "1_100" to "g.1_100".',
+                ),
+                'errors' => array(),
+            )),
 
             // Non-DNA input.
             array('R123L', array(

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2024-10-31
+ * Modified    : 2024-11-01
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -3033,6 +3033,18 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'range' => false,
                 'warnings' => array(
                     'WREFERENCEFORMAT' => 'The reference sequence ID should not include a gene symbol. Please rewrite "NM_123456.1(GENE_v001)" to "NM_123456.1".',
+                ),
+                'errors' => array(),
+            )),
+            array('GENE(NM_123456.1):c.100del', array(
+                'position_start' => 100,
+                'position_end' => 100,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'The reference sequence ID should not include a gene symbol. Please rewrite "GENE(NM_123456.1)" to "NM_123456.1".',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -3358,6 +3358,44 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 ),
                 'errors' => array(),
             )),
+
+            // Support some common non-HGVS descriptions.
+            array('1:1234567:A:C', array(
+                'position_start' => 1234567,
+                'position_end' => 1234567,
+                'type' => 'subst',
+                'range' => false,
+                'warnings' => array(
+                    'WINVALID' => 'This is not a valid HGVS description; it looks like a VCF-based description. Please rewrite "1:1234567:A:C" to "g.1234567A>C".',
+                ),
+                'errors' => array(
+                    'EREFSEQMISSING' => 'You indicated this variant is located on chromosome 1. However, the HGVS nomenclature does not include chromosomes in variant descriptions, they are represented by reference sequences. Therefore, please provide a reference sequence for this chromosome.',
+                ),
+            )),
+            array('1:1234567:AA:CC', array(
+                'position_start' => 1234567,
+                'position_end' => 1234568,
+                'type' => 'delins',
+                'range' => true,
+                'warnings' => array(
+                    'WINVALID' => 'This is not a valid HGVS description; it looks like a VCF-based description. Please rewrite "1:1234567:AA:CC" to "g.1234567_1234568delinsCC".',
+                ),
+                'errors' => array(
+                    'EREFSEQMISSING' => 'You indicated this variant is located on chromosome 1. However, the HGVS nomenclature does not include chromosomes in variant descriptions, they are represented by reference sequences. Therefore, please provide a reference sequence for this chromosome.',
+                ),
+            )),
+            array('X-1234567-AA-ATA', array(
+                'position_start' => 1234567,
+                'position_end' => 1234568,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WINVALID' => 'This is not a valid HGVS description; it looks like a VCF-based description. Please rewrite "X-1234567-AA-ATA" to "g.1234567_1234568insT".',
+                ),
+                'errors' => array(
+                    'EREFSEQMISSING' => 'You indicated this variant is located on chromosome X. However, the HGVS nomenclature does not include chromosomes in variant descriptions, they are represented by reference sequences. Therefore, please provide a reference sequence for this chromosome.',
+                ),
+            )),
         );
     }
 }

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2017-08-18
- * Modified    : 2024-10-30
+ * Modified    : 2024-10-31
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -3009,6 +3009,30 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'range' => false,
                 'warnings' => array(
                     'WREFERENCEFORMAT' => 'The genomic and transcript reference sequence IDs have been swapped. Please rewrite "NM_123456.1(NC_123456.1)" to "NC_123456.1(NM_123456.1)".',
+                ),
+                'errors' => array(),
+            )),
+            array('NM_123456.1(GENE):c.100del', array(
+                'position_start' => 100,
+                'position_end' => 100,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'The reference sequence ID should not include a gene symbol. Please rewrite "NM_123456.1(GENE)" to "NM_123456.1".',
+                ),
+                'errors' => array(),
+            )),
+            array('NM_123456.1(GENE_v001):c.100del', array(
+                'position_start' => 100,
+                'position_end' => 100,
+                'position_start_intron' => 0,
+                'position_end_intron' => 0,
+                'type' => 'del',
+                'range' => false,
+                'warnings' => array(
+                    'WREFERENCEFORMAT' => 'The reference sequence ID should not include a gene symbol. Please rewrite "NM_123456.1(GENE_v001)" to "NM_123456.1".',
                 ),
                 'errors' => array(),
             )),

--- a/tests/unit_tests/GetVariantInfoTest.php
+++ b/tests/unit_tests/GetVariantInfoTest.php
@@ -495,6 +495,16 @@ class GetVariantInfoTest extends PHPUnit\Framework\TestCase
                 'warnings' => array(),
                 'errors' => array(),
             )),
+            array('g.1_2insN[(10)]', array(
+                'position_start' => 1,
+                'position_end' => 2,
+                'type' => 'ins',
+                'range' => true,
+                'warnings' => array(
+                    'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines. Please rewrite "N[(10)]" to "N[10]".',
+                ),
+                'errors' => array(),
+            )),
             array('g.1_2ins(50)', array(
                 'position_start' => 1,
                 'position_end' => 2,


### PR DESCRIPTION
### Updates to the existing libraries (`lovd_getVariantInfo()`, `lovd_fixHGVS()`) and the creation of `lovd_guessVariantInfo()`.
- Add support for `c.0` and the like. This notation is only allowed as transcript variant, not for genomic sequences.
- Add support for `c.0?`.
- Mark some variants with `WNOTSUPPORTED` to stop processing with VV. These are not supported by VV, so if we mark them, the checkHGVS script won't send them to VV at all and mark the variants as green instead of red.
- Handle VV syntax errors better. If VV complains about the variant's syntax, but we thought it was valid HGVS, that means VV doesn't support what we do support. In that case, throw a `WNOTSUPPORTED`, instead. The checkHGVS interface will now mark these variants (e.g., `c.(123del)`) as green. Ideally, we catch these in `lovd_getVariantInfo()`, so we won't have to run VV at all.
- VV updated their transcript version warning; handle this. Instead of just updating what they use now, recognize it as well, next to what was already recognized. That way, we'll handle multiple versions of VV at the cost of slightly messier code.
- Add support for `del[A]` and `del(A)` variants.
- Add a `WNOTSUPPORTED` for `c.123?` and make sure VV handles this.
- Add `lovd_guessVariantInfo()` for recognizing malformed variants.
- Add `lovd_guessVariantPrefix()` that guesses the variant's prefix. It assumes the prefix isn't given. It checks the reference sequence and the variant description to predict the type of variant.
- Only throw an `EWRONGREFERENCE` when a prefix has been given.
- Add support for variants without prefixes.
- Don't overwrite `$sVariant` since we're using multiple `if()`s.
- Rename `EPREFIXMISSING` to `WPREFIXMISSING`, as it can be fixed.
- Enforce the order of errors and warnings. This way, `lovd_fixHGVS()` will be able to fix multiple renames in the proper order.
- Add support for `C123A` style of variant notation.
- Recognize protein substitution input and provide proper feedback. This is better than just returning false, which doesn't give the user any feedback about what's going on.
- Add tests for cases that are already handled but not tested yet.
- Improve handling of `EREFSEQ`.
- The VariantValidator error now always ends with a period.
- The checkHGVS interface handles this now not as an invalid variant anymore. Since the syntax-check was passed, it might be a valid variant. Instead, a warning is thrown explaining that the variant couldn't be further validated because VV didn't find the reference sequence.
- Update the protein description match to not match `c100dup`.
- Add support for `c100dup' style variants, missing a period.
- Add support for double colons in variant descriptions. Chose to implement this through `lovd_fixHGVS()` rather than `lovd_guessVariantInfo()`, as this way, it's easier.
- Add support for VCF-style variants, which sadly required some hacks.
- Specifically for the HGVS checker interface, add refseq info. This applies to VCF-style variants. Since we know the chromosome, we can suggest which NCs to use.
- Add support for dbSNP rs identifiers. Since they aren't variants, we can't convert them, the user has to provide the description.
- Add support for other variant identifiers.
- Give some proper feedback when users submit NP reference sequences.
- Also match protein changes with parentheses.
- Update the basic refseq check to support `NM_000001.1(GENE_v001)`.
- Improve flexibility in casing and handle `NM(GENE)` refseqs.
- Handle `GENE(NM)` refseqs, the gene should go.
- Add support for `c.1_2insN[(10)]`, which should lose the parentheses.
- Add support for `g.(100_200)delN[(50)]`, which should lose the parentheses.
- Throw a `WREFERENCENOTSUPPORTED` when GenBank identifiers are used. VV does not support them, but their syntax may otherwise be OK and now they were throwing an error.
- Update the HGVS syntax checker for `WREFERENCENOTSUPPORTED`. Consider it HGVS valid when only this was thrown, and prevent calling VV when this is thrown.
- Fix bug; when throwing `WREFERENCENOTSUPPORTED`, don't return true yet. Broken variants would otherwise return true on the quick test when using this type of reference sequence.
- Fix PHP error about a missing key. We could get an array back from `lovd_guessVariantInfo()` with a "messages" key, which is not included in `$aResponse` by default to save space. Perhaps that space saving wasn't a good idea, but anyway, now preventing errors when merging those two arrays.
- Add support for GenBank reference sequences inside insertions, too.
- Improve the checking of complex insertions to handle more errors. We can now fix a missing prefix in the inserted sequence when it's using a different refseq. The GenBank IDs that we now recognize now default to g. We may handle more issues as well, but added tests for the missing prefix issue.
- Fix bug; the check HGVS interface didn't recognize correct fixes anymore.
- Fix tests after recent code improvements.
- Add support for prefixes followed by a colon instead of a period.
- Add support for `g.[100del]`, which should lose the brackets.
- Add support for the allele syntax using commas.