### PR TITLE
Rebuild the HGVS-related libraries

### DIFF
--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -791,6 +791,27 @@ class HGVS
 
 
 
+class HGVS_Caret extends HGVS
+{
+    public array $patterns = [
+        // NOTE: The HGVS nomenclature hasn't clarified the "or" syntax well. It's likely a "moving target" and needs
+        //        clarification and an improved definition in the HGVS nomenclature. Until then, we won't support it.
+        'anything' => [ '/.*\^.+/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->data['type'] = '^';
+        $this->messages['ENOTSUPPORTED'] = 'Currently, variant descriptions using "^" are not yet supported. This does not necessarily mean the description is not valid according to the HGVS nomenclature.';
+        $this->setCorrectedValue($this->value);
+    }
+}
+
+
+
+
+
 class HGVS_DNAAllele extends HGVS
 {
     public array $components = [];
@@ -2915,6 +2936,7 @@ class HGVS_DNAVariantBody extends HGVS
         'null'                => [ 'HGVS_DNANull', [] ],
         'allele_trans'        => [ '[', 'HGVS_DNAAllele', '];[', 'HGVS_DNAAllele', ']', [] ],
         'allele_cis'          => [ '[', 'HGVS_DNAAllele', ']', [] ],
+        'or'                  => [ 'HGVS_DNAPositions', 'HGVS_Caret', [] ],
         'somatic'             => [ 'HGVS_DNAPositions', 'HGVS_DNAVariantType', 'HGVS_DNASomaticVariant', [] ],
         'other'               => [ 'HGVS_DNAPositions', 'HGVS_DNAVariantType', [] ],
         'unknown'             => [ 'HGVS_DNAUnknown', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2479,6 +2479,8 @@ class HGVS_ReferenceSequence extends HGVS
         'ensembl_transcript'          => [ '/(ENST)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
         'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
         'LRG_genomic'                 => [ '/(LRG)([_-]?)([0-9]+)/', [] ],
+        // Because I do actually want to match something so we can validate the variant itself, match anything.
+        'other'                       => [ '/[^:]+/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
     ];
 
     public function validate ()
@@ -2676,6 +2678,11 @@ class HGVS_ReferenceSequence extends HGVS
                     $this->messages['WREFERENCEFORMAT'] =
                         'LRG reference sequence IDs require an underscore between the prefix and the numeric ID.';
                 }
+                break;
+
+            case 'other':
+                $this->molecule_type = 'unknown';
+                $this->allowed_prefixes = [];
                 break;
         }
     }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1920,19 +1920,12 @@ class HGVS_DNAPosition extends HGVS
             $this->position_limits[3] = 0;
 
         } elseif (in_array($this->matched_pattern, ['pter', 'qter'])) {
-            if (!in_array($sVariantPrefix, ['g', 'm'])) {
-                if (isset($VariantPrefix->getMessages()['EPREFIXMISSING']) || isset($VariantPrefix->getMessages()['WPREFIXMISSING'])) {
-                    // Actually the prefix is missing completely. In that case, remove all suggestions that aren't g.
-                    //  and m. and just leave it.
-                    foreach (array_keys($VariantPrefix->corrected_values) as $sPrefix) {
-                        if (!in_array($sPrefix, ['g', 'm'])) {
-                            unset($VariantPrefix->corrected_values[$sPrefix]);
-                        }
-                    }
-                } else {
-                    // There really was a prefix, so complain that they used the wrong one.
-                    $this->messages['EWRONGPREFIX'] = 'Chromosomal positions pter and qter can only be reported using "g." or "m." genomic prefixes.';
-                }
+            if (isset($VariantPrefix->getMessages()['EPREFIXMISSING']) || isset($VariantPrefix->getMessages()['WPREFIXMISSING'])) {
+                // Actually the prefix is missing completely. In that case, set its value to g. and just leave it.
+                $VariantPrefix->setCorrectedValue('g');
+            } elseif ($sVariantPrefix != 'g') {
+                // There really was a prefix, so complain that they used the wrong one.
+                $this->messages['EWRONGPREFIX'] = 'Chromosomal positions pter and qter can only be reported using the "g." genomic prefix.';
             }
             $RefSeq = $this->getParentProperty('ReferenceSequence');
             if ($RefSeq && $RefSeq->molecule_type != 'chromosome') {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1871,6 +1871,8 @@ class HGVS_DNAVariantBody extends HGVS
         'con_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
         'con'                 => [ 'HGVS_DNAPositions', 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
         'unknown'             => [ 'HGVS_DNAUnknown', [] ],
+        'wildtype_with_pos'   => [ 'HGVS_DNAPositions', 'HGVS_DNAWildType', [] ],
+        'wildtype'            => [ 'HGVS_DNAWildType', [] ],
     ];
 
     public function validate ()
@@ -1909,6 +1911,23 @@ class HGVS_DNAVariantBody extends HGVS
                 unset($this->messages['WSUFFIXGIVEN']);
             }
         }
+    }
+}
+
+
+
+
+
+class HGVS_DNAWildType extends HGVS
+{
+    public array $patterns = [
+        [ '=', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->data['type'] = $this->getCorrectedValue();
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2973,7 +2973,7 @@ class HGVS_ReferenceSequence extends HGVS
         'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
         'LRG_genomic'                 => [ '/(LRG)([_-]?)([0-9]+)/', [] ],
         // Because I do actually want to match something so we can validate the variant itself, match anything.
-        'other'                       => [ '/[^:\[\]]+(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
+        'other'                       => [ '/[^:\[\]]{2,}(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4607,6 +4607,7 @@ class HGVS_VCF extends HGVS
         'with_build' => [ 'HGVS_Genome', 'HGVS_VCFSeparator', 'HGVS_Chromosome', 'HGVS_VCFSeparator', 'HGVS_VCFBody', [] ],
         'with_chr'   => [ 'HGVS_Chromosome', 'HGVS_VCFSeparator', 'HGVS_VCFBody', ['WREFSEQMISSING' => 'This VCF variant is missing a genome build, which is required to determine the reference sequence used.'] ],
         'basic'      => [ 'HGVS_VCFBody', ['EREFSEQMISSING' => 'This VCF variant is missing a genome build and chromosome, which is required to determine the reference sequence used.'] ],
+        'full_SPDI'  => [ 'HGVS_ReferenceSequence', 'HGVS_VCFSeparator', 'HGVS_VCFBody', [] ],
     ];
 
     public function validate ()
@@ -4614,6 +4615,18 @@ class HGVS_VCF extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         if ($this->matched_pattern == 'basic') {
             $this->corrected_values = $this->buildCorrectedValues('g.', $this->VCFBody->getCorrectedValues());
+        } elseif ($this->matched_pattern == 'full_SPDI') {
+            // SPDI is VCF-like syntax, but with a normal reference sequence attached.
+            // It lacks a prefix, so we need to generate it.
+            // We'll take whatever prefix is suggested by the reference sequence.
+            $this->Prefix = new HGVS_DNAPrefix(':', $this, $this->debugging); // We deliberately don't provide the value.
+            $this->corrected_values = $this->buildCorrectedValues(
+                $this->ReferenceSequence->getCorrectedValues(),
+                ':',
+                $this->Prefix->getCorrectedValues(),
+                '.',
+                $this->VCFBody->getCorrectedValues()
+            );
         } else {
             // The build is not needed; the Chromosome object has used it already.
             $this->corrected_values = $this->buildCorrectedValues(

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -607,6 +607,24 @@ class HGVS_DNAAllele extends HGVS
 
 
 
+class HGVS_Chr extends HGVS
+{
+    public array $patterns = [
+        [ '/chr/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue(strtolower($this->value));
+        $this->caseOK = ($this->value == $this->getCorrectedValue());
+    }
+}
+
+
+
+
+
 class HGVS_DNACon extends HGVS
 {
     public array $patterns = [

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3812,6 +3812,30 @@ class HGVS_ProteinPrefix extends HGVS
 
 
 
+class HGVS_ProteinRef extends HGVS
+{
+    public array $patterns = [
+        'valid_long'   => [ '/(Ala|Cys|Asp|Glu|Phe|Gly|His|Ile|Lys|Leu|Met|Asn|Pro|Gln|Arg|Ser|Thr|Sec|Val|Trp|Xaa|Tyr|Ter)/', [] ],
+        'invalid_long' => [ '/[A-Z][a-z]{2}/', [] ],
+        'valid_short'  => [ '/[AC-IK-NP-Y*]/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        if ($this->matched_pattern == 'valid_short') {
+            $this->setCorrectedValue(strtoupper($this->value));
+        } else {
+            $this->setCorrectedValue(strtoupper($this->value[0]) . strtolower(substr($this->value, 1)));
+        }
+        $this->caseOK = ($this->value == $this->getCorrectedValue());
+    }
+}
+
+
+
+
+
 class HGVS_Variant extends HGVS
 {
     public array $patterns = [

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2627,8 +2627,20 @@ class HGVS_DNAWildType extends HGVS
 class HGVS_Dot extends HGVS
 {
     public array $patterns = [
-        [ '.', [] ],
+        'something' => [ '/[:.,]+/', [] ],
+        'nothing'   => [ '/(?=[(0-9*-])/', [] ],
     ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue('.');
+        if ($this->value != $this->getCorrectedValue()) {
+            $Prefix = ($this->getParentProperty('DNAPrefix') ?: ($this->getParentProperty('RNAPrefix') ?: $this->getParentProperty('ProteinPrefix')));
+            $sPrefix = ($Prefix? $Prefix->getCorrectedValue() : 'g');
+            $this->messages['WPREFIXFORMAT'] = 'Molecule types in variant descriptions should be followed by a period (e.g., "' . $sPrefix . '.").';
+        }
+    }
 }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3634,6 +3634,7 @@ class HGVS_DNAVariantType extends HGVS
         'unknown'             => [ 'HGVS_DNAUnknown', [ 'EINVALID' => 'This variant description seems incomplete.' ] ],
         'wildtype_with_refs'  => [ 'HGVS_DNARefs', 'HGVS_DNAWildType', [] ],
         'wildtype'            => [ 'HGVS_DNAWildType', [] ],
+        'refs'                => [ '/[ACGTN]$/', [] ], // We only want to match valid nucleotides to prevent false positives.
     ];
 
     public function validate ()
@@ -3826,6 +3827,31 @@ class HGVS_DNAVariantType extends HGVS
             );
             $this->parent->corrected_values = $this->VCF->getCorrectedValues();
             $this->messages['WPOSITIONSCORRECTED'] = "The variant's positions have been corrected.";
+
+        } elseif ($this->matched_pattern == 'refs') {
+            // E.g., c.100A. Assuming this is some kind of allele statement, but we don't have the original base.
+            $this->caseOK = ($this->value == strtoupper($this->value));
+            $this->value = strtoupper($this->value);
+            // This could be a substitution...
+            $this->corrected_values = $this->buildCorrectedValues(
+                [
+                    'A' => 0.25,
+                    'C' => 0.25,
+                    'G' => 0.25,
+                    'T' => 0.25,
+                ],
+                '>',
+                $this->value
+            );
+            // Or a reference call.
+            $this->addCorrectedValue('=', 0.25);
+            // But not A>A.
+            unset($this->corrected_values[$this->value . '>' . $this->value]);
+            // Also inform the user properly.
+            $this->messages['WINVALID'] = 'This variant description seems incomplete. Did you mean to write a substitution?' .
+                ' Substitutions are written like "' . $Positions->getCorrectedValue() . $this->getCorrectedValue() . '".' .
+                ' Alternatively, did you mean to indicate this position was unchanged?' .
+                ' That is written like "' . $Positions->getCorrectedValue() . '=".';
         }
     }
 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1520,7 +1520,14 @@ class HGVS_DNAInsSuffix extends HGVS
 
         // Store the corrected value.
         if ($this->hasProperty('ReferenceSequence')) {
-            if ($this->matched_pattern == 'refseq_only') {
+            // Do some additional checks. The problem is that "ins10" can match "10" as "chr10",
+            //  and obviously, that makes no sense.
+            if ($this->ReferenceSequence->getProperties() == ['Chromosome']
+                && $this->ReferenceSequence->Chromosome->getProperties() == ['ChromosomeNumber']) {
+                // Just a number got interpreted as a chromosome. Block.
+                return 0; // Break out of this pattern only.
+
+            } elseif ($this->matched_pattern == 'refseq_only') {
                 // Try to reconstruct what's needed.
                 // Analyze the reference sequence to predict the prefixes.
                 $this->DNAPrefix = new HGVS_DNAPrefix(':', $this, $this->debugging);

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3846,6 +3846,7 @@ class HGVS_ReferenceSequence extends HGVS
         'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)([({[]?)(t)([0-9]+)([)}\]]?)/', [] ],
         'LRG_genomic'                 => [ '/(LRG)([_-]?)([0-9]+)/', [] ],
         'build_and_chr'               => [ 'HGVS_Genome', 'HGVS_VCFSeparator', 'HGVS_Chromosome', [] ],
+        'build(chr)'                  => [ 'HGVS_Genome', '(', 'HGVS_Chromosome', ')', [] ],
         'chr'                         => [ 'HGVS_Chromosome', [] ],
         // Because I do actually want to match something so we can validate the variant itself, match anything.
         'other'                       => [ '/([^:;\[\]]{2,})?(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
@@ -4100,6 +4101,7 @@ class HGVS_ReferenceSequence extends HGVS
                 break;
 
             case 'build_and_chr':
+            case 'build(chr)':
             case 'chr':
                 $this->molecule_type = 'chromosome';
                 $this->allowed_prefixes = [($this->Chromosome->ChromosomeNumber->getCorrectedValue() == 'M'? 'm' : 'g')];

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1529,6 +1529,7 @@ class HGVS_DNAPipeSuffix extends HGVS
 {
     public array $patterns = [
         'met=' => [ '/met=/', [] ],
+        'met'  => [ '/met/', [] ],
         'gom'  => [ '/gom/', [] ],
         'lom'  => [ '/lom/', [] ],
     ];
@@ -1538,6 +1539,10 @@ class HGVS_DNAPipeSuffix extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->setCorrectedValue(strtolower($this->value));
         $this->caseOK = ($this->value == $this->getCorrectedValue());
+        if ($this->matched_pattern == 'met') {
+            $this->appendCorrectedValue('=');
+            $this->messages['WMETFORMAT'] = 'To report normal methylation, use "met=".';
+        }
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2024-12-19
+ * Modified    : 2024-12-20
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1507,6 +1507,44 @@ class HGVS_DNANull extends HGVS
 
 
 
+class HGVS_DNAPipe extends HGVS
+{
+    public array $patterns = [
+        [ '|', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue('|');
+        $this->data['type'] = 'met'; // Generalized to methylation-related variants.
+    }
+}
+
+
+
+
+
+class HGVS_DNAPipeSuffix extends HGVS
+{
+    public array $patterns = [
+        'met=' => [ '/met=/', [] ],
+        'gom'  => [ '/gom/', [] ],
+        'lom'  => [ '/lom/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue(strtolower($this->value));
+        $this->caseOK = ($this->value == $this->getCorrectedValue());
+    }
+}
+
+
+
+
+
 class HGVS_DNAPosition extends HGVS
 {
     public array $patterns = [
@@ -2361,6 +2399,7 @@ class HGVS_DNAVariantBody extends HGVS
         'inv'                 => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'con_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
         'con'                 => [ 'HGVS_DNAPositions', 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
+        'pipe'                => [ 'HGVS_DNAPositions', 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
         'unknown'             => [ 'HGVS_DNAUnknown', [] ],
         'wildtype_with_pos'   => [ 'HGVS_DNAPositions', 'HGVS_DNAWildType', [] ],
         'wildtype'            => [ 'HGVS_DNAWildType', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2505,6 +2505,19 @@ class HGVS_DNAVariantBody extends HGVS
                 $this->data['type'] = ';';
             }
         }
+
+        // Handle somatic variants here. It's way easier for us that way.
+        if ($this->matched_pattern == 'somatic') {
+            // The second part should be something different.
+            $PartA = $this->DNAVariantType;
+            $PartB = $this->DNASomaticVariant->DNAVariantType;
+            if ($PartA->getCorrectedValue() == $PartB->getCorrectedValue()) {
+                // Throw a warning, and remove everything after the slash.
+                $this->messages['WSOMATICEQUAL'] = 'The somatic variant contains two equal variant descriptions.';
+                $this->DNASomaticVariant->setCorrectedValue('');
+            }
+        }
+
         // Delins variants deserve some additional attention.
         // Based on the REF and ALT info, we may need to shift the variant or change it to a different type.
         if ($this->matched_pattern == 'delXins_with_suffix'

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -264,9 +264,15 @@ class HGVS
                 $b = $this->validate();
                 if ($b === 0) {
                     // This is a request to just skip this pattern.
+                    if ($bDebugging) {
+                        print("$sClassString matched but was told to abandon matching this pattern during validation.\n");
+                    }
                     $this->matched = false;
                 } elseif ($b === false) {
                     // This is a request to break this entire object.
+                    if ($bDebugging) {
+                        print("$sClassString matched but was told to abandon matching this whole class during validation.\n");
+                    }
                     $this->matched = false;
                     break;
                 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2777,11 +2777,11 @@ class HGVS_DNAPositions extends HGVS
 class HGVS_DNAPrefix extends HGVS
 {
     public array $patterns = [
-        'coding'        => [ '/c/', [] ],
-        'genomic'       => [ '/g/', [] ],
-        'mitochondrial' => [ '/m/', [] ],
-        'non-coding'    => [ '/n/', [] ],
-        'circular'      => [ '/o/', [] ],
+        'coding'        => [ '/c(?![A-Z])/', [] ],
+        'genomic'       => [ '/g(?![A-Z])/', [] ],
+        'mitochondrial' => [ '/m(?![A-Z])/', [] ],
+        'non-coding'    => [ '/n(?![A-Z])/', [] ],
+        'circular'      => [ '/o(?![A-Z])/', [] ],
         'nothing'       => [ 'HGVS_Dot', [] ],
     ];
 
@@ -4287,7 +4287,7 @@ class HGVS_RNAAlts extends HGVS_DNAAlts
 class HGVS_RNAPrefix extends HGVS
 {
     public array $patterns = [
-        'RNA'     => [ '/r/', [] ],
+        'RNA'     => [ '/r(?![A-Z])/', [] ],
         'nothing' => [ 'HGVS_Dot', [] ],
     ];
 
@@ -4410,7 +4410,7 @@ class HGVS_ProteinPositionPosition extends HGVS
 class HGVS_ProteinPrefix extends HGVS
 {
     public array $patterns = [
-        'protein' => [ '/p/', [] ],
+        'protein' => [ '/p(?![A-Z])/', [] ],
         'nothing' => [ 'HGVS_Dot', [] ],
     ];
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1308,7 +1308,7 @@ class HGVS_DNAIns extends HGVS
                 $this->messages['EPOSITIONFORMAT'] =
                     'An insertion must be provided with the two positions between which the insertion has taken place.';
 
-            } elseif (!$Positions->uncertain && $Positions->getLengths() != [2,2]) {
+            } elseif (!$Positions->uncertain && $Positions->getCorrectedValue() != '?_?' && $Positions->getLengths() != [2,2]) {
                 // An insertion must always get two positions which are next to each other,
                 //  since the inserted nucleotides will be placed in the middle of those.
                 $this->messages['WPOSITIONSNOTFORINS'] =

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -698,7 +698,7 @@ class HGVS_DNADelSuffix extends HGVS
 
         // Remove any complaints that HGVS_Length may have had, when we already threw a WSUFFIXFORMAT.
         if (isset($this->messages['WSUFFIXFORMAT'])) {
-            unset($this->messages['WLENGTHFORMAT']);
+            unset($this->messages['WLENGTHFORMAT'], $this->messages['WLENGTHORDER'], $this->messages['WSAMELENGTHS']);
         }
 
         // Don't check anything about the suffix length when there are problems with the positions.
@@ -751,6 +751,11 @@ class HGVS_DNADelSuffix extends HGVS
                         " Please adjust either the variant's positions or the given deleted sequence.";
                 }
             }
+        }
+
+        // In case of any error, remove WSUFFIXFORMAT.
+        if (array_filter(array_keys($this->messages), function ($sKey) { return ($sKey[0] == 'E'); })) {
+            unset($this->messages['WSUFFIXFORMAT']);
         }
 
         // Store the corrected value.
@@ -883,7 +888,7 @@ class HGVS_DNAInsSuffix extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         // Remove any complaints that HGVS_Length may have had, when we already threw a WSUFFIXFORMAT.
         if (isset($this->messages['WSUFFIXFORMAT'])) {
-            unset($this->messages['WLENGTHFORMAT']);
+            unset($this->messages['WLENGTHFORMAT'], $this->messages['WLENGTHORDER'], $this->messages['WSAMELENGTHS']);
         }
 
         // A deletion-insertion of one base to one base, is a substitution.
@@ -965,6 +970,11 @@ class HGVS_DNAInsSuffix extends HGVS
                     '[', $this->DNAInsSuffixComplex->getCorrectedValues(), ']'
                 );
             }
+        }
+
+        // In case of any error, remove WSUFFIXFORMAT.
+        if (array_filter(array_keys($this->messages), function ($sKey) { return ($sKey[0] == 'E'); })) {
+            unset($this->messages['WSUFFIXFORMAT']);
         }
     }
 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-03
+ * Modified    : 2025-01-06
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1074,6 +1074,23 @@ class HGVS_DNAAlts extends HGVS
                 $this->setCorrectedValue(str_replace('U', 'T', $this->getCorrectedValue()));
             }
         }
+    }
+}
+
+
+
+
+
+class HGVS_DNACNV extends HGVS
+{
+    public array $patterns = [
+        [ '[', 'HGVS_Lengths', ']', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->data['type'] = 'cnv';
     }
 }
 
@@ -3183,6 +3200,7 @@ class HGVS_DNAVariantType extends HGVS
         'inv'                 => [ 'HGVS_DNAInv', [] ],
         'con_with_suffix'     => [ 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
         'con'                 => [ 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
+        'cnv'                 => [ 'HGVS_DNACNV', [] ],
         'repeat'              => [ 'HGVS_DNARepeat', [] ],
         'pipe_with_refs'      => [ 'HGVS_DNARefs', 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
         'pipe'                => [ 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1598,6 +1598,7 @@ class HGVS_DNANull extends HGVS
 
 class HGVS_DNAPipe extends HGVS
 {
+    use HGVS_CheckBasesGiven; // Gives us checkBasesGiven().
     public array $patterns = [
         'pipe(s)' => [ '/\|+/', [] ],
         'nothing' => [ 'HGVS_DNAPipeSuffix', [] ],
@@ -1608,6 +1609,9 @@ class HGVS_DNAPipe extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->setCorrectedValue('|');
         $this->data['type'] = 'met'; // Generalized to methylation-related variants.
+
+        // Check any possible Refs compared to the positions. If they match, complain about the given Refs.
+        $this->checkBasesGiven();
 
         if ($this->matched_pattern == 'nothing') {
             // This description doesn't use a pipe, but should.
@@ -2539,6 +2543,7 @@ class HGVS_DNASub extends HGVS
 
 class HGVS_DNAUnknown extends HGVS
 {
+    use HGVS_CheckBasesGiven; // Gives us checkBasesGiven().
     public array $patterns = [
         [ '?', [] ],
     ];
@@ -2547,6 +2552,8 @@ class HGVS_DNAUnknown extends HGVS
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->data['type'] = $this->getCorrectedValue();
+        // Check any possible Refs compared to the positions. If they match, complain about the given Refs.
+        $this->checkBasesGiven();
     }
 }
 
@@ -2857,6 +2864,7 @@ class HGVS_DNAVariantType extends HGVS
 
 class HGVS_DNAWildType extends HGVS
 {
+    use HGVS_CheckBasesGiven; // Gives us checkBasesGiven().
     public array $patterns = [
         [ '=', [] ],
     ];
@@ -2865,6 +2873,8 @@ class HGVS_DNAWildType extends HGVS
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->data['type'] = $this->getCorrectedValue();
+        // Check any possible Refs compared to the positions. If they match, complain about the given Refs.
+        $this->checkBasesGiven();
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3606,7 +3606,7 @@ class HGVS_Dot extends HGVS
 {
     public array $patterns = [
         'something' => [ '/[:.,]+/', [] ],
-        'nothing'   => [ '/(?=[(A-Z0-9*-])/', [] ],
+        'nothing'   => [ '/(?=[[(A-Z0-9*-])/', [] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1476,6 +1476,7 @@ class HGVS_DNAInsSuffix extends HGVS
     public array $patterns = [
         'refseq_with_positions_inv'        => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.' ] ],
         'refseq_with_positions'            => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.' ] ],
+        'refseq_only'                      => [ 'HGVS_ReferenceSequence', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.', 'EPOSITIONSMISSING' => 'The insertion of a reference sequence also requires the positions of the sequence taken from this reference sequence.' ] ],
         'complex_in_brackets'              => [ '[', 'HGVS_DNAInsSuffixComplex', ']', [] ],
         'positions_inverted'               => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'positions'                        => [ 'HGVS_DNAPositions', [] ],
@@ -1519,6 +1520,19 @@ class HGVS_DNAInsSuffix extends HGVS
 
         // Store the corrected value.
         if ($this->hasProperty('ReferenceSequence')) {
+            if ($this->matched_pattern == 'refseq_only') {
+                // Try to reconstruct what's needed.
+                // Analyze the reference sequence to predict the prefixes.
+                $this->DNAPrefix = new HGVS_DNAPrefix(':', $this, $this->debugging);
+                $this->corrected_values = $this->buildCorrectedValues(
+                    ['' => 0.1], // Make sure the confidence is only 1% (10% here times 10% for having an error).
+                    $this->ReferenceSequence->getCorrectedValues(),
+                    ':',
+                    $this->DNAPrefix->getCorrectedValues(),
+                    '.1_1000' // Just a random range, as an example.
+                );
+            }
+
             if (get_class($this) == 'HGVS_DNAInsSuffix') {
                 // This required square brackets. I threw the warning already.
                 $this->corrected_values = $this->buildCorrectedValues(

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1038,8 +1038,14 @@ class HGVS_DNANull extends HGVS
         $sVariantPrefix = $this->getParent('HGVS_Variant')->DNAPrefix->getCorrectedValue();
         $this->data['position_start'] = 0;
         $this->data['position_end'] = 0;
-        $this->data['position_start_intron'] = 0;
-        $this->data['position_end_intron'] = 0;
+        if (in_array($sVariantPrefix, ['g', 'm'])) {
+            // This is only allowed for transcript-based reference sequences, as it's a consequence of a genomic change
+            //  (a deletion or so). It indicates the lack of expression of the transcript.
+            $this->messages['EWRONGTYPE'] = 'The 0-allele is used to indicate there is no expression of a given transcript. This can not be used for genomic variants.';
+        } else {
+            $this->data['position_start_intron'] = 0;
+            $this->data['position_end_intron'] = 0;
+        }
         $this->data['range'] = false;
     }
 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2024-12-05
+ * Modified    : 2024-12-06
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -550,6 +550,17 @@ class HGVS_DNADel extends HGVS
 
 
 
+class HGVS_DNADup extends HGVS_DNADel
+{
+    public array $patterns = [
+        [ '/dup/', [] ],
+    ];
+}
+
+
+
+
+
 class HGVS_DNAAlts extends HGVS
 {
     public array $patterns = [
@@ -675,6 +686,7 @@ class HGVS_DNADelSuffix extends HGVS
         }
     }
 }
+class HGVS_DNADupSuffix extends HGVS_DNADelSuffix {}
 
 
 
@@ -1761,6 +1773,8 @@ class HGVS_DNAVariantBody extends HGVS
         'del'                 => [ 'HGVS_DNAPositions', 'HGVS_DNADel', [] ],
         'ins_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', [] ],
         'ins'                 => [ 'HGVS_DNAPositions', 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for insertions.' ] ],
+        'dup_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNADup', 'HGVS_DNADupSuffix', [] ],
+        'dup'                 => [ 'HGVS_DNAPositions', 'HGVS_DNADup', [] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -295,7 +295,7 @@ class HGVS
 
         // If we have not matched, fail completely.
         if (!$this->matched) {
-            $this->messages['EFAIL'] = 'Failed to recognize a HGVS nomenclature-compliant variant description in your input.';
+            $this->messages = ['EFAIL' => 'Failed to recognize a HGVS nomenclature-compliant variant description in your input.'];
         }
     }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -591,6 +591,8 @@ class HGVS_DNAAlts extends HGVS
 
 class HGVS_DNADelSuffix extends HGVS
 {
+    // NOTE: This class is used for deletion and duplication suffixes. By default, all messages speak of deletions.
+    //       When handling duplications, the code will fix the messages. This keeps the code very simple.
     use HGVS_DNASequence; // Gets us getSequence() and getLengths().
     public array $patterns = [
         // Since none of these match "ins", a "delAinsC" won't ever pass here.
@@ -683,6 +685,28 @@ class HGVS_DNADelSuffix extends HGVS
                 (!$this->Length->getCorrectedValues()? '' :
                     $this->buildCorrectedValues('[', $this->Length->getCorrectedValues(), ']'))
             );
+        }
+
+        // Now, handle the duplication suffixes.
+        // It's much more efficient to handle deletion suffixes and duplication suffixes in just one class.
+        // HGVS_DNADupSuffix extends this class, and, therefore, inherits all patterns, checks, and validations.
+        // However, all warnings and errors are now talking about deletions. Fix this by simply replacing the words.
+        if (get_class($this) == 'HGVS_DNADupSuffix') {
+            // We have to fix all messages now.
+            foreach ($this->messages as $sCode => $sMessage) {
+                $this->messages[$sCode] = str_replace(
+                    [
+                        '"del"',
+                        'deletion',
+                        'deleted',
+                    ], [
+                        '"dup"',
+                        'duplication',
+                        'duplicated',
+                    ],
+                    $sMessage
+                );
+            }
         }
     }
 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -794,6 +794,17 @@ class HGVS
             if (!$this->caseOK) {
                 $this->messages['WWRONGCASE'] = 'This is not a valid HGVS description, due to characters being in the wrong case.';
             }
+
+            if (get_class($this) == 'HGVS') {
+                // Something we can only do here; handle a missing reference sequence followed by a colon. E.g., ":c.10del".
+                if (isset($this->messages['EREFERENCEFORMAT']) && $this->ReferenceSequence->getCorrectedValue() == '') {
+                    $this->messages['WREFERENCEFORMAT'] = 'A colon was given, but no reference sequence was found.';
+                    unset($this->messages['EREFERENCEFORMAT']);
+                    // A simple, yet effective solution. Simply remove the refseq and the colon from the pattern.
+                    array_shift($this->patterns[$this->matched_pattern]);
+                    array_shift($this->patterns[$this->matched_pattern]);
+                }
+            }
         }
     }
 }
@@ -3765,7 +3776,7 @@ class HGVS_ReferenceSequence extends HGVS
         'build_and_chr'               => [ 'HGVS_Genome', 'HGVS_VCFSeparator', 'HGVS_Chromosome', [] ],
         'chr'                         => [ 'HGVS_Chromosome', [] ],
         // Because I do actually want to match something so we can validate the variant itself, match anything.
-        'other'                       => [ '/[^:;\[\]]{2,}(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
+        'other'                       => [ '/([^:;\[\]]{2,})?(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1430,6 +1430,37 @@ class HGVS_DNAInv extends HGVS
 
 
 
+class HGVS_DNAInvSuffix extends HGVS_DNADelSuffix
+{
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        parent::validate();
+
+        // It's much more efficient to handle deletion suffixes and inversion suffixes in just one class.
+        // Therefore, we extend the HGVS_DNADelSuffix class, and inherit all patterns, checks, and validations.
+        // However, all warnings and errors are now talking about deletions. Fix this by simply replacing the words.
+        foreach ($this->messages as $sCode => $sMessage) {
+            $this->messages[$sCode] = str_replace(
+                [
+                    '"del"',
+                    'deletion',
+                    'deleted',
+                ], [
+                    '"inv"',
+                    'inversion',
+                    'inverted',
+                ],
+                $sMessage
+            );
+        }
+    }
+}
+
+
+
+
+
 class HGVS_DNANull extends HGVS
 {
     public array $patterns = [
@@ -2312,6 +2343,7 @@ class HGVS_DNAVariantBody extends HGVS
         'ins'                 => [ 'HGVS_DNAPositions', 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for insertions.' ] ],
         'dup_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNADup', 'HGVS_DNADupSuffix', [] ],
         'dup'                 => [ 'HGVS_DNAPositions', 'HGVS_DNADup', [] ],
+        'inv_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', 'HGVS_DNAInvSuffix', [] ],
         'inv'                 => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'con_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
         'con'                 => [ 'HGVS_DNAPositions', 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1304,6 +1304,17 @@ class HGVS_DNADelSuffix extends HGVS
                     $this->messages['ESUFFIXTOOSHORT'] =
                         "The variant's positions indicate a sequence that's longer than the given deleted sequence." .
                         " Please adjust either the variant's positions or the given deleted sequence.";
+                    if ($bPositionLengthIsCertain && $bSuffixLengthIsCertain) {
+                        // Do this only when there are no uncertainties at all.
+                        // Otherwise, c.100_200delN[(10_1000)] also gets here.
+                        // Now, what's left, is stuff like c.100_200delA.
+                        // Johan mentioned that sometimes people do c.1_4delAA when they mean c.2_3 was deleted.
+                        // I don't know how often this happens, but I don't want to make too many assumptions.
+                        // Also, it's impossible here to make complex predictions since we're deep into the objects.
+                        // Just simplify by running makeUncertain().
+                        // We're throwing an error, so the predicted values have a low confidence.
+                        $Positions->makeUncertain();
+                    }
                 }
                 if ($nMaxLengthVariant && $nMaxLengthSuffix > $nMaxLengthVariant) {
                     $this->messages['ESUFFIXTOOLONG'] =

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1908,6 +1908,7 @@ class HGVS_ReferenceSequence extends HGVS
         'refseq_gene_with_non-coding' => [ '/(?:[A-Z][A-Za-z0-9#@-]*)\(([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
         'ensembl_genomic'             => [ '/(ENSG)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
         'ensembl_transcript'          => [ '/(ENST)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
+        'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
     ];
 
     public function validate ()
@@ -2036,6 +2037,24 @@ class HGVS_ReferenceSequence extends HGVS
                     $this->messages['EREFERENCEFORMAT'] =
                         'The reference sequence ID is missing the required version number.' .
                         ' NCBI RefSeq and Ensembl IDs require version numbers when used in variant descriptions.';
+                }
+                break;
+
+            case 'LRG_transcript':
+                $this->molecule_type = 'genome_transcript';
+                $this->setCorrectedValue(
+                    strtoupper($this->regex[1]) .
+                    '_' .
+                    (int) $this->regex[3] .
+                    strtolower($this->regex[4]) .
+                    (int) $this->regex[5]
+                );
+                $this->caseOK = ($this->regex[1] == strtoupper($this->regex[1])
+                    && $this->regex[4] == strtolower($this->regex[4]));
+
+                if (($this->regex[2] ?? '') != '_') {
+                    $this->messages['WREFERENCEFORMAT'] =
+                        'LRG reference sequence IDs require an underscore between the prefix and the numeric ID.';
                 }
                 break;
         }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1149,6 +1149,7 @@ class HGVS_DNAInsSuffix extends HGVS
     use HGVS_DNASequence; // Gets us getSequence() and getLengths().
     public array $patterns = [
         'complex_in_brackets'              => [ '[', 'HGVS_DNAInsSuffixComplex', ']', [] ],
+        'positions_inverted'               => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'positions'                        => [ 'HGVS_DNAPositions', [] ],
         'length_in_brackets'               => [ '[', 'HGVS_Length', ']', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
         'sequence_with_number'             => [ 'HGVS_DNAAlts', 'HGVS_Length', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
@@ -1221,6 +1222,10 @@ class HGVS_DNAInsSuffix extends HGVS
             } else {
                 // Anything else, we'll interpret as positions.
                 $this->corrected_values = $this->DNAPositions->getCorrectedValues();
+            }
+
+            if ($this->matched_pattern == 'positions_inverted') {
+                $this->appendCorrectedValue($this->DNAInv->getCorrectedValue());
             }
 
         } elseif (isset($this->DNAAlts) && !isset($this->Length)) {
@@ -1365,6 +1370,7 @@ class HGVS_DNAInsSuffixComplexComponent extends HGVS
         'positions_with_refseq'     => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', '.', 'HGVS_DNAPositions', [] ],
         'sequence_with_length'      => [ 'HGVS_DNAAlts', '[', 'HGVS_Length', ']', [] ],
         'sequence'                  => [ 'HGVS_DNAAlts', [] ],
+        'positions_inverted'        => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'positions'                 => [ 'HGVS_DNAPositions', [] ],
     ];
 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -182,7 +182,7 @@ class HGVS
                 $this->patterns[$sPatternName] = array_merge($aPattern, [$aMessages]);
             }
 
-            if ($sInputToParse) {
+            if ($sInputToParse !== '') {
                 // We matched everything, but there is a suffix, something left that didn't match.
                 // In the main HGVS object, this is a problem. Otherwise, this is what we have to return to the parent.
                 $this->value = substr($sValue, 0, -strlen($sInputToParse));

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1501,15 +1501,15 @@ class HGVS_DNAInsSuffix extends HGVS
             if ($this->DNAPositions->unknown && !$this->DNAPositions->range) {
                 // E.g., ins? or ins(?).
                 $this->setCorrectedValue('N[?]', 0.8); // We're not really sure that was what's meant.
-                $this->messages['WSUFFIXFORMAT'] = 'The part after "' . $this->parent->getData()['type'] . '" does not follow HGVS guidelines.' .
-                    ' To report an insertion of an unknown number of nucleotides, use "' . $this->parent->getData()['type'] . $this->getCorrectedValue() . '".';
+                $this->messages['WSUFFIXFORMAT'] = 'The part after "ins" does not follow HGVS guidelines.' .
+                    ' To report an insertion of an unknown number of nucleotides, use "' . $this->getCorrectedValue() . '".';
                 // Also remove the possible warning given by the Positions object. It doesn't like "(?)".
                 unset($this->messages['WTOOMANYPARENS']);
 
             } elseif (!$this->DNAPositions->intronic && !$this->DNAPositions->UTR && !$this->DNAPositions->range) {
                 // E.g., ins10 or ins(10). We will only interpret this as a length.
                 $this->setCorrectedValue('N[' . $this->DNAPositions->getCorrectedValue() . ']');
-                $this->messages['WSUFFIXFORMAT'] = 'The part after "' . $this->parent->getData()['type'] . '" does not follow HGVS guidelines.';
+                $this->messages['WSUFFIXFORMAT'] = 'The part after "ins" does not follow HGVS guidelines.';
                 // Also remove the possible warning given by the Positions object. It doesn't like "(10)".
                 unset($this->messages['WTOOMANYPARENS']);
 
@@ -1517,11 +1517,11 @@ class HGVS_DNAInsSuffix extends HGVS
                 && !$this->DNAPositions->DNAPositionStart->range && !$this->DNAPositions->DNAPositionEnd->range) {
                 // E.g., ins(10_20). Can be lengths (60% certainty) or positions (40% certainty).
                 $this->setCorrectedValue('N[' . $this->DNAPositions->getCorrectedValue() . ']', 0.6);
-                $this->messages['WSUFFIXFORMAT'] = 'The part after "' . $this->parent->getData()['type'] . '" does not follow HGVS guidelines.' .
-                    ' To report an insertion of an uncertain number of nucleotides, use "' . $this->parent->getData()['type'] . $this->getCorrectedValue() . '".';
+                $this->messages['WSUFFIXFORMAT'] = 'The part after "ins" does not follow HGVS guidelines.' .
+                    ' To report an insertion of an uncertain number of nucleotides, use "' . $this->getCorrectedValue() . '".';
                 $this->DNAPositions->makeCertain();
                 $this->addCorrectedValue($this->DNAPositions->getCorrectedValue(), 0.4);
-                $this->messages['WSUFFIXFORMAT'] .= ' To refer to the inserted sequence using an uncertain range of positions, use "' . $this->parent->getData()['type'] . array_keys($this->getCorrectedValues())[1] . '".';
+                $this->messages['WSUFFIXFORMAT'] .= ' To refer to the inserted sequence using an uncertain range of positions, use "' . array_keys($this->getCorrectedValues())[1] . '".';
                 // Also remove the possible warning given by the Positions object. It doesn't like "((10)_(20))".
                 unset($this->messages['WTOOMANYPARENS']);
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4888,6 +4888,12 @@ class HGVS_VCFRefs extends HGVS_DNARefs
         // Provide additional rules for validation, and stores values for the variant info if needed.
         if ($this->matched_pattern == 'nothing') {
             $this->value = '.';
+        } else {
+            // To prevent "30N." to match anything, make sure the REF is followed by a separator.
+            if (!preg_match('/[>: -]/', $this->getSuffix())) {
+                // Followed by something else than a separator, nope.
+                return false; // Break out of the entire object.
+            }
         }
         return parent::validate();
     }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3236,6 +3236,40 @@ class HGVS_ReferenceSequence extends HGVS
 
 
 
+class HGVS_RNAPrefix extends HGVS
+{
+    public array $patterns = [
+        'RNA'     => [ '/r/', [] ],
+        'nothing' => [ 'HGVS_Dot', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->molecule_type = 'transcript';
+        $this->setCorrectedValue(strtolower($this->value));
+        $this->caseOK = ($this->value == $this->getCorrectedValue());
+
+        if ($this->matched_pattern == 'nothing') {
+            $this->setCorrectedValue('r');
+            $this->suffix = $this->input; // Reset the suffix in case HGVS_Dot took something.
+            $this->messages['WPREFIXMISSING'] = 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "' . $this->getCorrectedValue() . '.").';
+        }
+
+        // If we have seen a reference sequence, check if we match that.
+        $RefSeq = $this->getParentProperty('ReferenceSequence');
+        if ($RefSeq && $RefSeq->molecule_type != $this->molecule_type) {
+            $this->messages['EWRONGREFERENCE'] =
+                'The given reference sequence (' . $RefSeq->getCorrectedValue() . ') does not match the RNA type (' . $this->getCorrectedValue() . ').' .
+                ' For ' . $this->getCorrectedValue() . '. variants, please use a ' . $this->molecule_type . ' reference sequence.';
+        }
+    }
+}
+
+
+
+
+
 class HGVS_Variant extends HGVS
 {
     public array $patterns = [

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1112,7 +1112,17 @@ class HGVS_DNACNV extends HGVS
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
-        $this->data['type'] = 'cnv';
+
+        if (!$this->Lengths->getCorrectedValue()) {
+            // The length was 1, and this has been corrected away.
+            // Here, we interpret this as a WT variant.
+            $this->data['type'] = '=';
+            $this->messages['WWRONGTYPE'] = 'Did you mean to describe an unchanged sequence?';
+            $this->setCorrectedValue('=');
+
+        } else {
+            $this->data['type'] = 'cnv';
+        }
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-08
+ * Modified    : 2025-01-15
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -908,14 +908,14 @@ class HGVS_DNAAllele extends HGVS
 class HGVS_Chr extends HGVS
 {
     public array $patterns = [
-        [ '/chr/', [] ],
+        [ '/chr(omosome)?/', [] ],
     ];
 
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
-        $this->setCorrectedValue(strtolower($this->value));
-        $this->caseOK = ($this->value == $this->getCorrectedValue());
+        $this->setCorrectedValue('chr');
+        $this->caseOK = ($this->value == strtolower($this->value));
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2689,6 +2689,21 @@ class HGVS_VCF extends HGVS
         'with_chr'   => [ 'HGVS_Chromosome', 'HGVS_VCFSeparator', 'HGVS_VCFBody', ['WREFSEQMISSING' => 'This VCF variant is missing a genome build, which is required to determine the reference sequence used.'] ],
         'basic'      => [ 'HGVS_VCFBody', ['EREFSEQMISSING' => 'This VCF variant is missing a genome build and chromosome, which is required to determine the reference sequence used.'] ],
     ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        if ($this->matched_pattern == 'basic') {
+            $this->corrected_values = $this->buildCorrectedValues('g.', $this->VCFBody->getCorrectedValues());
+        } else {
+            // The build is not needed; the Chromosome object has used it already.
+            $this->corrected_values = $this->buildCorrectedValues(
+                $this->Chromosome->getCorrectedValues(),
+                ':g.',
+                $this->VCFBody->getCorrectedValues()
+            );
+        }
+    }
 }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1035,22 +1035,22 @@ class HGVS_DNADel extends HGVS
 
 class HGVS_DNADelSuffix extends HGVS
 {
-    // NOTE: This class is used for deletion and duplication suffixes. By default, all messages speak of deletions.
-    //       When handling duplications, the code will fix the messages. This keeps the code very simple.
+    // NOTE: This class is used for deletion, duplication, and inversion suffixes. By default, all messages speak of
+    //       deletions. When handling other variants, the code will fix the messages. This keeps the code very simple.
     use HGVS_DNASequence; // Gets us getSequence() and getLengths().
     public array $patterns = [
         // Since none of these match "ins", a "delAinsC" won't ever pass here.
-        [ 'HGVS_Length', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '[', 'HGVS_Length', ']', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ 'HGVS_DNARefs', 'HGVS_Length', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ 'HGVS_DNARefs', '[', 'HGVS_Length', ']', [] ],
+        [ 'HGVS_Lengths', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
+        [ '[', 'HGVS_Lengths', ']', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
+        [ 'HGVS_DNARefs', 'HGVS_Lengths', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
+        [ 'HGVS_DNARefs', '[', 'HGVS_Lengths', ']', [] ],
         [ 'HGVS_DNARefs', [] ],
         [ '(', 'HGVS_DNARefs', ')', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '(', 'HGVS_DNARefs', 'HGVS_Length', ')', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '(', 'HGVS_DNARefs', '[', 'HGVS_Length', '])', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
+        [ '(', 'HGVS_DNARefs', 'HGVS_Lengths', ')', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
+        [ '(', 'HGVS_DNARefs', '[', 'HGVS_Lengths', '])', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
         [ '[', 'HGVS_DNARefs', ']', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '[', 'HGVS_DNARefs', 'HGVS_Length', ']', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '[', 'HGVS_DNARefs', '[', 'HGVS_Length', ']]', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
+        [ '[', 'HGVS_DNARefs', 'HGVS_Lengths', ']', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
+        [ '[', 'HGVS_DNARefs', '[', 'HGVS_Lengths', ']]', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
     ];
 
     public function validate ()
@@ -1059,9 +1059,9 @@ class HGVS_DNADelSuffix extends HGVS
         $Positions = $this->getParentProperty('DNAPositions');
         $aMessages = $Positions->getMessages();
 
-        // Remove any complaints that HGVS_Length may have had, when we already threw a WSUFFIXFORMAT.
+        // Remove any complaints that HGVS_Lengths may have had, when we already threw a WSUFFIXFORMAT.
         if (isset($this->messages['WSUFFIXFORMAT'])) {
-            unset($this->messages['WLENGTHFORMAT'], $this->messages['WLENGTHORDER'], $this->messages['WSAMELENGTHS']);
+            unset($this->messages['WLENGTHFORMAT'], $this->messages['WLENGTHORDER'], $this->messages['WSAMELENGTHS'], $this->messages['WTOOMANYPARENS']);
         }
 
         // Don't check anything about the suffix length when there are problems with the positions.
@@ -1126,13 +1126,13 @@ class HGVS_DNADelSuffix extends HGVS
             // The suffix should be removed.
             // NOTE: This is not true for delAinsG, but we don't know that here yet.
             $this->setCorrectedValue('');
-        } elseif (!isset($this->Length)) {
+        } elseif (!isset($this->Lengths)) {
             $this->corrected_values = $this->DNARefs->getCorrectedValues();
         } else {
             $this->corrected_values = $this->buildCorrectedValues(
                 (isset($this->DNARefs)? $this->DNARefs->getCorrectedValues() : 'N'),
-                (!$this->Length->getCorrectedValues()? '' :
-                    $this->buildCorrectedValues('[', $this->Length->getCorrectedValues(), ']'))
+                (!$this->Lengths->getCorrectedValues()? '' :
+                    $this->buildCorrectedValues('[', $this->Lengths->getCorrectedValues(), ']'))
             );
         }
     }
@@ -1254,24 +1254,24 @@ class HGVS_DNAInsSuffix extends HGVS
         'complex_in_brackets'              => [ '[', 'HGVS_DNAInsSuffixComplex', ']', [] ],
         'positions_inverted'               => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'positions'                        => [ 'HGVS_DNAPositions', [] ],
-        'length_in_brackets'               => [ '[', 'HGVS_Length', ']', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_number'             => [ 'HGVS_DNAAlts', 'HGVS_Length', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_length'             => [ 'HGVS_DNAAlts', '[', 'HGVS_Length', ']', [] ],
+        'length_in_brackets'               => [ '[', 'HGVS_Lengths', ']', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
+        'sequence_with_number'             => [ 'HGVS_DNAAlts', 'HGVS_Lengths', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
+        'sequence_with_length'             => [ 'HGVS_DNAAlts', '[', 'HGVS_Lengths', ']', [] ],
         'sequence'                         => [ 'HGVS_DNAAlts', [] ],
         'sequence_in_parens'               => [ '(', 'HGVS_DNAAlts', ')', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_number_in_parens'   => [ '(', 'HGVS_DNAAlts', 'HGVS_Length', ')', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_length_in_parens'   => [ '(', 'HGVS_DNAAlts', '[', 'HGVS_Length', '])', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
+        'sequence_with_number_in_parens'   => [ '(', 'HGVS_DNAAlts', 'HGVS_Lengths', ')', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
+        'sequence_with_length_in_parens'   => [ '(', 'HGVS_DNAAlts', '[', 'HGVS_Lengths', '])', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
         'sequence_in_brackets'             => [ '[', 'HGVS_DNAAlts', ']', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_number_in_brackets' => [ '[', 'HGVS_DNAAlts', 'HGVS_Length', ']', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_length_in_brackets' => [ '[', 'HGVS_DNAAlts', '[', 'HGVS_Length', ']]', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
+        'sequence_with_number_in_brackets' => [ '[', 'HGVS_DNAAlts', 'HGVS_Lengths', ']', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
+        'sequence_with_length_in_brackets' => [ '[', 'HGVS_DNAAlts', '[', 'HGVS_Lengths', ']]', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
     ];
 
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
-        // Remove any complaints that HGVS_Length may have had, when we already threw a WSUFFIXFORMAT.
+        // Remove any complaints that HGVS_Lengths may have had, when we already threw a WSUFFIXFORMAT.
         if (isset($this->messages['WSUFFIXFORMAT'])) {
-            unset($this->messages['WLENGTHFORMAT'], $this->messages['WLENGTHORDER'], $this->messages['WSAMELENGTHS']);
+            unset($this->messages['WLENGTHFORMAT'], $this->messages['WLENGTHORDER'], $this->messages['WSAMELENGTHS'], $this->messages['WTOOMANYPARENS']);
         }
 
         // A deletion-insertion of one base to one base, is a substitution.
@@ -1331,14 +1331,14 @@ class HGVS_DNAInsSuffix extends HGVS
                 $this->appendCorrectedValue($this->DNAInv->getCorrectedValue());
             }
 
-        } elseif (isset($this->DNAAlts) && !isset($this->Length)) {
+        } elseif (isset($this->DNAAlts) && !isset($this->Lengths)) {
             $this->corrected_values = $this->DNAAlts->getCorrectedValues();
 
-        } elseif (isset($this->Length)) {
+        } elseif (isset($this->Lengths)) {
             $this->corrected_values = $this->buildCorrectedValues(
                 (isset($this->DNAAlts)? $this->DNAAlts->getCorrectedValues() : 'N'),
-                (!$this->Length->getCorrectedValues()? '' :
-                    $this->buildCorrectedValues('[', $this->Length->getCorrectedValues(), ']'))
+                (!$this->Lengths->getCorrectedValues()? '' :
+                    $this->buildCorrectedValues('[', $this->Lengths->getCorrectedValues(), ']'))
             );
         } else {
             // Complex insertions. The DNAInsSuffixComplex object should have filtered the components already.
@@ -1471,7 +1471,7 @@ class HGVS_DNAInsSuffixComplexComponent extends HGVS
     public array $patterns = [
         'positions_with_refseq_inv' => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'positions_with_refseq'     => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', [] ],
-        'sequence_with_length'      => [ 'HGVS_DNAAlts', '[', 'HGVS_Length', ']', [] ],
+        'sequence_with_length'      => [ 'HGVS_DNAAlts', '[', 'HGVS_Lengths', ']', [] ],
         'sequence'                  => [ 'HGVS_DNAAlts', [] ],
         'positions_inverted'        => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'positions'                 => [ 'HGVS_DNAPositions', [] ],
@@ -3676,7 +3676,7 @@ trait HGVS_DNASequence
                 if (in_array(get_class($Pattern), ['HGVS_DNARefs', 'HGVS_DNAAlts'])) {
                     $aSequencesMin[] = $Pattern->getCorrectedValue();
                     $aSequencesMax[] = $Pattern->getCorrectedValue();
-                } elseif (get_class($Pattern) == 'HGVS_Length') {
+                } elseif (get_class($Pattern) == 'HGVS_Lengths') {
                     $aLengths = $Pattern->getLengths();
                     $nLastKey = array_key_last($aSequencesMin);
                     if (!isset($nLastKey)) {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2024-12-30
+ * Modified    : 2024-12-31
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -712,7 +712,9 @@ class HGVS
             $this->buildInfo();
         }
 
-        return (empty($this->info['errors']) && empty($this->info['warnings']));
+        return (
+            empty($this->info['errors'])
+            && empty(array_diff_key($this->info['warnings'], array_flip(['WNOTSUPPORTED']))));
     }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3755,14 +3755,14 @@ class HGVS_Lengths extends HGVS
 class HGVS_ReferenceSequence extends HGVS
 {
     public array $patterns = [
-        'refseq_genomic_coding'       => [ '/(N[CG])([_-])?([0-9]+)(\.[0-9]+)?[({]([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
-        'refseq_genomic_non-coding'   => [ '/(N[CG])([_-])?([0-9]+)(\.[0-9]+)?[({]([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
+        'refseq_genomic_coding'       => [ '/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[({]([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
+        'refseq_genomic_non-coding'   => [ '/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[({]([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
         'refseq_genomic_with_gene'    => [ '/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[({]([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)[)}]/', [] ],
-        'refseq_genomic'              => [ '/(N[CG])([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
-        'refseq_coding_genomic'       => [ '/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[({](N[CG])([_-])?([0-9]+)(\.[0-9]+)?[)}]/', [] ],
+        'refseq_genomic'              => [ '/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
+        'refseq_coding_genomic'       => [ '/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[({](N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
         'refseq_coding_with_gene'     => [ '/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[({]([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)[)}]/', [] ],
         'refseq_coding'               => [ '/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
-        'refseq_non-coding_genomic'   => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[({](N[CG])([_-])?([0-9]+)(\.[0-9]+)?[)}]/', [] ],
+        'refseq_non-coding_genomic'   => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[({](N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
         'refseq_non-coding_with_gene' => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[({]([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)[)}]/', [] ],
         'refseq_non-coding'           => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
         'refseq_gene_with_genomic'    => [ '/([A-Z][A-Za-z0-9#@-]*)[({](N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
@@ -3770,8 +3770,8 @@ class HGVS_ReferenceSequence extends HGVS
         'refseq_gene_with_non-coding' => [ '/(?:[A-Z][A-Za-z0-9#@-]*)[({]([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
         'refseq_protein'              => [ '/([NXY]P)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
         'refseq_other'                => [ '/^(N[TW]_([0-9]{6})|[A-Z][0-9]{5}|[A-Z]{2}[0-9]{6})(\.[0-9]+)/', [] ],
-        'ensembl_genomic'             => [ '/(ENSG)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
-        'ensembl_transcript'          => [ '/(ENST)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
+        'ensembl_genomic'             => [ '/(ENSG)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
+        'ensembl_transcript'          => [ '/(ENST)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
         'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
         'LRG_genomic'                 => [ '/(LRG)([_-]?)([0-9]+)/', [] ],
         'build_and_chr'               => [ 'HGVS_Genome', 'HGVS_VCFSeparator', 'HGVS_Chromosome', [] ],
@@ -3822,7 +3822,7 @@ class HGVS_ReferenceSequence extends HGVS
                 );
                 $this->caseOK = ($this->value == strtoupper($this->value));
 
-                if (($this->regex[2] ?? '') != '_' || ($this->regex[6] ?? '') != '_') {
+                if ($this->regex[2] != '_' || $this->regex[6] != '_') {
                     $this->messages['WREFERENCEFORMAT'] =
                         'NCBI reference sequence IDs require an underscore between the prefix and the numeric ID.';
                 } elseif (strlen((int) $this->regex[3]) > 6) {
@@ -3881,7 +3881,7 @@ class HGVS_ReferenceSequence extends HGVS
                     $this->appendCorrectedValue('(' . strtoupper($this->regex[5]) . ')');
                 }
 
-                if (($this->regex[2] ?? '') != '_') {
+                if ($this->regex[2] != '_') {
                     $this->messages['WREFERENCEFORMAT'] =
                         'NCBI reference sequence IDs require an underscore between the prefix and the numeric ID.';
                 } elseif (strlen((int) $this->regex[3]) > 6) {
@@ -3921,7 +3921,7 @@ class HGVS_ReferenceSequence extends HGVS
                 );
                 $this->caseOK = ($this->regex[1] == strtoupper($this->regex[1]));
 
-                if (($this->regex[2] ?? '') != '_') {
+                if ($this->regex[2] != '_') {
                     $this->messages['WREFERENCEFORMAT'] =
                         'NCBI reference sequence IDs require an underscore between the prefix and the numeric ID.';
                 } elseif (strlen((int) $this->regex[3]) > 9) {
@@ -3974,7 +3974,7 @@ class HGVS_ReferenceSequence extends HGVS
                 );
                 $this->caseOK = ($this->value == strtoupper($this->value));
 
-                if (!empty($this->regex[2])) {
+                if ($this->regex[2]) {
                     $this->messages['WREFERENCEFORMAT'] =
                         'Ensembl reference sequence IDs don\'t allow a divider between the prefix and the numeric ID.';
                 } elseif (strlen((int) $this->regex[3]) > 11) {
@@ -4003,7 +4003,7 @@ class HGVS_ReferenceSequence extends HGVS
                 $this->caseOK = ($this->regex[1] == strtoupper($this->regex[1])
                     && $this->regex[4] == strtolower($this->regex[4]));
 
-                if (($this->regex[2] ?? '') != '_') {
+                if ($this->regex[2] != '_') {
                     $this->messages['WREFERENCEFORMAT'] =
                         'LRG reference sequence IDs require an underscore between the prefix and the numeric ID.';
                 }
@@ -4019,7 +4019,7 @@ class HGVS_ReferenceSequence extends HGVS
                 );
                 $this->caseOK = ($this->regex[1] == strtoupper($this->regex[1]));
 
-                if (($this->regex[2] ?? '') != '_') {
+                if ($this->regex[2] != '_') {
                     $this->messages['WREFERENCEFORMAT'] =
                         'LRG reference sequence IDs require an underscore between the prefix and the numeric ID.';
                 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -28,15 +28,6 @@
  *
  *************/
 
-// Don't allow direct access.
-if (!defined('ROOT_PATH')) {
-    exit;
-}
-
-
-
-
-
 #[AllowDynamicProperties]
 class HGVS
 {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2520,7 +2520,7 @@ class HGVS_DNASub extends HGVS
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->setCorrectedValue($this->value);
-        $this->data['type'] = 'subst';
+        $this->data['type'] = $this->getCorrectedValue();
     }
 }
 
@@ -2829,7 +2829,7 @@ class HGVS_DNAVariantType extends HGVS
                     $this->messages['WWRONGTYPE'] = "This deletion-insertion doesn't change the given sequence.";
                 } else {
                     $this->messages['WWRONGTYPE'] = 'Based on the given sequences, this deletion-insertion should be described as ' .
-                        ($sNewType == 'subst'? 'a substitution.' :
+                        ($sNewType == '>'? 'a substitution.' :
                             ($sNewType == 'del'? 'a deletion.' :
                                 ($sNewType == 'dup'? 'a duplication.' :
                                     ($sNewType == 'ins'? 'an insertion.' : 'an inversion.'))));
@@ -3567,7 +3567,7 @@ class HGVS_VCFBody extends HGVS
             // Recalculate the position always; we might have started with a
             //  range, but ended with just a single position.
             $this->setCorrectedValue($this->getPositionString($sPosition, $nIntronOffset, $nOffset) . $sREF . '>' . $sALT);
-            $this->data['type'] = 'subst';
+            $this->data['type'] = '>';
 
         } elseif ($nALT == 0) {
             // Deletion.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -173,7 +173,7 @@ class HGVS
                 $this->suffix = $sInputToParse;
                 if (!isset($this->parent)) {
                     // This is the main HGVS class. The variant has a suffix that we didn't identify.
-                    $this->messages['WSUFFIXGIVEN'] = 'Nothing should follow "' . $this->value . '".';
+                    $this->messages['WINPUTLEFT'] = 'We stopped reading past "' . $this->value . '".';
                 }
 
             } else {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -804,6 +804,15 @@ class HGVS_Caret extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->data['type'] = '^';
         $this->messages['ENOTSUPPORTED'] = 'Currently, variant descriptions using "^" are not yet supported. This does not necessarily mean the description is not valid according to the HGVS nomenclature.';
+
+        // Our tool will still fail when more input is expected. Try to fix that.
+        if (preg_match('/([\])]+)$/', $this->input, $aRegs)) {
+            // Our input ended with a closing bracket or parenthesis. Add them to our suffix.
+            $this->suffix = $aRegs[1];
+            // But then, take it off of our value, as well.
+            $this->value = substr($this->value, 0, -strlen($aRegs[1]));
+        }
+
         $this->setCorrectedValue($this->value);
     }
 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1571,6 +1571,15 @@ class HGVS_DNANull extends HGVS
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
+        // We're a bit special. We don't allow any input to be left.
+        // The reason for this is that we don't want to match DNAPositions starting with a zero.
+        // However, if we would go last in line, the DNAPositions + DNAUnknown would pick c.0? up.
+        if ($this->suffix) {
+            // There is more left. We're not an actual DNANull.
+            $this->matched = false;
+            return;
+        }
+
         $this->data['type'] = substr($this->getCorrectedValue(), 0, 1);
         $this->predicted = ($this->matched_pattern == 'predicted');
 
@@ -2662,7 +2671,11 @@ class HGVS_DNAVariantType extends HGVS
         'inv'                 => [ 'HGVS_DNAInv', [] ],
         'con_with_suffix'     => [ 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
         'con'                 => [ 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
+        'pipe_with_refs'      => [ 'HGVS_DNARefs', 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
         'pipe'                => [ 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
+        'unknown_with_refs'   => [ 'HGVS_DNARefs', 'HGVS_DNAUnknown', [ 'EINVALID' => 'This variant description seems incomplete.' ] ],
+        'unknown'             => [ 'HGVS_DNAUnknown', [ 'EINVALID' => 'This variant description seems incomplete.' ] ],
+        'wildtype_with_refs'  => [ 'HGVS_DNARefs', 'HGVS_DNAWildType', [] ],
         'wildtype'            => [ 'HGVS_DNAWildType', [] ],
     ];
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3424,6 +3424,14 @@ class HGVS_DNAVariantType extends HGVS
                 return 0; // Break out of this pattern only.
             }
 
+            // Have "2 A C" sent to the VCF code, instead of having it handled here.
+            // We'll have WWHITESPACE and WSUBSTFORMAT, while I rather have a WVCF.
+            // Therefore, bail out when the variant body already has a WWHITESPACE and when DNASub is a whitespace.
+            if (!$this->DNASub->getValue() && $this->getParent('HGVS_DNAVariantBody') && isset($this->getParent('HGVS_DNAVariantBody')->getMessages()['WWHITESPACE'])) {
+                // Let the VCF handle this.
+                return false; // Break out of the entire object.
+            }
+
             if ($this->matched_pattern == 'substitution') {
                 $sREF = $this->DNARefs->getCorrectedValue();
                 $sALT = $this->DNAAlts->getCorrectedValue();

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -45,6 +45,8 @@ class HGVS
     //        matched. An object holds its value, a string has a fixed value by itself, but a regex can't store a value.
     public array $patterns = [
         'full_variant' => [ 'HGVS_ReferenceSequence', ':', 'HGVS_Variant', [] ],
+        'variant'      => [ 'HGVS_Variant', ['EREFSEQMISSING' => 'This variant is missing a reference sequence.'] ],
+        'VCF'          => [ 'HGVS_VCF', ['WVCF' => 'Recognized a VCF-like format; converting this format to HGVS nomenclature.'] ],
     ];
     public array $corrected_values = [];
     public array $data = [];
@@ -2578,6 +2580,19 @@ class HGVS_Variant extends HGVS
             }
         }
     }
+}
+
+
+
+
+
+class HGVS_VCF extends HGVS
+{
+    public array $patterns = [
+        'with_build' => [ 'HGVS_Genome', 'HGVS_VCFSeparator', 'HGVS_Chromosome', 'HGVS_VCFSeparator', 'HGVS_VCFBody', [] ],
+        'with_chr'   => [ 'HGVS_Chromosome', 'HGVS_VCFSeparator', 'HGVS_VCFBody', ['WREFSEQMISSING' => 'This VCF variant is missing a genome build, which is required to determine the reference sequence used.'] ],
+        'basic'      => [ 'HGVS_VCFBody', ['EREFSEQMISSING' => 'This VCF variant is missing a genome build and chromosome, which is required to determine the reference sequence used.'] ],
+    ];
 }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2980,6 +2980,7 @@ class HGVS_DNASub extends HGVS
 {
     public array $patterns = [
         'valid'   => [ '>', [] ],
+        'slash'   => [ '/', [] ],
         // Special characters arising from copying variants from PDFs. Some journals decided to use specialized fonts to
         //  create markup for normal characters, such as the ">" in a substitution. This is a terrible idea, as
         //  text-recognition then completely fails and copying the variant from the PDF results in a broken format.
@@ -3000,7 +3001,9 @@ class HGVS_DNASub extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->setCorrectedValue('>');
         $this->data['type'] = $this->getCorrectedValue();
-        if ($this->matched_pattern == 'invalid') {
+        if ($this->matched_pattern == 'slash') {
+            $this->messages['WSUBSTFORMAT'] = 'Substitutions are indicated using the ">" character, not the "/" character.';
+        } elseif ($this->matched_pattern == 'invalid') {
             // A bit of a weird hack. We made our match optional, since we need to match a space. But a fully optional
             //  match will match always and mess everything up.
             if (!$this->value) {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3536,16 +3536,19 @@ class HGVS_VCFBody extends HGVS
         if ($nREF == 0 && $nALT == 0) {
             // Nothing left. Take the original range and add '='.
             $this->setCorrectedValue($this->getPositionString($sPosition, $nIntronOffset, 0, $nOffset) . '=');
+            $this->data['type'] = '=';
 
         } elseif ($nREF == 1 && $nALT == 1) {
             // Substitution.
             // Recalculate the position always; we might have started with a
             //  range, but ended with just a single position.
             $this->setCorrectedValue($this->getPositionString($sPosition, $nIntronOffset, $nOffset) . $sREF . '>' . $sALT);
+            $this->data['type'] = 'subst';
 
         } elseif ($nALT == 0) {
             // Deletion.
             $this->setCorrectedValue($this->getPositionString($sPosition, $nIntronOffset, $nOffset, $nREF) . 'del');
+            $this->data['type'] = 'del';
 
         } elseif ($nREF == 0) {
             // Something has been added... could be an insertion or a duplication.
@@ -3553,11 +3556,13 @@ class HGVS_VCFBody extends HGVS
                 // Duplication. Note that the start position might be quite
                 //  far from the actual insert.
                 $this->setCorrectedValue($this->getPositionString($sPosition, $nIntronOffset, ($nOffset - $nALT), $nALT) . 'dup');
+                $this->data['type'] = 'dup';
 
             } else {
                 // Insertion. We should check if we're sure about where the insertion should go.
                 // If the $sREF was '.' from the beginning, we can't be sure.
                 $this->setCorrectedValue($this->getPositionString($sPosition, $nIntronOffset, ($nOffset - 1), 2) . 'ins' . $sALT, (!$sOriREF? 0.7 : 1));
+                $this->data['type'] = 'ins';
                 if (!$sOriREF) {
                     // ADD (not replace) this suggestion to the list.
                     $this->addCorrectedValue($this->getPositionString($sPosition, $nIntronOffset, $nOffset, 2) . 'ins' . $sALT, 0.3);
@@ -3571,11 +3576,17 @@ class HGVS_VCFBody extends HGVS
             if ($sREF == strrev(str_replace(array('A', 'C', 'G', 'T'), array('T', 'G', 'C', 'A'), strtoupper($sALT)))) {
                 // Inversion.
                 $this->setCorrectedValue($this->getPositionString($sPosition, $nIntronOffset, $nOffset, $nREF) . 'inv');
+                $this->data['type'] = 'inv';
             } else {
                 // Deletion-insertion. Both REF and ALT are >1.
                 $this->setCorrectedValue($this->getPositionString($sPosition, $nIntronOffset, $nOffset, $nREF) . 'delins' . $sALT);
+                $this->data['type'] = 'delins';
             }
         }
+
+        // Store REF and ALT so we can check these values from outside of this class.
+        $this->REF = $sREF;
+        $this->ALT = $sALT;
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2024-12-18
+ * Modified    : 2024-12-19
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1361,12 +1361,30 @@ class HGVS_DNAInsSuffixComplex extends HGVS
 class HGVS_DNAInsSuffixComplexComponent extends HGVS
 {
     public array $patterns = [
-        'positions_with_refseq_inv' => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', '.', 'HGVS_DNAPositions', 'inv', [] ],
+        'positions_with_refseq_inv' => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', '.', 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'positions_with_refseq'     => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', '.', 'HGVS_DNAPositions', [] ],
         'sequence_with_length'      => [ 'HGVS_DNAAlts', '[', 'HGVS_Length', ']', [] ],
         'sequence'                  => [ 'HGVS_DNAAlts', [] ],
         'positions'                 => [ 'HGVS_DNAPositions', [] ],
     ];
+}
+
+
+
+
+
+class HGVS_DNAInv extends HGVS
+{
+    public array $patterns = [
+        [ '/inv/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue(strtolower($this->value));
+        $this->caseOK = ($this->value == $this->getCorrectedValue());
+    }
 }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1938,7 +1938,8 @@ class HGVS_DNAPosition extends HGVS
             $this->intronic = false;
             $this->offset = 0;
             if ($this->matched_pattern == 'pter') {
-                $this->position = $this->position_limits[0];
+                $this->position = 1;
+                $this->position_limits[0] = $this->position;
                 $this->position_limits[1] = $this->position;
             } else {
                 $this->position = $this->position_limits[1];

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -823,6 +823,37 @@ class HGVS_ChromosomeNumber extends HGVS
 
 
 
+class HGVS_DNAAlts extends HGVS
+{
+    public array $patterns = [
+        'invalid' => [ '/[A-Z]+/', [] ],
+        'valid'   => [ '/[ACGTMRWSYKVHDBN]+/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue(strtoupper($this->value));
+        $this->caseOK = ($this->value == $this->getCorrectedValue());
+
+        // If we had checked the 'valid' rule first, we would not support recognizing invalid nucleotides after valid
+        //  nucleotides. The valid ones would match, and we would return the invalid nucleotides as a suffix. That's a
+        //  problem, so we're first just matching everything.
+
+        // Check for invalid nucleotides.
+        $sUnknownBases = preg_replace($this->patterns['valid'][0], '', $this->getCorrectedValue());
+        if ($sUnknownBases) {
+            $this->messages['EINVALIDNUCLEOTIDES'] = 'This variant description contains invalid nucleotides: "' . implode('", "', array_unique(str_split($sUnknownBases))) . '".';
+            // Then, replace the 'U's with 'T's.
+            $this->setCorrectedValue(str_replace('U', 'T', $this->getCorrectedValue()));
+        }
+    }
+}
+
+
+
+
+
 class HGVS_DNACon extends HGVS
 {
     public array $patterns = [
@@ -854,37 +885,6 @@ class HGVS_DNADel extends HGVS
         $this->setCorrectedValue(strtolower($this->value));
         $this->data['type'] = $this->getCorrectedValue();
         $this->caseOK = ($this->value == $this->getCorrectedValue());
-    }
-}
-
-
-
-
-
-class HGVS_DNAAlts extends HGVS
-{
-    public array $patterns = [
-        'invalid' => [ '/[A-Z]+/', [] ],
-        'valid'   => [ '/[ACGTMRWSYKVHDBN]+/', [] ],
-    ];
-
-    public function validate ()
-    {
-        // Provide additional rules for validation, and stores values for the variant info if needed.
-        $this->setCorrectedValue(strtoupper($this->value));
-        $this->caseOK = ($this->value == $this->getCorrectedValue());
-
-        // If we had checked the 'valid' rule first, we would not support recognizing invalid nucleotides after valid
-        //  nucleotides. The valid ones would match, and we would return the invalid nucleotides as a suffix. That's a
-        //  problem, so we're first just matching everything.
-
-        // Check for invalid nucleotides.
-        $sUnknownBases = preg_replace($this->patterns['valid'][0], '', $this->getCorrectedValue());
-        if ($sUnknownBases) {
-            $this->messages['EINVALIDNUCLEOTIDES'] = 'This variant description contains invalid nucleotides: "' . implode('", "', array_unique(str_split($sUnknownBases))) . '".';
-            // Then, replace the 'U's with 'T's.
-            $this->setCorrectedValue(str_replace('U', 'T', $this->getCorrectedValue()));
-        }
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1902,6 +1902,25 @@ class HGVS_DNAVariantBody extends HGVS
             $this->predicted = false;
         }
 
+        // We need to handle alleles a bit differently to make sure we have the data set correctly.
+        if ($this->matched_pattern == 'allele_trans') {
+            // Overwrite the data fields with the data from the first component.
+            $this->data = array_merge(
+                $this->data,
+                $this->DNAAllele[0]->DNAVariantBody->getData()
+            );
+            // But, always set the type to that of the allele syntax.
+            $this->data['type'] = ';';
+
+        } elseif ($this->matched_pattern == 'allele_cis') {
+            // Overwrite the data fields with the data from the first component.
+            $this->data = array_merge(
+                $this->data,
+                $this->DNAAllele->DNAVariantBody->getData()
+            );
+            $this->data['type'] = ';';
+        }
+
         // Substitutions deserve some additional attention.
         // Since this is the only class where we'll have all the data, all substitution checks need to be done here.
         if (in_array($this->matched_pattern, ['substitution', 'substitution_VCF'])) {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -225,7 +225,16 @@ class HGVS
 
             if (!$bMatching) {
                 // The rule didn't match, unset any properties that we may have set.
+                // Also, when an object is tainted, mark any following objects as well, so they will always be re-run.
+                $bTainted = false;
                 foreach ($this->properties as $sProperty) {
+                    foreach ((is_array($this->$sProperty)? $this->$sProperty : [$this->$sProperty]) as $Component) {
+                        if ($Component->isTainted()) {
+                            $bTainted = true;
+                        } elseif ($bTainted) {
+                            $Component->tainted = true;
+                        }
+                    }
                     unset($this->$sProperty);
                 }
                 $this->properties = []; // Reset the array, too.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-24
+ * Modified    : 2025-01-27
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1097,7 +1097,8 @@ class HGVS_DNAAlts extends HGVS
         // Check for invalid nucleotides.
         $sUnknownBases = preg_replace($this->patterns['valid'][0] . 'i', '', $this->getCorrectedValue());
         if ($sUnknownBases) {
-            $this->messages['EINVALIDNUCLEOTIDES'] = 'This variant description contains invalid nucleotides: "' . implode('", "', array_unique(str_split($sUnknownBases))) . '".';
+            $sCode = (preg_match('/^[Ut]+$/', $sUnknownBases)? 'WINVALIDNUCLEOTIDES' : 'EINVALIDNUCLEOTIDES');
+            $this->messages[$sCode] = 'This variant description contains one or more invalid nucleotides: "' . implode('", "', array_unique(str_split($sUnknownBases))) . '".';
             // Then, replace the 'U's with 'T's or the other way around.
             if (get_class($this) == 'HGVS_RNAAlts') {
                 $this->setCorrectedValue(str_replace('t', 'u', $this->getCorrectedValue()));
@@ -2888,7 +2889,8 @@ class HGVS_DNARefs extends HGVS
         // OK, with that out of the way, we can check for invalid nucleotides.
         $sUnknownBases = preg_replace($this->patterns['valid'][0] . 'i', '', $this->getCorrectedValue());
         if ($sUnknownBases) {
-            $this->messages['EINVALIDNUCLEOTIDES'] = 'This variant description contains invalid nucleotides: "' . implode('", "', array_unique(str_split($sUnknownBases))) . '".';
+            $sCode = (preg_match('/^[Ut]+$/', $sUnknownBases)? 'WINVALIDNUCLEOTIDES' : 'EINVALIDNUCLEOTIDES');
+            $this->messages[$sCode] = 'This variant description contains one or more invalid nucleotides: "' . implode('", "', array_unique(str_split($sUnknownBases))) . '".';
             // Then, replace the 'U's with 'T's or the other way around.
             if (get_class($this) == 'HGVS_RNARefs') {
                 $this->setCorrectedValue(str_replace('t', 'u', $this->getCorrectedValue()));
@@ -3646,7 +3648,7 @@ class HGVS_DNAVariantType extends HGVS
                     array_keys($this->messages),
                     function ($sKey)
                     {
-                        return ($sKey[0] == 'E' && $sKey != 'EINVALIDNUCLEOTIDES');
+                        return ($sKey[0] == 'E');
                     })) {
                 // Calculate the corrected value. Toss it all in a VCF parser.
                 $this->VCF = new HGVS_VCFBody(
@@ -3678,7 +3680,7 @@ class HGVS_DNAVariantType extends HGVS
                     array_keys($this->messages),
                     function ($sKey)
                     {
-                        return ($sKey[0] == 'E' && $sKey != 'EINVALIDNUCLEOTIDES');
+                        return ($sKey[0] == 'E');
                     }))) {
             // Positions are known; REF and ALT are known. Toss it all in a VCF parser.
             $this->VCF = new HGVS_VCFBody(

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -56,6 +56,7 @@ class HGVS
     public array $regex = [];
     public bool $caseOK = true;
     public bool $matched = false;
+    public bool $possibly_incomplete = false;
     public int $patterns_matched = 0;
     public string $input;
     public string $current_pattern;
@@ -85,6 +86,8 @@ class HGVS
                 // Quick check: do we still have something left?
                 if ($sInputToParse === '') {
                     $bMatching = false;
+                    // This can be a sign that a variant wasn't submitted completely, and we should try to get more input.
+                    $this->possibly_incomplete = true;
                     break;
                 }
 
@@ -127,6 +130,7 @@ class HGVS
                         $bMatching = false;
                         // We still need to store whether any patterns were matched.
                         $this->patterns_matched += $aPattern[$i]->getPatternsMatched();
+                        $this->possibly_incomplete = ($this->possibly_incomplete || $aPattern[$i]->isPossiblyIncomplete());
                         break;
                     }
 
@@ -541,6 +545,15 @@ class HGVS
     public function isTheCaseOK ()
     {
         return $this->caseOK;
+    }
+
+
+
+
+
+    public function isPossiblyIncomplete ()
+    {
+        return $this->possibly_incomplete;
     }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -625,6 +625,33 @@ class HGVS_Chr extends HGVS
 
 
 
+class HGVS_ChromosomeNumber extends HGVS
+{
+    public array $patterns = [
+        'number' => [ '/[0-9]{1,2}/', [] ],
+        'X'      => [ '/X/', [] ],
+        'Y'      => [ '/Y/', [] ],
+        'M'      => [ '/M/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue(strtoupper($this->value));
+        // Assuming use for humans.
+        if ($this->matched_pattern == 'number') {
+            $this->setCorrectedValue((int) $this->value);
+            if ($this->getCorrectedValue() > 22) {
+                $this->messages['EINVALIDCHROMOSOME'] = 'This variant description contains an invalid chromosome number: "' . $this->value . '".';
+            }
+        }
+    }
+}
+
+
+
+
+
 class HGVS_DNACon extends HGVS
 {
     public array $patterns = [

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2492,6 +2492,7 @@ class HGVS_ReferenceSequence extends HGVS
             case 'refseq_coding_genomic':
             case 'refseq_non-coding_genomic':
                 $this->molecule_type = 'genome_transcript';
+                $this->allowed_prefixes = [(strpos($this->matched_pattern, 'non-coding') !== false? 'n' : 'c')];
                 // If the transcript and the genomic refseq are switched, fix all of that and log it.
                 if (substr($this->matched_pattern, -7) == 'genomic') {
                     $this->messages['WREFERENCEFORMAT'] =
@@ -2548,6 +2549,7 @@ class HGVS_ReferenceSequence extends HGVS
 
             case 'refseq_genomic':
                 $this->molecule_type = 'genome';
+                $this->allowed_prefixes = [(strtoupper($this->regex[1]) == 'NC' && in_array((int) $this->regex[3], ['1807', '12920'])? 'm' : 'g')];
                 $this->setCorrectedValue(
                     strtoupper($this->regex[1]) .
                     '_' .
@@ -2580,6 +2582,7 @@ class HGVS_ReferenceSequence extends HGVS
             case 'refseq_gene_with_non-coding':
             case 'refseq_protein':
                 $this->molecule_type = ($this->matched_pattern == 'refseq_protein'? 'protein' : 'transcript');
+                $this->allowed_prefixes = [(strpos($this->matched_pattern, 'non-coding') !== false? 'n' : ($this->matched_pattern == 'refseq_protein'? 'p' : 'c'))];
                 $this->setCorrectedValue(
                     strtoupper($this->regex[1]) .
                     '_' .
@@ -2609,6 +2612,7 @@ class HGVS_ReferenceSequence extends HGVS
 
             case 'refseq_other':
                 $this->molecule_type = 'genome';
+                $this->allowed_prefixes = ['g', 'o'];
                 // We won't attempt to fix things. We don't actually know if anything like this is valid.
                 $this->setCorrectedValue(strtoupper($this->regex[0]));
                 $this->caseOK = ($this->regex[1] == strtoupper($this->regex[1]));
@@ -2623,7 +2627,13 @@ class HGVS_ReferenceSequence extends HGVS
 
             case 'ensembl_genomic':
             case 'ensembl_transcript':
-                $this->molecule_type = ($this->matched_pattern == 'ensembl_genomic'? 'genome' : 'transcript');
+                if ($this->matched_pattern == 'ensembl_genomic') {
+                    $this->molecule_type = 'genome';
+                    $this->allowed_prefixes = ['g', 'm', 'o'];
+                } else {
+                    $this->molecule_type = 'transcript';
+                    $this->allowed_prefixes = ['c', 'n'];
+                }
                 $this->setCorrectedValue(
                     strtoupper($this->regex[1]) .
                     str_pad((int) $this->regex[3], 11, '0', STR_PAD_LEFT) .
@@ -2649,6 +2659,7 @@ class HGVS_ReferenceSequence extends HGVS
 
             case 'LRG_transcript':
                 $this->molecule_type = 'genome_transcript';
+                $this->allowed_prefixes = ['c', 'n'];
                 $this->setCorrectedValue(
                     strtoupper($this->regex[1]) .
                     '_' .
@@ -2667,6 +2678,7 @@ class HGVS_ReferenceSequence extends HGVS
 
             case 'LRG_genomic':
                 $this->molecule_type = 'genome';
+                $this->allowed_prefixes = ['g'];
                 $this->setCorrectedValue(
                     strtoupper($this->regex[1]) .
                     '_' .

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1199,7 +1199,7 @@ class HGVS_DNAIns extends HGVS
 
         if ($this->data['type'] == 'ins') {
             // Insertions have some specific needs.
-            $Positions = $this->getParent('HGVS_DNAVariantBody')->DNAPositions;
+            $Positions = $this->getParentProperty('DNAPositions');
             // If one position is given, this is a problem. Only if it's a question mark, can we fix it.
             if (!$Positions->range) {
                 if ($Positions->unknown) {
@@ -1276,13 +1276,13 @@ class HGVS_DNAInsSuffix extends HGVS
 
         // A deletion-insertion of one base to one base, is a substitution.
         if ($this->parent->getData()['type'] == 'delins'
-            && $this->getParent('HGVS_DNAVariantBody')->DNAPositions->getLengths() == [1,1]
+            && $this->getParentProperty('DNAPositions')->getLengths() == [1,1]
             && isset($this->DNAAlts)
             && $this->getLengths() == [1,1]) {
             $this->messages['WWRONGTYPE'] =
                 'A deletion-insertion of one base to one base should be described as a substitution.';
             // Force the corrected value of the DelSuffix to NOT empty.
-            $DelSuffix = ($this->getParent('HGVS_DNAVariantBody')->DNADelSuffix ?? false);
+            $DelSuffix = $this->getParentProperty('DNADelSuffix');
             if ($DelSuffix && $DelSuffix->getMessages()['WSUFFIXGIVEN']) {
                 // Undo that change.
                 $DelSuffix->setCorrectedValue($DelSuffix->DNARefs->getCorrectedValue());
@@ -2529,19 +2529,11 @@ class HGVS_DNAVariantBody extends HGVS
         'delins'              => [ 'HGVS_DNAPositions', 'HGVS_DNADel', 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
         'del_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNADel', 'HGVS_DNADelSuffix', [] ],
         'del'                 => [ 'HGVS_DNAPositions', 'HGVS_DNADel', [] ],
-        'ins_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', [] ],
-        'ins'                 => [ 'HGVS_DNAPositions', 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for insertions.' ] ],
-        'dup_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNADup', 'HGVS_DNADupSuffix', [] ],
-        'dup'                 => [ 'HGVS_DNAPositions', 'HGVS_DNADup', [] ],
-        'inv_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', 'HGVS_DNAInvSuffix', [] ],
-        'inv'                 => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
-        'con_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
-        'con'                 => [ 'HGVS_DNAPositions', 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
         'pipe'                => [ 'HGVS_DNAPositions', 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
         'pipe_without_pipe'   => [ 'HGVS_DNAPositions', 'HGVS_DNAPipeSuffix', [] ],
+        'other'               => [ 'HGVS_DNAPositions', 'HGVS_DNAVariantType', [] ],
         'unknown'             => [ 'HGVS_DNAUnknown', [] ],
         'wildtype'            => [ 'HGVS_DNAWildType', [] ],
-        'other'               => [ 'HGVS_DNAPositions', 'HGVS_DNAVariantType', [] ],
     ];
 
     public function validate ()
@@ -2662,6 +2654,14 @@ class HGVS_DNAVariantType extends HGVS
     public array $patterns = [
         'substitution'        => [ 'HGVS_DNARefs', 'HGVS_DNASub', 'HGVS_DNAAlts', [] ],
         'substitution_VCF'    => [ 'HGVS_VCFRefs', 'HGVS_DNASub', 'HGVS_VCFAlts', [] ],
+        'ins_with_suffix'     => [ 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', [] ],
+        'ins'                 => [ 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for insertions.' ] ],
+        'dup_with_suffix'     => [ 'HGVS_DNADup', 'HGVS_DNADupSuffix', [] ],
+        'dup'                 => [ 'HGVS_DNADup', [] ],
+        'inv_with_suffix'     => [ 'HGVS_DNAInv', 'HGVS_DNAInvSuffix', [] ],
+        'inv'                 => [ 'HGVS_DNAInv', [] ],
+        'con_with_suffix'     => [ 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
+        'con'                 => [ 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
         'wildtype'            => [ 'HGVS_DNAWildType', [] ],
     ];
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2665,7 +2665,8 @@ class HGVS_Variant extends HGVS
         if ($this->predicted
             || (isset($this->DNAVariantBody->DNAPositions)
                 && ($this->DNAVariantBody->DNAPositions->uncertain || $this->DNAVariantBody->DNAPositions->unknown))
-            || in_array($this->data['type'] ?? '', ['0', '?', ';'])) {
+            || in_array($this->data['type'] ?? '', ['0', '?', ';'])
+            || $this->DNAVariantBody->getCorrectedValue() == '=') {
             if (empty($this->messages) && $this->caseOK) {
                 $this->messages['WNOTSUPPORTED'] = 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.';
             } else {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3596,7 +3596,7 @@ class HGVS_ReferenceSequence extends HGVS
         'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
         'LRG_genomic'                 => [ '/(LRG)([_-]?)([0-9]+)/', [] ],
         // Because I do actually want to match something so we can validate the variant itself, match anything.
-        'other'                       => [ '/[^:\[\]]{2,}(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
+        'other'                       => [ '/[^:;\[\]]{2,}(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1032,28 +1032,6 @@ class HGVS_DNADelSuffix extends HGVS
                     $this->buildCorrectedValues('[', $this->Length->getCorrectedValues(), ']'))
             );
         }
-
-        // Now, handle the duplication suffixes.
-        // It's much more efficient to handle deletion suffixes and duplication suffixes in just one class.
-        // HGVS_DNADupSuffix extends this class, and, therefore, inherits all patterns, checks, and validations.
-        // However, all warnings and errors are now talking about deletions. Fix this by simply replacing the words.
-        if (get_class($this) == 'HGVS_DNADupSuffix') {
-            // We have to fix all messages now.
-            foreach ($this->messages as $sCode => $sMessage) {
-                $this->messages[$sCode] = str_replace(
-                    [
-                        '"del"',
-                        'deletion',
-                        'deleted',
-                    ], [
-                        '"dup"',
-                        'duplication',
-                        'duplicated',
-                    ],
-                    $sMessage
-                );
-            }
-        }
     }
 }
 
@@ -1067,7 +1045,37 @@ class HGVS_DNADup extends HGVS_DNADel
         [ '/dup/', [] ],
     ];
 }
-class HGVS_DNADupSuffix extends HGVS_DNADelSuffix {}
+
+
+
+
+
+class HGVS_DNADupSuffix extends HGVS_DNADelSuffix
+{
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        parent::validate();
+
+        // It's much more efficient to handle deletion suffixes and duplication suffixes in just one class.
+        // Therefore, we extend the HGVS_DNADelSuffix class, and inherit all patterns, checks, and validations.
+        // However, all warnings and errors are now talking about deletions. Fix this by simply replacing the words.
+        foreach ($this->messages as $sCode => $sMessage) {
+            $this->messages[$sCode] = str_replace(
+                [
+                    '"del"',
+                    'deletion',
+                    'deleted',
+                ], [
+                    '"dup"',
+                    'duplication',
+                    'duplicated',
+                ],
+                $sMessage
+            );
+        }
+    }
+}
 
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3925,8 +3925,18 @@ class HGVS_ReferenceSequence extends HGVS
                 if (in_array(strtolower($this->value), ['http', 'https'])) {
                     $this->matched = false;
                     return;
+                } else {
+                    // We also want to be absolutely certain that we are not matching a variant description that has a
+                    //  reference sequence further downstream, like c.100_101insNC_...:...
+                    // We'll check this by tossing in the description in the variant object and see what we get.
+                    $Variant = new HGVS_Variant($this->input);
+                    if ($Variant->hasMatched()) {
+                        // That doesn't mean that it's valid, but it's more likely to be a variant description
+                        //  than a reference sequence, so discard it here.
+                        $this->matched = false;
+                        return;
+                    }
                 }
-
                 break;
         }
     }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1884,8 +1884,8 @@ class HGVS_DNAPosition extends HGVS
 {
     public array $patterns = [
         'unknown'          => [ '?', [] ],
-        'unknown_intronic' => [ '/([-‐*]?([0-9,]+))([+‐-]\?)/u', [] ],
-        'known'            => [ '/([-‐*]?([0-9,]+))([+‐-]([0-9,]+))?/u', [] ],
+        'unknown_intronic' => [ '/([-‐−–—*]?([0-9,]+))([+—–−‐-]\?)/u', [] ],
+        'known'            => [ '/([-‐−–—*]?([0-9,]+))([+—–−‐-]([0-9,]+))?/u', [] ],
         'pter'             => [ '/pter/', [] ],
         'qter'             => [ '/qter/', [] ],
     ];
@@ -1957,13 +1957,14 @@ class HGVS_DNAPosition extends HGVS
             $this->ISCN = true;
 
         } else {
-            // We've seen input from papers that don't use a hyphen-minus (-) but a non-breaking hyphen (‐).
+            // We've seen input from papers that don't use a hyphen-minus (-) but a non-breaking hyphen (‐) or other
+            //  hyphen-like characters (−, –, —).
             // Since the user can't really see the difference, it's not really an error, but we do need to fix it.
-            if (strpos($this->value, '‐') !== false) {
+            if (preg_match('/[‐−–—]/u', $this->value, $aRegs)) {
                 array_walk($this->regex, function (&$sValue) {
-                    $sValue = str_replace('‐', '-', $sValue);
+                    $sValue = str_replace(array('‐', '−', '–', '—'), '-', $sValue);
                 });
-                $this->messages['WPOSITIONFORMAT'] = 'Invalid character "‐" found in variant position; only regular hyphens are allowed to be used in the HGVS nomenclature.';
+                $this->messages['WPOSITIONFORMAT'] = 'Invalid character "' . $aRegs[0] . '" found in variant position; only regular hyphens are allowed to be used in the HGVS nomenclature.';
             }
 
             // Remove grouping separators (thousand separators, commas).

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-02
+ * Modified    : 2025-01-03
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -732,8 +732,8 @@ class HGVS
         }
 
         return (
-            empty($this->info['errors'])
-            && empty(array_diff_key($this->info['warnings'], array_flip(['WNOTSUPPORTED']))));
+            empty(array_diff_key($this->info['errors'], array_flip(['ENOTSUPPORTED'])))
+            && empty(array_diff_key($this->info['warnings'], array_flip(['WNOTSUPPORTED', 'WREFERENCENOTSUPPORTED']))));
     }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2023,11 +2023,11 @@ class HGVS_DNAPositions extends HGVS
 class HGVS_DNAPrefix extends HGVS
 {
     public array $patterns = [
-        'coding'     => [ '/c/', [] ],
-        'genomic'    => [ '/g/', [] ],
-        'mito'       => [ '/m/', [] ],
-        'non-coding' => [ '/n/', [] ],
-        'circular'   => [ '/o/', [] ],
+        'coding'        => [ '/c/', [] ],
+        'genomic'       => [ '/g/', [] ],
+        'mitochondrial' => [ '/m/', [] ],
+        'non-coding'    => [ '/n/', [] ],
+        'circular'      => [ '/o/', [] ],
     ];
 
     public function validate ()
@@ -2036,6 +2036,16 @@ class HGVS_DNAPrefix extends HGVS
         $this->molecule_type = (in_array($this->matched_pattern, ['coding', 'non-coding'])? 'transcript' : 'genome');
         $this->setCorrectedValue(strtolower($this->value));
         $this->caseOK = ($this->value == $this->getCorrectedValue());
+
+        // If we have seen a reference sequence, check if we match that.
+        $RefSeq = $this->getParentProperty('ReferenceSequence');
+        if ($RefSeq && !empty($RefSeq->allowed_prefixes) && !in_array($this->getCorrectedValue(), $RefSeq->allowed_prefixes)) {
+            $this->messages['EWRONGREFERENCE'] =
+                'The given reference sequence (' . $RefSeq->getCorrectedValue() . ') does not match the DNA type (' . $this->getCorrectedValue() . ').' .
+                ' For variants on ' . $RefSeq->getCorrectedValue() . ', please use the ' . implode('. or ', $RefSeq->allowed_prefixes) . '. prefix.' .
+                ' For ' . $this->getCorrectedValue() . '. variants, please use a ' . $this->matched_pattern .
+                ($this->matched_pattern == 'genomic'? '' : ' ' . $this->molecule_type) . ' reference sequence.';
+        }
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -740,7 +740,7 @@ class HGVS_DNADelSuffix extends HGVS
                 // Universal length checks. These messages are kept universal and slightly simplified.
                 // E.g., an ESUFFIXTOOLONG may mean that the deleted sequence CAN BE too long, but isn't always.
                 // (e.g., g.(100_200)del(100_300).
-                if ($nMinLengthSuffix < $nMinLengthVariant) {
+                if ($nMinLengthSuffix && $nMinLengthSuffix < $nMinLengthVariant) {
                     $this->messages['ESUFFIXTOOSHORT'] =
                         "The variant's positions indicate a sequence that's longer than the given deleted sequence." .
                         " Please adjust either the variant's positions or the given deleted sequence.";

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -299,7 +299,7 @@ class HGVS
         ];
 
         foreach ($this as $sPropertyName => $Property) {
-            if (!in_array($sPropertyName, ['parent', 'patterns'])) {
+            if (!in_array($sPropertyName, ['memory', 'parent', 'patterns'])) {
                 $aReturn[$sPropertyName] = $Property;
             }
         }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1770,10 +1770,10 @@ class HGVS_DNANull extends HGVS
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
-        // We're a bit special. We don't allow input to be left that may be a position.
+        // We're a bit special. We don't allow input to be left that may be a position or a (float) number.
         // The reason for this is that we don't want to match DNAPositions starting with a zero.
         // However, if we would go last in line, the DNAPositions + DNAUnknown would pick c.0? up.
-        if ($this->suffix !== '' && preg_match('/^[0-9_*+-]/', $this->suffix)) {
+        if ($this->suffix !== '' && preg_match('/^[.0-9_*+-]/', $this->suffix)) {
             // There is more left that could be position. We're not an actual DNANull.
             return false; // Break out of the entire object.
         }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -453,6 +453,24 @@ class HGVS
 
 
 
+    public function getMatchedPattern ()
+    {
+        return ($this->matched_pattern ?? false);
+    }
+
+
+
+
+
+    public function getMatchedPatternFormatted ()
+    {
+        return str_replace('_', ' ', ($this->matched_pattern ?? ''));
+    }
+
+
+
+
+
     public function getMessages ()
     {
         return ($this->messages ?? []);

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1296,11 +1296,11 @@ class HGVS_DNADelSuffix extends HGVS
             // The suffix should be removed.
             // NOTE: This is not true for delAinsG, but we don't know that here yet.
             $this->setCorrectedValue('');
-        } elseif (!isset($this->Lengths)) {
+        } elseif (!$this->hasProperty('Lengths')) {
             $this->corrected_values = $this->DNARefs->getCorrectedValues();
         } else {
             $this->corrected_values = $this->buildCorrectedValues(
-                (isset($this->DNARefs)? $this->DNARefs->getCorrectedValues() : 'N'),
+                ($this->hasProperty('DNARefs')? $this->DNARefs->getCorrectedValues() : 'N'),
                 (!$this->Lengths->getCorrectedValues()? '' :
                     $this->buildCorrectedValues('[', $this->Lengths->getCorrectedValues(), ']'))
             );
@@ -1481,7 +1481,7 @@ class HGVS_DNAInsSuffix extends HGVS
             && $this->getParent('HGVS_DNAVariantType')->getData()['type'] == 'delins'
             && $this->getParentProperty('DNAPositions')->getLengths() == [1,1]
             && !$this->getParentProperty('DNADelSuffix')
-            && isset($this->DNAAlts)
+            && $this->hasProperty('DNAAlts')
             && $this->getLengths() == [1,1]) {
             // Make this an EWRONGTYPE, since I can't fix it without a del suffix.
             $this->messages['EWRONGTYPE'] =
@@ -1499,7 +1499,7 @@ class HGVS_DNAInsSuffix extends HGVS
                 );
             }
 
-        } elseif (isset($this->DNAPositions)) {
+        } elseif ($this->hasProperty('DNAPositions')) {
             // However, some additional checks are needed.
             // Unknown single positions aren't allowed.
             // Numeric single positions are assumed to be lengths.
@@ -1540,12 +1540,12 @@ class HGVS_DNAInsSuffix extends HGVS
                 $this->appendCorrectedValue($this->DNAInv->getCorrectedValue());
             }
 
-        } elseif (isset($this->DNAAlts) && !isset($this->Lengths)) {
+        } elseif ($this->hasProperty('DNAAlts') && !$this->hasProperty('Lengths')) {
             $this->corrected_values = $this->DNAAlts->getCorrectedValues();
 
-        } elseif (isset($this->Lengths)) {
+        } elseif ($this->hasProperty('Lengths')) {
             $this->corrected_values = $this->buildCorrectedValues(
-                (isset($this->DNAAlts)? $this->DNAAlts->getCorrectedValues() : 'N'),
+                ($this->hasProperty('DNAAlts')? $this->DNAAlts->getCorrectedValues() : 'N'),
                 (!$this->Lengths->getCorrectedValues()? '' :
                     $this->buildCorrectedValues('[', $this->Lengths->getCorrectedValues(), ']'))
             );
@@ -2234,6 +2234,10 @@ class HGVS_DNAPositions extends HGVS
                 $this->DNAPositionStart = new HGVS_DNAPositionStart($this->DNAPosition->getCorrectedValue(), $this);
                 $this->DNAPositionEnd = $NewPosition;
                 unset($this->DNAPosition);
+                $this->properties = [
+                    'DNAPositionStart',
+                    'DNAPositionEnd'
+                ];
                 // Re-run the entire validation, so that all internal values will be set correctly.
                 // This may cause issues with errors that don't reflect the user's input.
                 // Trick validate() into thinking we matched a different pattern.
@@ -4422,7 +4426,7 @@ class HGVS_Variant extends HGVS
         // But I want the message to say whether it was a valid HGVS description,
         //  so I need to do that here, once I know whether it was correct or not.
         if ($this->predicted
-            || (isset($this->DNAVariantBody->DNAPositions)
+            || ($this->DNAVariantBody->hasProperty('DNAPositions')
                 && ($this->DNAVariantBody->DNAPositions->uncertain || $this->DNAVariantBody->DNAPositions->unknown || $this->DNAVariantBody->DNAPositions->ISCN))
             || in_array($this->data['type'] ?? '', ['0', '?', ';', 'met', 'repeat', 'sup'])
             || $this->DNAVariantBody->getCorrectedValue() == '=') {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -919,9 +919,9 @@ class HGVS_Chromosome extends HGVS
         if (!$this->ChromosomeNumber->isValid()) {
             // We received an invalid chromosome number that we won't be able to handle.
             $this->setCorrectedValue('chr' . $sChr);
-        } elseif ($this->getParent('HGVS_VCF') && $this->getParent('HGVS_VCF')->hasProperty('Genome')) {
+        } elseif ($this->getParentProperty('Genome')) {
             // We received a genome build, choose the right NC.
-            $this->setCorrectedValue($this->refseqs[$this->getParent('HGVS_VCF')->Genome->getCorrectedValue()][$sChr]);
+            $this->setCorrectedValue($this->refseqs[$this->getParentProperty('Genome')->getCorrectedValue()][$sChr]);
         } else {
             // We didn't receive a genome build. We'll suggest them all.
             // Note that we don't have very reliable information about how much data each genome build has.
@@ -1056,7 +1056,7 @@ class HGVS_DNADelSuffix extends HGVS
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
-        $Positions = $this->getParent('HGVS_DNAVariantBody')->DNAPositions;
+        $Positions = $this->getParentProperty('DNAPositions');
         $aMessages = $Positions->getMessages();
 
         // Remove any complaints that HGVS_Length may have had, when we already threw a WSUFFIXFORMAT.
@@ -1663,7 +1663,8 @@ class HGVS_DNAPosition extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->unknown = ($this->matched_pattern == 'unknown');
         $this->unknown_offset = ($this->matched_pattern == 'unknown_intronic');
-        $sVariantPrefix = ($this->getParent('HGVS_Variant')? $this->getParent('HGVS_Variant')->DNAPrefix->getCorrectedValue() : 'g'); // VCFs usually don't have a prefix.
+        $VariantPrefix = $this->getParentProperty('DNAPrefix');
+        $sVariantPrefix = ($VariantPrefix? $VariantPrefix->getCorrectedValue() : 'g'); // VCFs usually don't have a prefix.
         $this->position_limits = $this->position_limits[$sVariantPrefix];
         $nCorrectionConfidence = 1;
 
@@ -1826,7 +1827,8 @@ class HGVS_DNAPositionStart extends HGVS
 
             // Before we add more errors or warnings, check if we have multiple errors that are the same.
             // We currently don't handle arrays as error messages.
-            $sVariantPrefix = $this->getParent('HGVS_Variant')->DNAPrefix->getCorrectedValue();
+            $VariantPrefix = $this->getParentProperty('DNAPrefix');
+            $sVariantPrefix = ($VariantPrefix? $VariantPrefix->getCorrectedValue() : 'g');
             // Get new messages for errors that occurred twice.
             $aDoubleMessages = array_intersect_key(
                 [
@@ -2160,12 +2162,7 @@ class HGVS_DNAPositions extends HGVS
             || ($this->matched_pattern == 'range'
                 && ($this->DNAPositionStart->uncertain || $this->DNAPositionEnd->uncertain))
         );
-        if ($this->getParent('HGVS_Variant')) {
-            $VariantPrefix = $this->getParent('HGVS_Variant')->DNAPrefix;
-        } else {
-            // VCFs don't always have a prefix.
-            $VariantPrefix = new HGVS_DNAPrefix('g');
-        }
+        $VariantPrefix = ($this->getParentProperty('DNAPrefix') ?: new HGVS_DNAPrefix('g')); // VCFs usually don't have a prefix.
         $nCorrectionConfidence = (current($this->corrected_values) ?: 1); // Fetch current one, because this object can be revalidated.
 
         if (!$this->range) {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2486,6 +2486,30 @@ class HGVS_DNARefs extends HGVS
 
 
 
+class HGVS_DNARepeat extends HGVS
+{
+    public array $patterns = [
+        'multiple' => [ 'HGVS_DNARepeatComponent', 'HGVS_DNARepeat', [] ],
+        'single'   => [ 'HGVS_DNARepeatComponent', [] ],
+    ];
+}
+
+
+
+
+
+class HGVS_DNARepeatComponent extends HGVS
+{
+    public array $patterns = [
+        // NOTE: We're using DNAAlts, because mixed repeats can be described using IUPAC codes other than A, C, G, or T.
+        'sequence_with_length'      => [ 'HGVS_DNAAlts', '[', 'HGVS_Lengths', ']', [] ],
+    ];
+}
+
+
+
+
+
 class HGVS_DNASomatic extends HGVS
 {
     public array $patterns = [
@@ -2678,6 +2702,7 @@ class HGVS_DNAVariantType extends HGVS
         'inv'                 => [ 'HGVS_DNAInv', [] ],
         'con_with_suffix'     => [ 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
         'con'                 => [ 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
+        'repeat'              => [ 'HGVS_DNARepeat', [] ],
         'pipe_with_refs'      => [ 'HGVS_DNARefs', 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
         'pipe'                => [ 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
         'unknown_with_refs'   => [ 'HGVS_DNARefs', 'HGVS_DNAUnknown', [ 'EINVALID' => 'This variant description seems incomplete.' ] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1901,12 +1901,15 @@ class HGVS_DNAPositionStart extends HGVS
                     $this->DNAPosition[1]->position_sortable = $this->DNAPosition[1]->position_limits[1];
                 }
 
-                // Start positions, when a range, internally store the lowest known value.
-                // End positions, when a range, internally store the highest known value.
+                // Storing the positions.
+                // After discussing the issue, it is decided to use to inner positions in cases where the positions are
+                //  uncertain. This means that e.g. c.(1_2)_(5_6)del will be returned as having a position_start of 2
+                //  and a position_end of 5. However, if we find a variant such as c.(1_?)_(?_6)del, we will save the
+                //  outer positions (so a position_start of 1 and a position_end of 6).
                 if (get_class($this) == 'HGVS_DNAPositionStart') {
-                    $iPositionToStore = ($this->DNAPosition[0]->unknown? 1 : 0);
-                } else {
                     $iPositionToStore = ($this->DNAPosition[1]->unknown? 0 : 1);
+                } else {
+                    $iPositionToStore = ($this->DNAPosition[0]->unknown? 1 : 0);
                 }
                 foreach (['position', 'position_sortable', 'offset'] as $variable) {
                     $this->$variable = $this->DNAPosition[$iPositionToStore]->$variable;

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1113,7 +1113,19 @@ class HGVS_DNACNV extends HGVS
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
 
-        if (!$this->Lengths->getCorrectedValue()) {
+        // At least two positions are required. With only one position, it's very old repeat syntax.
+        $Prefix = ($this->getParentProperty('DNAPrefix') ?: $this->getParentProperty('RNAPrefix'));
+        $Positions = $this->getParentProperty('DNAPositions');
+        if ($Positions && !$Positions->range) {
+            // This is very old repeat syntax. Actually, with a range, it is too,
+            //  but we can't really tell the difference (except for the variant length, I guess).
+            // Anyway, this, for sure, is wrong.
+            $this->data['type'] = 'repeat';
+            $this->messages['EBASESMISSING'] = 'This repeat syntax is no longer supported; the positions should span the entire repeat sequence, and the sequence of the repeat should be given, e.g., c.6955_6993CAG[26].';
+            // Make sure no corrections are made. We also get here with, e.g., "100[1]" and we don't want that changed.
+            $this->setCorrectedValue($this->value);
+
+        } elseif (!$this->Lengths->getCorrectedValue()) {
             // The length was 1, and this has been corrected away.
             // Here, we interpret this as a WT variant.
             $this->data['type'] = '=';

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1380,8 +1380,8 @@ class HGVS_DNAInsSuffixComplex extends HGVS
 class HGVS_DNAInsSuffixComplexComponent extends HGVS
 {
     public array $patterns = [
-        'positions_with_refseq_inv' => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', '.', 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
-        'positions_with_refseq'     => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', '.', 'HGVS_DNAPositions', [] ],
+        'positions_with_refseq_inv' => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
+        'positions_with_refseq'     => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', [] ],
         'sequence_with_length'      => [ 'HGVS_DNAAlts', '[', 'HGVS_Length', ']', [] ],
         'sequence'                  => [ 'HGVS_DNAAlts', [] ],
         'positions_inverted'        => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
@@ -2624,6 +2624,17 @@ class HGVS_DNAWildType extends HGVS
 
 
 
+class HGVS_Dot extends HGVS
+{
+    public array $patterns = [
+        [ '.', [] ],
+    ];
+}
+
+
+
+
+
 class HGVS_Genome extends HGVS
 {
     public array $patterns = [
@@ -3000,8 +3011,8 @@ class HGVS_ReferenceSequence extends HGVS
 class HGVS_Variant extends HGVS
 {
     public array $patterns = [
-        'DNA_predicted' => [ 'HGVS_DNAPrefix', '.(', 'HGVS_DNAVariantBody', ')', [] ],
-        'DNA'           => [ 'HGVS_DNAPrefix', '.', 'HGVS_DNAVariantBody', [] ],
+        'DNA_predicted' => [ 'HGVS_DNAPrefix', 'HGVS_Dot', '(', 'HGVS_DNAVariantBody', ')', [] ],
+        'DNA'           => [ 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAVariantBody', [] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3722,6 +3722,27 @@ class HGVS_RNARefs extends HGVS_DNARefs
 
 
 
+class HGVS_ProteinPosition extends HGVS
+{
+    public array $patterns = [
+        // NOTE: The HGVS nomenclature doesn't state that unknown protein positions can't be used in a description.
+        //       However, the nomenclature doesn't explain how to use it, and therefore, we will not define it.
+        [ 'HGVS_ProteinRef', 'HGVS_ProteinPositionPosition', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        foreach (['position', 'position_sortable', 'position_limits'] as $variable) {
+            $this->$variable = $this->ProteinPositionPosition->$variable;
+        }
+    }
+}
+
+
+
+
+
 class HGVS_ProteinPositionPosition extends HGVS
 {
     public array $patterns = [

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1500,18 +1500,12 @@ class HGVS_DNANull extends HGVS
         $this->data['type'] = substr($this->getCorrectedValue(), 0, 1);
         $this->predicted = ($this->matched_pattern == 'predicted');
 
-        $sVariantPrefix = $this->getParent('HGVS_Variant')->DNAPrefix->getCorrectedValue();
-        $this->data['position_start'] = 0;
-        $this->data['position_end'] = 0;
-        if (in_array($sVariantPrefix, ['g', 'm'])) {
+        $Prefix = $this->getParentProperty('DNAPrefix');
+        if ($Prefix && in_array($Prefix->getCorrectedValue(), ['g', 'm'])) {
             // This is only allowed for transcript-based reference sequences, as it's a consequence of a genomic change
             //  (a deletion or so). It indicates the lack of expression of the transcript.
             $this->messages['EWRONGTYPE'] = 'The 0-allele is used to indicate there is no expression of a given transcript. This can not be used for genomic variants.';
-        } else {
-            $this->data['position_start_intron'] = 0;
-            $this->data['position_end_intron'] = 0;
         }
-        $this->data['range'] = false;
     }
 }
 
@@ -2504,6 +2498,17 @@ class HGVS_DNAVariantBody extends HGVS
                 // OK, set the type to that of the allele syntax.
                 $this->data['type'] = ';';
             }
+
+        } elseif (!$this->hasProperty('DNAPositions')) {
+            // No allele, but no positions, either. Store something anyway.
+            $Prefix = $this->getParentProperty('DNAPrefix');
+            $this->data['position_start'] = 0;
+            $this->data['position_end'] = 0;
+            if ($Prefix && in_array($Prefix->getCorrectedValue(), ['c', 'n'])) {
+                $this->data['position_start_intron'] = 0;
+                $this->data['position_end_intron'] = 0;
+            }
+            $this->data['range'] = false;
         }
 
         // Handle somatic variants here. It's way easier for us that way.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2024-12-13
+ * Modified    : 2024-12-16
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -782,7 +782,7 @@ class HGVS_ChromosomeNumber extends HGVS
         // Assuming use for humans.
         if ($this->matched_pattern == 'number') {
             $this->setCorrectedValue((int) $this->value);
-            if ($this->getCorrectedValue() > 22) {
+            if (!$this->getCorrectedValue() || $this->getCorrectedValue() > 22) {
                 $this->messages['EINVALIDCHROMOSOME'] = 'This variant description contains an invalid chromosome number: "' . $this->value . '".';
             }
         }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -839,6 +839,12 @@ class HGVS_DNAAllele extends HGVS
                 ';',
                 $this->DNAAllele->getCorrectedValues()
             );
+
+        } elseif ($this->matched_pattern == 'multiple_cis') {
+            // We don't allow everything in cis. A "null" value (c.0) is not something that can go in cis.
+            if ($this->DNAVariantBody->getInfo()['type'] == '0' || $this->DNAAllele->getInfo()['type'] == '0') {
+                $this->messages['EALLELEINVALIDCIS'] = 'This is not a possible combination of variants in cis. Did you mean to report them in trans?';
+            }
         }
     }
 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1804,6 +1804,20 @@ class HGVS_DNAPosition extends HGVS
             $this->position_limits[3] = 0;
 
         } elseif (in_array($this->matched_pattern, ['pter', 'qter'])) {
+            if (!in_array($sVariantPrefix, ['g', 'm'])) {
+                if (isset($VariantPrefix->getMessages()['EPREFIXMISSING']) || isset($VariantPrefix->getMessages()['WPREFIXMISSING'])) {
+                    // Actually the prefix is missing completely. In that case, remove all suggestions that aren't g.
+                    //  and m. and just leave it.
+                    foreach (array_keys($VariantPrefix->corrected_values) as $sPrefix) {
+                        if (!in_array($sPrefix, ['g', 'm'])) {
+                            unset($VariantPrefix->corrected_values[$sPrefix]);
+                        }
+                    }
+                } else {
+                    // There really was a prefix, so complain that they used the wrong one.
+                    $this->messages['EWRONGPREFIX'] = 'Chromosomal positions pter, cen, and qter can only be reported using "g." or "m." genomic prefixes.';
+                }
+            }
             $RefSeq = $this->getParentProperty('ReferenceSequence');
             if ($RefSeq && $RefSeq->molecule_type != 'chromosome') {
                 $this->messages['EWRONGREFERENCE'] =

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1836,6 +1836,23 @@ class HGVS_DNASub extends HGVS
 
 
 
+class HGVS_DNAUnknown extends HGVS
+{
+    public array $patterns = [
+        [ '?', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->data['type'] = $this->getCorrectedValue();
+    }
+}
+
+
+
+
+
 class HGVS_DNAVariantBody extends HGVS
 {
     public array $patterns = [
@@ -1853,6 +1870,7 @@ class HGVS_DNAVariantBody extends HGVS
         'dup'                 => [ 'HGVS_DNAPositions', 'HGVS_DNADup', [] ],
         'con_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
         'con'                 => [ 'HGVS_DNAPositions', 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
+        'unknown'             => [ 'HGVS_DNAUnknown', [] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3851,6 +3851,25 @@ class HGVS_DNAVariantType extends HGVS
                     ' Substitutions are written like "' . $Positions->getCorrectedValue() . $this->getCorrectedValue() . '".' .
                     ' Alternatively, did you mean to indicate this position was unchanged?' .
                     ' That is written like "' . $Positions->getCorrectedValue() . '=".';
+
+            } else {
+                // For sure, suggest a deletion-insertion.
+                $this->corrected_values = $this->buildCorrectedValues(
+                    'delins',
+                    $this->value
+                );
+                // Also inform the user properly.
+                $this->messages['EINVALID'] = 'This variant description seems incomplete. Did you mean to write a deletion-insertion?' .
+                    ' They are written like "' . $Positions->getCorrectedValue() . $this->getCorrectedValue() . '".';
+
+                // Only when the lengths match, suggest a reference call.
+                if ($Positions->getLengths()[0] == strlen($this->value)) {
+                    // Lower the confidence a bit, first.
+                    $this->appendCorrectedValue('', 0.5);
+                    $this->addCorrectedValue('=', 0.5);
+                    $this->messages['EINVALID'] .= ' Alternatively, did you mean to indicate this position was unchanged?' .
+                        ' That is written like "' . $Positions->getCorrectedValue() . '=".';
+                }
             }
         }
     }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1381,6 +1381,8 @@ class HGVS_DNAInsSuffix extends HGVS
 {
     use HGVS_DNASequence; // Gets us getSequence() and getLengths().
     public array $patterns = [
+        'positions_with_refseq_inv'        => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.' ] ],
+        'positions_with_refseq'            => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.' ] ],
         'complex_in_brackets'              => [ '[', 'HGVS_DNAInsSuffixComplex', ']', [] ],
         'positions_inverted'               => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'positions'                        => [ 'HGVS_DNAPositions', [] ],
@@ -1416,7 +1418,15 @@ class HGVS_DNAInsSuffix extends HGVS
         }
 
         // Store the corrected value.
-        if (isset($this->DNAPositions)) {
+        if (substr($this->matched_pattern, 0, 21) == 'positions_with_refseq') {
+            // This required square brackets. I threw the warning already.
+            $this->corrected_values = $this->buildCorrectedValues(
+                '[',
+                $this->getCorrectedValues(), // This will use the objects in our pattern.
+                ']'
+            );
+
+        } elseif (isset($this->DNAPositions)) {
             // However, some additional checks are needed.
             // Unknown single positions aren't allowed.
             // Numeric single positions are assumed to be lengths.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2521,7 +2521,7 @@ class HGVS_ReferenceSequence extends HGVS
         'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
         'LRG_genomic'                 => [ '/(LRG)([_-]?)([0-9]+)/', [] ],
         // Because I do actually want to match something so we can validate the variant itself, match anything.
-        'other'                       => [ '/[^:]+/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
+        'other'                       => [ '/[^:]+(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -702,7 +702,7 @@ class HGVS_DNADelSuffix extends HGVS
         }
 
         // Don't check anything about the suffix length when there are problems with the positions.
-        if (isset($aMessages['EPOSITIONFORMAT'])) {
+        if (isset($aMessages['EPOSITIONFORMAT']) || isset($aMessages['EPOSITIONLIMIT'])) {
             $this->messages['ISUFFIXNOTVALIDATED'] = "Due to the invalid variant position, the variant's suffix couldn't be fully validated.";
         } else {
             // Check all length requirements.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2564,6 +2564,12 @@ class HGVS_DNAVariantBody extends HGVS
                 unset($this->messages['WSUFFIXGIVEN']);
             }
         }
+
+        if ($this->matched_pattern == 'wildtype') {
+            $this->messages['IALLWILDTYPE'] =
+                'Using the "=" symbol without providing positions indicates that the entire reference sequence has been sequenced and found not to be changed.' .
+                ' If this is not what was intended, provide the positions that were found not to be changed.';
+        }
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2717,6 +2717,11 @@ class HGVS_DNAPrefix extends HGVS
                     ' For variants on ' . $RefSeq->getCorrectedValue() . ', please use the ' . implode('. or ', $RefSeq->allowed_prefixes) . '. prefix.' .
                     ' For ' . $this->getCorrectedValue() . '. variants, please use a ' . $this->matched_pattern .
                     ($this->matched_pattern == 'genomic'? '' : ' ' . $this->molecule_type) . ' reference sequence.';
+                // Specifically for LRGs; suggest to add "t1". That's a "dumb" suggestion,
+                //  but we anyway will have a low confidence score, since we're raising an error here, not a warning.
+                if ($RefSeq->matched_pattern == 'LRG_genomic') {
+                    $RefSeq->appendCorrectedValue('t1');
+                }
             }
 
         } elseif ($this->matched_pattern == 'nothing') {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1413,7 +1413,8 @@ class HGVS_DNAInsSuffix extends HGVS
             && !$this->getParentProperty('DNADelSuffix')
             && isset($this->DNAAlts)
             && $this->getLengths() == [1,1]) {
-            $this->messages['WWRONGTYPE'] =
+            // Make this an EWRONGTYPE, since I can't fix it without a del suffix.
+            $this->messages['EWRONGTYPE'] =
                 'A deletion-insertion of one base to one base should be described as a substitution.';
         }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3852,7 +3852,7 @@ class HGVS_DNAVariantType extends HGVS
                     ' Alternatively, did you mean to indicate this position was unchanged?' .
                     ' That is written like "' . $Positions->getCorrectedValue() . '=".';
 
-            } else {
+            } elseif (!$Positions->uncertain) {
                 // For sure, suggest a deletion-insertion.
                 $this->corrected_values = $this->buildCorrectedValues(
                     'delins',
@@ -3870,6 +3870,10 @@ class HGVS_DNAVariantType extends HGVS
                     $this->messages['EINVALID'] .= ' Alternatively, did you mean to indicate this position was unchanged?' .
                         ' That is written like "' . $Positions->getCorrectedValue() . '=".';
                 }
+
+            } else {
+                // Uncertain positions? Nah, reject the match.
+                return 0; // Break out of this pattern only.
             }
         }
     }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4880,7 +4880,17 @@ class HGVS_VCFRefs extends HGVS_DNARefs
     public array $patterns = [
         'invalid' => [ '/[A-Z]+/', [] ],
         'valid'   => [ '/(\.|[ACGTN]+)/', [] ],
+        'nothing' => [ '/(?=[: -])/', [] ],
     ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        if ($this->matched_pattern == 'nothing') {
+            $this->value = '.';
+        }
+        return parent::validate();
+    }
 }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1841,6 +1841,7 @@ class HGVS_DNAPipeSuffix extends HGVS
     public array $patterns = [
         'met='    => [ '/met=/', [] ],
         'met'     => [ '/met/', [] ],
+        '='       => [ '/=/', [] ],
         'gom'     => [ '/gom/', [] ],
         'lom'     => [ '/lom/', [] ],
         'invalid' => [ '/[A-Z]+/', [] ],
@@ -1851,7 +1852,7 @@ class HGVS_DNAPipeSuffix extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         // If our direct parent is HGVS_DNAPipe, that means the Pipe wasn't actually there.
         // That means we have to be more careful with what we're matching.
-        if ($this->getParent('HGVS_DNAPipe') && $this->matched_pattern == 'invalid']) {
+        if ($this->getParent('HGVS_DNAPipe') && in_array($this->matched_pattern, ['=', 'invalid'])) {
             return false; // Break out of the entire object.
         }
 
@@ -1859,6 +1860,10 @@ class HGVS_DNAPipeSuffix extends HGVS
             // We don't recognize this, but also don't want to make statements about what case would be right.
             $this->setCorrectedValue($this->value);
             $this->messages['ENOTSUPPORTED'] = 'This is not a valid HGVS description, please verify your input after "|".';
+
+        } elseif ($this->matched_pattern == '=') {
+            $this->setCorrectedValue('met=');
+            $this->messages['WMETFORMAT'] = 'To report normal methylation, use "met=".';
 
         } else {
             $this->setCorrectedValue(strtolower($this->value));

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -452,6 +452,28 @@ class HGVS
 
 
 
+    public function getParentProperty ($sPropertyName)
+    {
+        // Finds a certain property in the first parent that it finds that has this property.
+        // Useful especially in nested variants; for complex insertions,
+        //  our reference sequence may be in the insertion or all the way up to the HGVS object.
+        if (!$this->parent) {
+            return false;
+        } else {
+            $o = $this->parent;
+            // Let's keep the code simple by using recursion.
+            if ($o->hasProperty($sPropertyName)) {
+                return $o->$sPropertyName;
+            } else {
+                return $o->getParentProperty($sPropertyName);
+            }
+        }
+    }
+
+
+
+
+
     public function getProperties ()
     {
         return ($this->properties ?? []);

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3380,6 +3380,11 @@ class HGVS_Variant extends HGVS
         $this->predicted = (substr($this->matched_pattern, -9) == 'predicted'
             || !empty($this->DNAVariantBody->predicted)); // NOTE: This is due to c.0? being predicted.
 
+        // Clean up the messages a bit.
+        if (isset($this->messages['EPREFIXMISSING']) || isset($this->messages['WPREFIXMISSING'])) {
+            unset($this->messages['WPREFIXFORMAT']);
+        }
+
         // Some variant types aren't supported for validation and mapping.
         // But I want the message to say whether it was a valid HGVS description,
         //  so I need to do that here, once I know whether it was correct or not.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2467,6 +2467,23 @@ class HGVS_Variant extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->predicted = (substr($this->matched_pattern, -9) == 'predicted'
             || !empty($this->DNAVariantBody->predicted)); // NOTE: This is due to c.0? being predicted.
+
+        // Some variant types aren't supported for validation and mapping.
+        // But I want the message to say whether it was a valid HGVS description,
+        //  so I need to do that here, once I know whether it was correct or not.
+        if ($this->predicted
+            || (isset($this->DNAVariantBody->DNAPositions)
+                && ($this->DNAVariantBody->DNAPositions->uncertain || $this->DNAVariantBody->DNAPositions->unknown))
+            || in_array($this->data['type'] ?? '', ['0', '?', ';'])) {
+            if (empty($this->messages) && $this->caseOK) {
+                $this->messages['WNOTSUPPORTED'] = 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.';
+            } else {
+                $this->messages['WNOTSUPPORTED'] = 'This syntax is currently not supported for mapping and validation.';
+            }
+            if (($this->data['type'] ?? '') == ';') {
+                $this->messages['WNOTSUPPORTED'] .= ' Please submit your variants separately.';
+            }
+        }
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -246,6 +246,20 @@ class HGVS
     {
         // Conveniently adds the corrected value for us.
         $this->corrected_values[$sValue] = $nConfidence;
+
+        return true;
+    }
+
+
+
+
+
+    public function appendCorrectedValue ($sValue, $nConfidence = 1)
+    {
+        // Append to any existing corrected value(s), using the given confidence.
+        $this->corrected_values = $this->buildCorrectedValues($this->corrected_values, [$sValue => $nConfidence]);
+
+        return true;
     }
 
 
@@ -1960,7 +1974,7 @@ class HGVS_DNAPositions extends HGVS
             // This may cause issues with errors that don't reflect the user's input.
             $this->validate();
             // We're not super confident about this.
-            $this->corrected_values[$this->getCorrectedValue()] *= 0.75;
+            $this->appendCorrectedValue('', 0.75);
             return true;
         }
 
@@ -1985,7 +1999,7 @@ class HGVS_DNAPositions extends HGVS
             // This may cause issues with errors that don't reflect the user's input.
             $this->validate();
             // We're not super confident about this.
-            $this->corrected_values[$this->getCorrectedValue()] *= 0.75;
+            $this->appendCorrectedValue('', 0.75);
             return true;
         }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3108,8 +3108,8 @@ class HGVS_Lengths extends HGVS
                 ['' => $nCorrectionConfidence],
                 '(', $this->Length[0]->getCorrectedValues(), '_', $this->Length[1]->getCorrectedValues(), ')'
             );
-        } elseif ($this->lengths[0] == 1) {
-            // Actually, when the length is 1, it's redundant, and it shouldn't be given.
+        } elseif ($this->lengths[0] == 1 && !$this->getParent('HGVS_DNARepeatComponent')) {
+            // Actually, when the length is 1, and we're not a repeat, it's redundant and it shouldn't be given.
             $this->setCorrectedValue('');
         } else {
             $this->corrected_values = $this->buildCorrectedValues(

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3211,7 +3211,7 @@ class HGVS_DNASup extends HGVS
             if (isset($VariantPrefix->getMessages()['EPREFIXMISSING']) || isset($VariantPrefix->getMessages()['WPREFIXMISSING'])) {
                 // Actually the prefix is missing completely. In that case, remove all suggestions that aren't g.
                 //  and m. and just leave it.
-                foreach (array_keys($VariantPrefix->getCorrected_values()) as $sPrefix) {
+                foreach (array_keys($VariantPrefix->getCorrectedValues()) as $sPrefix) {
                     if (!in_array($sPrefix, ['g', 'm'])) {
                         unset($VariantPrefix->corrected_values[$sPrefix]);
                     }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1043,7 +1043,7 @@ class HGVS_Chromosome extends HGVS
 class HGVS_ChromosomeNumber extends HGVS
 {
     public array $patterns = [
-        'number' => [ '/[0-9]{1,2}/', [] ],
+        'number' => [ '/[0-9]{1,2}(?![0-9])/', [] ],
         'X'      => [ '/X/', [] ],
         'Y'      => [ '/Y/', [] ],
         'M'      => [ '/M/', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-22
+ * Modified    : 2025-01-24
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -2085,6 +2085,23 @@ class HGVS_DNAPosition extends HGVS
 
 
 
+class HGVS_DNAPositionSeparator extends HGVS
+{
+    public array $patterns = [
+        [ '_', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue('_');
+    }
+}
+
+
+
+
+
 class HGVS_DNAPositionStart extends HGVS
 {
     public array $patterns = [
@@ -2240,8 +2257,8 @@ class HGVS_DNAPositionEnd extends HGVS_DNAPositionStart {}
 class HGVS_DNAPositions extends HGVS
 {
     public array $patterns = [
-        'range'            => [ 'HGVS_DNAPositionStart', '_', 'HGVS_DNAPositionEnd', [] ],
-        'uncertain_range'  => [ '(', 'HGVS_DNAPositionStart', '_', 'HGVS_DNAPositionEnd', ')', [] ],
+        'range'            => [ 'HGVS_DNAPositionStart', 'HGVS_DNAPositionSeparator', 'HGVS_DNAPositionEnd', [] ],
+        'uncertain_range'  => [ '(', 'HGVS_DNAPositionStart', 'HGVS_DNAPositionSeparator', 'HGVS_DNAPositionEnd', ')', [] ],
         'uncertain_single' => [ '(', 'HGVS_DNAPosition', ')', [ 'WTOOMANYPARENS' => "This variant description contains a position with redundant parentheses." ] ],
         'single'           => [ 'HGVS_DNAPosition', [] ],
     ];

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2552,7 +2552,6 @@ class HGVS_DNAVariantBody extends HGVS
         'allele_trans'        => [ '[', 'HGVS_DNAAllele', '];[', 'HGVS_DNAAllele', ']', [] ],
         'allele_cis'          => [ '[', 'HGVS_DNAAllele', ']', [] ],
         'somatic'             => [ 'HGVS_DNAPositions', 'HGVS_DNAVariantType', 'HGVS_DNASomaticVariant', [] ],
-        'pipe'                => [ 'HGVS_DNAPositions', 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
         'other'               => [ 'HGVS_DNAPositions', 'HGVS_DNAVariantType', [] ],
         'unknown'             => [ 'HGVS_DNAUnknown', [] ],
         'wildtype'            => [ 'HGVS_DNAWildType', [] ],
@@ -2663,6 +2662,7 @@ class HGVS_DNAVariantType extends HGVS
         'inv'                 => [ 'HGVS_DNAInv', [] ],
         'con_with_suffix'     => [ 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
         'con'                 => [ 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
+        'pipe'                => [ 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
         'wildtype'            => [ 'HGVS_DNAWildType', [] ],
     ];
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2319,7 +2319,7 @@ class HGVS_DNAPositions extends HGVS
                 $PositionC = ($this->DNAPositionEnd->range? $this->DNAPositionEnd->DNAPosition[0] : $this->DNAPositionEnd);
                 $PositionD = $this->DNAPositionEnd; // Will anyway be C if D == ?.
 
-                if (!$this->arePositionsSorted($PositionA, $PositionD)) {
+                if (!$this->arePositionsSorted($PositionA, $PositionD) && !in_array($sVariantPrefix, ['m', 'o'])) {
                     $this->messages['WPOSITIONORDER'] = "This variant description contains positions not given in the correct order.";
                     // Due to excessive complexity with ranges and possible solutions and assumptions,
                     //  we'll only swap positions when neither Start nor End is a range.
@@ -2338,7 +2338,7 @@ class HGVS_DNAPositions extends HGVS
                         $nCorrectionConfidence *= 0.8;
                     }
 
-                } elseif (!$this->arePositionsSorted($PositionB, $PositionC)) {
+                } elseif (!$this->arePositionsSorted($PositionB, $PositionC) && !in_array($sVariantPrefix, ['m', 'o'])) {
                     // We can't fix that, so throw an error, not a warning.
                     $this->messages['EPOSITIONFORMAT'] = "This variant description contains positions that overlap but that are not the same.";
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -49,6 +49,7 @@ class HGVS
         'VCF'                => [ 'HGVS_VCF', ['WVCF' => 'Recognized a VCF-like format; converting this format to HGVS nomenclature.'] ],
         'reference_sequence' => [ 'HGVS_ReferenceSequence', [] ],
         'genome_build'       => [ 'HGVS_Genome', [] ],
+        'variant_identifier' => [ 'HGVS_VariantIdentifier', [] ],
     ];
     public array $corrected_values = [];
     public array $data = [];
@@ -4380,6 +4381,39 @@ class HGVS_Variant extends HGVS
                 $this->messages['WNOTSUPPORTED'] .= ' Please submit your variants separately.';
             }
         }
+    }
+}
+
+
+
+
+
+class HGVS_VariantIdentifier extends HGVS
+{
+    public array $patterns = [
+        'dbSNP'              => [ '/rs[0-9]+/', [] ],
+        'ClinVar_reference'  => [ '/RCV[0-9]+(\.[0-9]+)?/', [] ],
+        'ClinVar_submission' => [ '/SCV[0-9]+(\.[0-9]+)?/', [] ],
+        'ClinVar_variation'  => [ '/VCV[0-9]+(\.[0-9]+)?/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->data = [
+            'position_start' => 0,
+            'position_end'   => 0,
+            'range'          => false,
+            'type'           => 'identifier',
+        ];
+        if (substr($this->matched_pattern, 0, 7) == 'ClinVar') {
+            $this->setCorrectedValue(strtoupper($this->value));
+        } else {
+            $this->setCorrectedValue(strtolower($this->value));
+        }
+        $this->caseOK = ($this->value == $this->getCorrectedValue());
+        $this->messages['EINVALID'] = 'This is not a valid HGVS description; it looks like a ' .
+            str_replace('_', ' ', $this->matched_pattern) . ' identifier. Please provide a variant description following the HGVS nomenclature.';
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2428,7 +2428,6 @@ class HGVS_DNAVariantBody extends HGVS
         'pipe'                => [ 'HGVS_DNAPositions', 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
         'pipe_without_pipe'   => [ 'HGVS_DNAPositions', 'HGVS_DNAPipeSuffix', [] ],
         'unknown'             => [ 'HGVS_DNAUnknown', [] ],
-        'wildtype_with_pos'   => [ 'HGVS_DNAPositions', 'HGVS_DNAWildType', [] ],
         'wildtype'            => [ 'HGVS_DNAWildType', [] ],
         'other'               => [ 'HGVS_DNAPositions', 'HGVS_DNAVariantType', [] ],
     ];
@@ -2506,6 +2505,7 @@ class HGVS_DNAVariantType extends HGVS
     public array $patterns = [
         'substitution'        => [ 'HGVS_DNARefs', 'HGVS_DNASub', 'HGVS_DNAAlts', [] ],
         'substitution_VCF'    => [ 'HGVS_VCFRefs', 'HGVS_DNASub', 'HGVS_VCFAlts', [] ],
+        'wildtype'            => [ 'HGVS_DNAWildType', [] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1076,7 +1076,8 @@ class HGVS_DNADelSuffix extends HGVS
             list($nMinLengthVariant, $nMaxLengthVariant) = $Positions->getLengths();
             $bPositionLengthIsCertain = ($nMinLengthVariant == $nMaxLengthVariant);
             list($nMinLengthSuffix, $nMaxLengthSuffix) = $this->getLengths();
-            $bSuffixLengthIsCertain = ($nMinLengthSuffix == $nMaxLengthSuffix);
+            $bSuffixLengthIsUnknown = ($this->hasProperty('Lengths') && $this->Lengths->unknown);
+            $bSuffixLengthIsCertain = ($nMinLengthSuffix == $nMaxLengthSuffix && !$bSuffixLengthIsUnknown);
 
             // Simplest situation first: certain everything, length matches.
             if ($bPositionLengthIsCertain && $bSuffixLengthIsCertain && $nMinLengthVariant == $nMinLengthSuffix) {
@@ -1099,7 +1100,7 @@ class HGVS_DNADelSuffix extends HGVS
                     " This is a conflict; when the deleted sequence is certain, make the variant's positions certain by removing the parentheses and remove the deleted sequence from the variant description.";
                 $Positions->makeCertain();
 
-            } else {
+            } elseif (!$bSuffixLengthIsUnknown && !isset($this->messages['EINVALIDNUCLEOTIDES'])) {
                 // Universal length checks. These messages are kept universal and slightly simplified.
                 // E.g., an ESUFFIXTOOLONG may mean that the deleted sequence CAN BE too long, but isn't always.
                 // (e.g., g.(100_200)del(100_300).

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3682,7 +3682,7 @@ class HGVS_ReferenceSequence extends HGVS
         'refseq_non-coding'           => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
         'refseq_gene_with_coding'     => [ '/(?:[A-Z][A-Za-z0-9#@-]*)\(([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
         'refseq_gene_with_non-coding' => [ '/(?:[A-Z][A-Za-z0-9#@-]*)\(([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
-        'refseq_protein'              => [ '/([NX]P)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
+        'refseq_protein'              => [ '/([NXY]P)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
         'refseq_other'                => [ '/^(N[TW]_([0-9]{6})|[A-Z][0-9]{5}|[A-Z]{2}[0-9]{6})(\.[0-9]+)/', [] ],
         'ensembl_genomic'             => [ '/(ENSG)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
         'ensembl_transcript'          => [ '/(ENST)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2956,6 +2956,24 @@ class HGVS_DNASub extends HGVS
 
 
 
+class HGVS_DNASup extends HGVS
+{
+    public array $patterns = [
+        [ '/sup/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue(strtolower($this->value));
+        $this->caseOK = ($this->value == $this->getCorrectedValue());
+    }
+}
+
+
+
+
+
 class HGVS_DNAUnknown extends HGVS
 {
     use HGVS_CheckBasesGiven; // Gives us checkBasesGiven().
@@ -3215,6 +3233,7 @@ class HGVS_DNAVariantType extends HGVS
         'con_with_suffix'     => [ 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
         'con'                 => [ 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
         'cnv'                 => [ 'HGVS_DNACNV', [] ],
+        'sup'                 => [ 'HGVS_DNASup', [] ],
         'repeat'              => [ 'HGVS_DNARepeat', [] ],
         'pipe_with_refs'      => [ 'HGVS_DNARefs', 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
         'pipe'                => [ 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -323,6 +323,25 @@ class HGVS
 
 
 
+    public function allowMissingReferenceSequence ()
+    {
+        // Remove any error message about not having a reference sequence.
+        // Apparently, in this context, we're OK not having one.
+
+        if (isset($this->messages['EREFSEQMISSING'])) {
+            $this->messages['IREFSEQMISSING'] = $this->messages['EREFSEQMISSING'];
+            unset($this->messages['EREFSEQMISSING']);
+            // Rebuild the info just in case.
+            $this->buildInfo();
+        }
+
+        return true;
+    }
+
+
+
+
+
     public function appendCorrectedValue ($sValue, $nConfidence = 1)
     {
         // Append to any existing corrected value(s), using the given confidence.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4101,12 +4101,6 @@ class HGVS_ReferenceSequence extends HGVS
 
             case 'build_and_chr':
             case 'chr':
-                // First, make sure we're not just a large number or so. We currently match 123456del, and that's bad.
-                if ($this->suffix !== '' && substr($this->suffix, 0, 1) != ':') {
-                    // Abort.
-                    return 0; // Break out of this pattern only.
-                }
-
                 $this->molecule_type = 'chromosome';
                 $this->allowed_prefixes = [($this->Chromosome->ChromosomeNumber->getCorrectedValue() == 'M'? 'm' : 'g')];
                 $this->messages['WREFSEQMISSING'] = 'You indicated this variant is located on chromosome ' . $this->Chromosome->ChromosomeNumber->getCorrectedValue() .

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-28
+ * Modified    : 2025-01-29
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1474,8 +1474,8 @@ class HGVS_DNAInsSuffix extends HGVS
 {
     use HGVS_DNASequence; // Gets us getSequence() and getLengths().
     public array $patterns = [
-        'positions_with_refseq_inv'        => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.' ] ],
-        'positions_with_refseq'            => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.' ] ],
+        'refseq_with_positions_inv'        => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.' ] ],
+        'refseq_with_positions'            => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.' ] ],
         'complex_in_brackets'              => [ '[', 'HGVS_DNAInsSuffixComplex', ']', [] ],
         'positions_inverted'               => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'positions'                        => [ 'HGVS_DNAPositions', [] ],
@@ -1518,7 +1518,7 @@ class HGVS_DNAInsSuffix extends HGVS
         }
 
         // Store the corrected value.
-        if (substr($this->matched_pattern, 0, 21) == 'positions_with_refseq') {
+        if ($this->hasProperty('ReferenceSequence')) {
             if (get_class($this) == 'HGVS_DNAInsSuffix') {
                 // This required square brackets. I threw the warning already.
                 $this->corrected_values = $this->buildCorrectedValues(
@@ -1700,8 +1700,8 @@ class HGVS_DNAInsSuffixComplex extends HGVS
 class HGVS_DNAInsSuffixComplexComponent extends HGVS_DNAInsSuffix
 {
     public array $patterns = [
-        'positions_with_refseq_inv' => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
-        'positions_with_refseq'     => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', [] ],
+        'refseq_with_positions_inv' => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
+        'refseq_with_positions'     => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', [] ],
         'sequence_with_length'      => [ 'HGVS_DNAAlts', '[', 'HGVS_Lengths', ']', [] ],
         'sequence'                  => [ 'HGVS_DNAAlts', [] ],
         'positions_inverted'        => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2979,14 +2979,30 @@ class HGVS_DNASomaticVariant extends HGVS
 class HGVS_DNASub extends HGVS
 {
     public array $patterns = [
-        [ '>', [] ],
+        'valid'   => [ '>', [] ],
+        // Special characters arising from copying variants from PDFs. Some journals decided to use specialized fonts to
+        //  create markup for normal characters, such as the ">" in a substitution. This is a terrible idea, as
+        //  text-recognition then completely fails and copying the variant from the PDF results in a broken format.
+        // " " seen in AIPL1_20702822_Jacobson-2011.pdf ("c.216G A")
+        // "®" seen in CACNA1F_9662399_Strom-1998.pdf ("1106G®A")
+        // "?" seen in CACNA1F_12111638_Wutz-2002.pdf ("220T?C")
+        // "!" seen in CRB1_32351147_Liu-2020.pdf ("C!T")
+        // "." seen in MERTK_19403518_Charbel%20Issa-2009.pdf ("c.2189+1G.T")
+        // "4" seen in MERTK_30851773_Bhatia-2019.pdf ("c.1647T4G")
+        // "→" seen in NYX_11062472_Pusch-2000.pdf ("1040T→C")
+        // Because " " has already been trimmed to "", make pattern optional.
+        // Note the "u" modifier to allow for UTF-8 characters.
+        'invalid' => [ '/[®?!.4→]/u', [] ],
     ];
 
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
-        $this->setCorrectedValue($this->value);
+        $this->setCorrectedValue('>');
         $this->data['type'] = $this->getCorrectedValue();
+        if ($this->matched_pattern == 'invalid') {
+            $this->messages['WSUBSTFORMAT'] = 'This variant description contains an invalid character, probably because it was copied from a PDF file.';
+        }
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1389,6 +1389,10 @@ class HGVS_DNAInv extends HGVS
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->setCorrectedValue(strtolower($this->value));
+        if (!$this->getParent('HGVS_DNAInsSuffix')) {
+            // We are *not* in an insertion, set the variant type.
+            $this->data['type'] = $this->getCorrectedValue();
+        }
         $this->caseOK = ($this->value == $this->getCorrectedValue());
 
         // Inversions have some specific needs.
@@ -2308,6 +2312,7 @@ class HGVS_DNAVariantBody extends HGVS
         'ins'                 => [ 'HGVS_DNAPositions', 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for insertions.' ] ],
         'dup_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNADup', 'HGVS_DNADupSuffix', [] ],
         'dup'                 => [ 'HGVS_DNAPositions', 'HGVS_DNADup', [] ],
+        'inv'                 => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
         'con_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
         'con'                 => [ 'HGVS_DNAPositions', 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
         'unknown'             => [ 'HGVS_DNAUnknown', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1911,7 +1911,7 @@ class HGVS_DNAPosition extends HGVS
     public array $patterns = [
         'unknown'          => [ '?', [] ],
         'unknown_intronic' => [ '/([-‐−–—*]?([0-9,]+))([+—–−‐-]\?)/u', [] ],
-        'known'            => [ '/([-‐−–—*]?([0-9,]+))([+—–−‐-]([0-9,]+))?/u', [] ],
+        'known'            => [ '/([-‐−–—*]?([0-9,]+))([+—–−‐-]([0-9,]+))?(?![0-9]*bp)/u', [] ],
         'pter'             => [ '/pter/', [] ],
         'qter'             => [ '/qter/', [] ],
     ];
@@ -3877,8 +3877,9 @@ class HGVS_Genome extends HGVS
 class HGVS_Length extends HGVS
 {
     public array $patterns = [
-        'unknown' => [ '?', [] ],
-        'known'   => [ '/([0-9]+)/', [] ],
+        'unknown'  => [ '?', [] ],
+        'known_bp' => [ '/([0-9]+)bp/', [] ],
+        'known'    => [ '/([0-9]+)/', [] ],
     ];
 
     public function validate ()
@@ -3893,9 +3894,11 @@ class HGVS_Length extends HGVS
         } else {
             $this->length = (int) $this->value;
 
-            // Check for values with zeros.
+            // Check for values with zeros or a "bp" suffix.
             if (!$this->length) {
                 $this->messages['ELENGTHFORMAT'] = 'This variant description contains an invalid sequence length: "' . $this->value . '".';
+            } elseif ($this->matched_pattern == 'known_bp') {
+                $this->messages['WLENGTHFORMAT'] = 'In the HGVS nomenclature, sequence lengths are not indicated using "bp".';
             } elseif ((string) $this->length !== $this->regex[1]) {
                 $this->messages['WLENGTHWITHZERO'] = 'Sequence lengths should not be prefixed by a 0.';
                 $nCorrectionConfidence *= 0.9;

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1909,6 +1909,7 @@ class HGVS_ReferenceSequence extends HGVS
         'ensembl_genomic'             => [ '/(ENSG)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
         'ensembl_transcript'          => [ '/(ENST)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
         'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
+        'LRG_genomic'                 => [ '/(LRG)([_-]?)([0-9]+)/', [] ],
     ];
 
     public function validate ()
@@ -2051,6 +2052,21 @@ class HGVS_ReferenceSequence extends HGVS
                 );
                 $this->caseOK = ($this->regex[1] == strtoupper($this->regex[1])
                     && $this->regex[4] == strtolower($this->regex[4]));
+
+                if (($this->regex[2] ?? '') != '_') {
+                    $this->messages['WREFERENCEFORMAT'] =
+                        'LRG reference sequence IDs require an underscore between the prefix and the numeric ID.';
+                }
+                break;
+
+            case 'LRG_genomic':
+                $this->molecule_type = 'genome';
+                $this->setCorrectedValue(
+                    strtoupper($this->regex[1]) .
+                    '_' .
+                    (int) $this->regex[3]
+                );
+                $this->caseOK = ($this->regex[1] == strtoupper($this->regex[1]));
 
                 if (($this->regex[2] ?? '') != '_') {
                     $this->messages['WREFERENCEFORMAT'] =

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3270,6 +3270,40 @@ class HGVS_RNAPrefix extends HGVS
 
 
 
+class HGVS_ProteinPrefix extends HGVS
+{
+    public array $patterns = [
+        'protein' => [ '/p/', [] ],
+        'nothing' => [ 'HGVS_Dot', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->molecule_type = 'protein';
+        $this->setCorrectedValue(strtolower($this->value));
+        $this->caseOK = ($this->value == $this->getCorrectedValue());
+
+        if ($this->matched_pattern == 'nothing') {
+            $this->setCorrectedValue('p');
+            $this->suffix = $this->input; // Reset the suffix in case HGVS_Dot took something.
+            $this->messages['WPREFIXMISSING'] = 'This variant description seems incomplete. Variant descriptions should start with a molecule type (e.g., "' . $this->getCorrectedValue() . '.").';
+        }
+
+        // If we have seen a reference sequence, check if we match that.
+        $RefSeq = $this->getParentProperty('ReferenceSequence');
+        if ($RefSeq && $RefSeq->molecule_type != $this->molecule_type) {
+            $this->messages['EWRONGREFERENCE'] =
+                'The given reference sequence (' . $RefSeq->getCorrectedValue() . ') does not match the protein type (' . $this->getCorrectedValue() . ').' .
+                ' For ' . $this->getCorrectedValue() . '. variants, please use a ' . $this->molecule_type . ' reference sequence.';
+        }
+    }
+}
+
+
+
+
+
 class HGVS_Variant extends HGVS
 {
     public array $patterns = [

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1421,6 +1421,15 @@ class HGVS_DNAPosition extends HGVS
                 }
             }
 
+            // Intronic positions require a "genome_transcript" type of reference sequence.
+            if ($this->intronic) {
+                $RefSeq = $this->getParentProperty('ReferenceSequence');
+                if ($RefSeq && $RefSeq->molecule_type != 'genome_transcript') {
+                    $this->messages['EWRONGREFERENCE'] =
+                        'A genomic transcript reference sequence is required to verify intronic positions.';
+                }
+            }
+
             // Adjust minimum and maximum values, to be used in further processing, but keep within limits.
             if ($this->position_sortable < $this->position_limits[0]) {
                 $this->position_limits[1] = $this->position_limits[0];

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -539,6 +539,7 @@ class HGVS_DNAAllele extends HGVS
     public array $patterns = [
         'multiple_cis'     => [ 'HGVS_DNAVariantBody', ';', 'HGVS_DNAAllele', [] ],
         'multiple_unknown' => [ 'HGVS_DNAVariantBody', '(;)', 'HGVS_DNAAllele', [] ],
+        'multiple_comma'   => [ 'HGVS_DNAVariantBody', ',', 'HGVS_DNAAllele', [ 'WALLELEFORMAT' => 'The allele syntax uses semicolons (;) to separate variants, not commas.' ] ],
         'single'           => [ 'HGVS_DNAVariantBody', [] ],
     ];
 
@@ -564,6 +565,24 @@ class HGVS_DNAAllele extends HGVS
         }
 
         return $this->components;
+    }
+
+
+
+
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        if ($this->matched_pattern == 'multiple_comma') {
+            // Fix the separator. Set a slightly lower confidence, because we don't know if this is cis or unknown.
+            $this->corrected_values = $this->buildCorrectedValues(
+                ['' => 0.9],
+                $this->DNAVariantBody->getCorrectedValues(),
+                ';',
+                $this->DNAAllele->getCorrectedValues()
+            );
+        }
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1096,9 +1096,9 @@ class HGVS_ChromosomeNumber extends HGVS
 {
     public array $patterns = [
         'number' => [ '/[0-9]{1,2}(?![0-9])/', [] ],
-        'X'      => [ '/X/', [] ],
-        'Y'      => [ '/Y/', [] ],
-        'M'      => [ '/M/', [] ],
+        'X'      => [ '/X(?![A-Z])/', [] ],
+        'Y'      => [ '/Y(?![A-Z])/', [] ],
+        'M'      => [ '/M(?![A-Z])/', [] ],
     ];
 
     public function validate ()
@@ -3905,8 +3905,8 @@ class HGVS_Dot extends HGVS
 class HGVS_Genome extends HGVS
 {
     public array $patterns = [
-        'ucsc' => [ '/hg(18|19|38)/', [] ],
-        'ncbi' => [ '/GRCh3(6|7|8)/', [] ],
+        'ucsc' => [ '/hg(18|19|38)(?![0-9])/', [] ],
+        'ncbi' => [ '/GRCh3(6|7|8)(?![0-9])/', [] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4518,6 +4518,12 @@ class HGVS_VCFBody extends HGVS
             return false; // Break out of the entire object.
         }
 
+        // Also, the VCF separators need to be the same. We're getting too many false positives, otherwise.
+        if ($this->VCFSeparator[0]->getValue() != $this->VCFSeparator[1]->getValue()) {
+            // Likely something else.
+            return false; // Break out of the entire object.
+        }
+
         // Loop through the REF and ALT to isolate where they are different.
         // Recognize deletions, insertions, duplications, and more.
         // (ANNOVAR does something else than most other VCF generators)

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3152,7 +3152,7 @@ class HGVS_DNASub extends HGVS
         // Special characters arising from copying variants from PDFs. Some journals decided to use specialized fonts to
         //  create markup for normal characters, such as the ">" in a substitution. This is a terrible idea, as
         //  text-recognition then completely fails and copying the variant from the PDF results in a broken format.
-        // " " seen in AIPL1_20702822_Jacobson-2011.pdf ("c.216G A")
+        // "⬎" seen in AIPL1_20702822_Jacobson-2011.pdf ("c.216G⬎A")
         // "®" seen in CACNA1F_9662399_Strom-1998.pdf ("1106G®A")
         // "?" seen in CACNA1F_12111638_Wutz-2002.pdf ("220T?C")
         // "!" seen in CRB1_32351147_Liu-2020.pdf ("C!T")
@@ -3161,7 +3161,7 @@ class HGVS_DNASub extends HGVS
         // "→" seen in NYX_11062472_Pusch-2000.pdf ("1040T→C")
         // Because " " has already been trimmed to "", make pattern optional.
         // Note the "u" modifier to allow for UTF-8 characters.
-        'invalid' => [ '/[®?!.4→]?/u', [] ],
+        'invalid' => [ '/[⬎®?!.4→]?/u', [] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -44,9 +44,11 @@ class HGVS
     //        you should create an object. The reason for this is that we can't deduce from a regular expression what it
     //        matched. An object holds its value, a string has a fixed value by itself, but a regex can't store a value.
     public array $patterns = [
-        'full_variant' => [ 'HGVS_ReferenceSequence', ':', 'HGVS_Variant', [] ],
-        'variant'      => [ 'HGVS_Variant', ['EREFSEQMISSING' => 'This variant is missing a reference sequence.'] ],
-        'VCF'          => [ 'HGVS_VCF', ['WVCF' => 'Recognized a VCF-like format; converting this format to HGVS nomenclature.'] ],
+        'full_variant'       => [ 'HGVS_ReferenceSequence', ':', 'HGVS_Variant', [] ],
+        'variant'            => [ 'HGVS_Variant', ['EREFSEQMISSING' => 'This variant is missing a reference sequence.'] ],
+        'VCF'                => [ 'HGVS_VCF', ['WVCF' => 'Recognized a VCF-like format; converting this format to HGVS nomenclature.'] ],
+        'reference_sequence' => [ 'HGVS_ReferenceSequence', [] ],
+        'genome_build'       => [ 'HGVS_Genome', [] ],
     ];
     public array $corrected_values = [];
     public array $data = [];

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -410,6 +410,15 @@ class HGVS
 
 
 
+    public function getInput ()
+    {
+        return ($this->input ?? '');
+    }
+
+
+
+
+
     public function getMessages ()
     {
         return ($this->messages ?? []);

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3225,7 +3225,8 @@ class HGVS_Variant extends HGVS
                 && ($this->DNAVariantBody->DNAPositions->uncertain || $this->DNAVariantBody->DNAPositions->unknown))
             || in_array($this->data['type'] ?? '', ['0', '?', ';', 'met'])
             || $this->DNAVariantBody->getCorrectedValue() == '=') {
-            if (empty($this->messages) && $this->caseOK) {
+            if ($this->caseOK
+                && !array_filter(array_keys($this->messages), function ($sKey) { return in_array($sKey[0], ['E','W']); })) {
                 $this->messages['WNOTSUPPORTED'] = 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.';
             } else {
                 $this->messages['WNOTSUPPORTED'] = 'This syntax is currently not supported for mapping and validation.';

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-16
+ * Modified    : 2025-01-17
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1406,7 +1406,7 @@ class HGVS_DNAIns extends HGVS
 
             } elseif ($Positions->DNAPositionStart->range || $Positions->DNAPositionEnd->range) {
                 // An insertion should not be defined using more than two positions.
-                $this->messages['EPOSITIONFORMAT'] =
+                $this->messages['EPOSITIONSNOTFORINS'] =
                     'An insertion must be provided with the two positions between which the insertion has taken place.';
 
             } elseif (!$Positions->uncertain && $Positions->getCorrectedValue() != '?_?' && $Positions->getLengths() != [2,2]) {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3616,8 +3616,9 @@ class HGVS_DNAVariantType extends HGVS
             // Since the VCF format is very loose already (any number followed by two words will match), we have to be a
             //  bit strict here. We don't want to have false positives when scanning text, which will happen if we match
             //  text like "30 patients with". Simply refuse to match with EINVALIDNUCLEOTIDES.
-            if ($this->DNASub->getValue() != '>'
-                && (isset($this->messages['EINVALIDNUCLEOTIDES']) || $this->matched_pattern == 'substitution_VCF')) {
+            if (($this->DNASub->getValue() != '>'
+                    && (isset($this->messages['EINVALIDNUCLEOTIDES']) || $this->matched_pattern == 'substitution_VCF'))
+                || ($this->matched_pattern == 'substitution_VCF' && !$this->VCFAlts->getInput())) {
                 // This is more likely something else. Bail out.
                 return 0; // Break out of this pattern only.
             }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2574,6 +2574,24 @@ class HGVS_DNARepeat extends HGVS
                         }
                     }
                 }
+
+                if (empty($this->messages['EINVALIDREPEATLENGTH']) && $Positions && $Positions->range) {
+                    // Do a rudimentary length check. Take all given bases, and compare it to the positions.
+                    // We don't know the number of repeats that the reference has, but at least the bases should fit.
+                    $nPositionsLength = $Positions->getLengths()[0];
+                    // This is the simplest way, not going through all objects.
+                    $sSequence = preg_replace('/\[[^\]]+\]/', '', $this->getValue());
+                    $nSequenceLength = strlen($sSequence);
+
+                    if ($nSequenceLength > $nPositionsLength) {
+                        $this->messages['EINVALIDREPEATLENGTH'] =
+                            'The sequence ' . $sSequence . ' does not fit in the given positions ' . $Positions->getCorrectedValue() . '. Adjust your positions or the given sequences.';
+
+                    } elseif (count($aRepeatUnits) == 1 && ($nPositionsLength % $nSequenceLength)) {
+                        $this->messages['EINVALIDREPEATLENGTH'] =
+                            'The given repeat unit (' . $sSequence . ') does not fit in the given positions ' . $Positions->getCorrectedValue() . '. Adjust your positions or the given sequences.';
+                    }
+                }
             }
         }
     }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2370,6 +2370,43 @@ class HGVS_DNARefs extends HGVS
 
 
 
+class HGVS_DNASomatic extends HGVS
+{
+    public array $patterns = [
+        [ '/\/+/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue(substr($this->value, 0, 2)); // Maximum number of slashes: 2.
+        $nLength = strlen($this->value);
+        if ($nLength == 1) {
+            $this->data['type'] = 'mosaic';
+        } elseif ($nLength == 2) {
+            $this->data['type'] = 'chimeric';
+        } else {
+            $this->data['type'] = 'chimeric';
+            $this->messages['WSOMATICFORMAT'] = 'Somatic variants are reported using one or two slashes; one slash for mosaicism, two for chimerism.';
+        }
+    }
+}
+
+
+
+
+
+class HGVS_DNASomaticVariant extends HGVS
+{
+    public array $patterns = [
+        [ 'HGVS_DNASomatic', 'HGVS_DNAVariantType', [] ],
+    ];
+}
+
+
+
+
+
 class HGVS_DNASub extends HGVS
 {
     public array $patterns = [
@@ -2411,6 +2448,7 @@ class HGVS_DNAVariantBody extends HGVS
         'null'                => [ 'HGVS_DNANull', [] ],
         'allele_trans'        => [ '[', 'HGVS_DNAAllele', '];[', 'HGVS_DNAAllele', ']', [] ],
         'allele_cis'          => [ '[', 'HGVS_DNAAllele', ']', [] ],
+        'somatic'             => [ 'HGVS_DNAPositions', 'HGVS_DNAVariantType', 'HGVS_DNASomaticVariant', [] ],
         'delXins_with_suffix' => [ 'HGVS_DNAPositions', 'HGVS_DNADel', 'HGVS_DNADelSuffix', 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', [] ],
         'delXins'             => [ 'HGVS_DNAPositions', 'HGVS_DNADel', 'HGVS_DNADelSuffix', 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
         'delins_with_suffix'  => [ 'HGVS_DNAPositions', 'HGVS_DNADel', 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2638,6 +2638,33 @@ class HGVS_DNAPositions extends HGVS
                 ['' => $nCorrectionConfidence],
                 $this->DNAPositionStart->getCorrectedValues(), '_', $this->DNAPositionEnd->getCorrectedValues()
             );
+
+            // However, if "pter" or "qter" are involved and stuff has been moved around,
+            //  also suggest the possibility of a typo.
+            if (isset($this->messages['WPOSITIONORDER']) && !$this->DNAPositionStart->range && !$this->DNAPositionEnd->range) {
+                if ($this->DNAPositionStart->getCorrectedValue() == 'pter'
+                    && $this->DNAPositionEnd->getCorrectedValue() != 'qter') {
+                    // First, lower the current confidence.
+                    $this->appendCorrectedValue('', 0.5);
+                    // Then, suggest the alternative fix.
+                    $this->addCorrectedValue(
+                        $this->DNAPositionEnd->getCorrectedValue() . '_qter',
+                        $nCorrectionConfidence * 0.5
+                    );
+
+                } elseif ($this->DNAPositionEnd->getCorrectedValue() == 'qter'
+                    && $this->DNAPositionStart->getCorrectedValue() != 'pter') {
+                    // First, lower the current confidence.
+                    $this->appendCorrectedValue('', 0.5);
+                    // Then, suggest the alternative fix.
+                    $this->addCorrectedValue(
+                        'pter_' . $this->DNAPositionStart->getCorrectedValue(),
+                        $nCorrectionConfidence * 0.5
+                    );
+                }
+
+            }
+
         } else {
             $this->corrected_values = $this->buildCorrectedValues(
                 ['' => $nCorrectionConfidence],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1857,8 +1857,8 @@ class HGVS_DNAPosition extends HGVS
 {
     public array $patterns = [
         'unknown'          => [ '?', [] ],
-        'unknown_intronic' => [ '/([-‐*]?([0-9]+))([+‐-]\?)/u', [] ],
-        'known'            => [ '/([-‐*]?([0-9]+))([+‐-]([0-9]+))?/u', [] ], // Note: We're using these sub patterns in the validation.
+        'unknown_intronic' => [ '/([-‐*]?([0-9,]+))([+‐-]\?)/u', [] ],
+        'known'            => [ '/([-‐*]?([0-9,]+))([+‐-]([0-9,]+))?/u', [] ],
         'pter'             => [ '/pter/', [] ],
         'qter'             => [ '/qter/', [] ],
     ];
@@ -1936,6 +1936,14 @@ class HGVS_DNAPosition extends HGVS
                     $sValue = str_replace('‐', '-', $sValue);
                 });
                 $this->messages['WPOSITIONFORMAT'] = 'Invalid character "‐" found in variant position; only regular hyphens are allowed to be used in the HGVS nomenclature.';
+            }
+
+            // Remove grouping separators (thousand separators, commas).
+            if (strpos($this->value, ',') !== false) {
+                array_walk($this->regex, function (&$sValue) {
+                    $sValue = str_replace(',', '', $sValue);
+                });
+                $this->messages['WPOSITIONFORMAT'] = 'Invalid character "," found in variant position; the HGVS nomenclature does not use grouping separators within positions.';
             }
 
             $this->UTR = !ctype_digit($this->value[0]);

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2553,7 +2553,7 @@ class HGVS_ReferenceSequence extends HGVS
         'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
         'LRG_genomic'                 => [ '/(LRG)([_-]?)([0-9]+)/', [] ],
         // Because I do actually want to match something so we can validate the variant itself, match anything.
-        'other'                       => [ '/[^:]+(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
+        'other'                       => [ '/[^:\[\]]+(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3414,6 +3414,16 @@ class HGVS_DNAVariantType extends HGVS
         // Substitutions deserve some additional attention.
         // Since this is the only class where we'll have all the data, all substitution checks need to be done here.
         if (in_array($this->matched_pattern, ['substitution', 'substitution_VCF'])) {
+            // First, if our DNASub was not actually a '>', we require DNARefs and DNAAlts to have valid nucleotides.
+            // Since the VCF format is very loose already (any number followed by two words will match), we have to be a
+            //  bit strict here. We don't want to have false positives when scanning text, which will happen if we match
+            //  text like "30 patients with". Simply refuse to match with EINVALIDNUCLEOTIDES.
+            if ($this->DNASub->getValue() != '>'
+                && (isset($this->messages['EINVALIDNUCLEOTIDES']) || $this->matched_pattern == 'substitution_VCF')) {
+                // This is more likely something else. Bail out.
+                return 0; // Break out of this pattern only.
+            }
+
             if ($this->matched_pattern == 'substitution') {
                 $sREF = $this->DNARefs->getCorrectedValue();
                 $sALT = $this->DNAAlts->getCorrectedValue();

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1972,6 +1972,13 @@ class HGVS_DNAVariantBody extends HGVS
                     ':' . $sREF . ':' . $sALT,
                     $this
                 );
+                // Lower the confidence of our prediction when the position was single but the REF was not.
+                // (e.g., c.100AAA>G).
+                $nCorrectionConfidence = (!$this->DNAPositions->range && strlen($sREF) > 1? 0.6 : 1);
+                $this->corrected_values = $this->buildCorrectedValues(
+                    ['' => $nCorrectionConfidence],
+                    $this->VCF->getCorrectedValues()
+                );
             }
         }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2844,7 +2844,7 @@ class HGVS_Dot extends HGVS
 {
     public array $patterns = [
         'something' => [ '/[:.,]+/', [] ],
-        'nothing'   => [ '/(?=[(0-9*-])/', [] ],
+        'nothing'   => [ '/(?=[(A-Z0-9*-])/', [] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4406,10 +4406,12 @@ class HGVS_VariantIdentifier extends HGVS
             'range'          => false,
             'type'           => 'identifier',
         ];
+        // Increase the confidence when we have no suffix, to counteract the EINVALID.
+        $nConfidence = ($this->suffix === ''? 10 : 1);
         if (substr($this->matched_pattern, 0, 7) == 'ClinVar') {
-            $this->setCorrectedValue(strtoupper($this->value));
+            $this->setCorrectedValue(strtoupper($this->value), $nConfidence);
         } else {
-            $this->setCorrectedValue(strtolower($this->value));
+            $this->setCorrectedValue(strtolower($this->value), $nConfidence);
         }
         $this->caseOK = ($this->value == $this->getCorrectedValue());
         $this->messages['EINVALID'] = 'This is not a valid HGVS description; it looks like a ' .

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4510,6 +4510,14 @@ class HGVS_VCFBody extends HGVS
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
 
+        // Since the VCF format is very loose already (any number followed by two words will match), we have to be a bit
+        //  strict here. We don't want to have false positives when scanning text, which will happen if we match text
+        //  like "30 patients with". Simply refuse to match with EINVALIDNUCLEOTIDES.
+        if (isset($this->messages['EINVALIDNUCLEOTIDES'])) {
+            // This is more likely something else. Bail out.
+            return false; // Break out of the entire object.
+        }
+
         // Loop through the REF and ALT to isolate where they are different.
         // Recognize deletions, insertions, duplications, and more.
         // (ANNOVAR does something else than most other VCF generators)

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3698,7 +3698,7 @@ class HGVS_ReferenceSequence extends HGVS
                 // But I don't want to throw an error, either. It could still be valid HGVS nomenclature.
                 $this->messages['WREFERENCENOTSUPPORTED'] =
                     'Currently, variant descriptions using "' . $this->value . '" are not yet supported.' .
-                    ' This does not necessarily mean the description is not valid HGVS.' .
+                    ' This does not necessarily mean the description is not valid according to the HGVS nomenclature.' .
                     ' Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.';
                 break;
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2024-12-09
+ * Modified    : 2024-12-10
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -527,6 +527,19 @@ class HGVS
             }
         }
     }
+}
+
+
+
+
+
+class HGVS_DNAAllele extends HGVS
+{
+    public array $components = [];
+    public array $patterns = [
+        'multiple_cis'     => [ 'HGVS_DNAVariantBody', ';', 'HGVS_DNAAllele', [] ],
+        'multiple_unknown' => [ 'HGVS_DNAVariantBody', '(;)', 'HGVS_DNAAllele', [] ],
+    ];
 }
 
 
@@ -1859,6 +1872,8 @@ class HGVS_DNAVariantBody extends HGVS
 {
     public array $patterns = [
         'null'                => [ 'HGVS_DNANull', [] ],
+        'allele_trans'        => [ '[', 'HGVS_DNAAllele', '];[', 'HGVS_DNAAllele', ']', [] ],
+        'allele_cis'          => [ '[', 'HGVS_DNAAllele', ']', [] ],
         'substitution'        => [ 'HGVS_DNAPositions', 'HGVS_DNARefs', 'HGVS_DNASub', 'HGVS_DNAAlts', [] ],
         'substitution_VCF'    => [ 'HGVS_DNAPositions', 'HGVS_VCFRefs', 'HGVS_DNASub', 'HGVS_VCFAlts', [] ],
         'delXins_with_suffix' => [ 'HGVS_DNAPositions', 'HGVS_DNADel', 'HGVS_DNADelSuffix', 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1666,6 +1666,7 @@ class HGVS_DNAPosition extends HGVS
     public array $position_limits = [
         'g' => [1, 4294967295, 0, 0], // position min, position max, offset min, offset max.
         'm' => [1, 4294967295, 0, 0],
+        'o' => [1, 4294967295, 0, 0],
         'c' => [-8388608, 8388607, -2147483648, 2147483647],
         'n' => [1, 8388607, -2147483648, 2147483647],
     ];

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -357,6 +357,12 @@ class HGVS
     public function appendCorrectedValue ($sValue, $nConfidence = 1)
     {
         // Append to any existing corrected value(s), using the given confidence.
+
+        // If there aren't any corrected values yet, generate them first.
+        if (!$this->corrected_values) {
+            $this->getCorrectedValues();
+        }
+
         $this->corrected_values = $this->buildCorrectedValues($this->corrected_values, [$sValue => $nConfidence]);
 
         return true;

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1621,11 +1621,11 @@ class HGVS_DNANull extends HGVS
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
-        // We're a bit special. We don't allow any input to be left.
+        // We're a bit special. We don't allow input to be left that may be a position.
         // The reason for this is that we don't want to match DNAPositions starting with a zero.
         // However, if we would go last in line, the DNAPositions + DNAUnknown would pick c.0? up.
-        if ($this->suffix !== '') {
-            // There is more left. We're not an actual DNANull.
+        if ($this->suffix !== '' && preg_match('/^[0-9_*+-]/', $this->suffix)) {
+            // There is more left that could be position. We're not an actual DNANull.
             $this->matched = false;
             return;
         }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2024-12-11
+ * Modified    : 2024-12-12
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -618,6 +618,27 @@ class HGVS_Chr extends HGVS
         // Provide additional rules for validation, and stores values for the variant info if needed.
         $this->setCorrectedValue(strtolower($this->value));
         $this->caseOK = ($this->value == $this->getCorrectedValue());
+    }
+}
+
+
+
+
+
+class HGVS_Chromosome extends HGVS
+{
+    public array $patterns = [
+        'with_prefix'    => [ 'HGVS_Chr', 'HGVS_ChromosomeNumber', [] ],
+        'without_prefix' => [ 'HGVS_ChromosomeNumber', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        // Our corrected value is a genomic reference sequence.
+        // If the parent has a build, use that. Otherwise, use all possible builds.
+        $sChr = $this->ChromosomeNumber->getCorrectedValue();
+        $this->setCorrectedValue('chr' . $sChr);
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2458,8 +2458,16 @@ class HGVS_ReferenceSequence extends HGVS
 class HGVS_Variant extends HGVS
 {
     public array $patterns = [
-        'DNA' => [ 'HGVS_DNAPrefix', '.', 'HGVS_DNAVariantBody', [] ],
+        'DNA_predicted' => [ 'HGVS_DNAPrefix', '.(', 'HGVS_DNAVariantBody', ')', [] ],
+        'DNA'           => [ 'HGVS_DNAPrefix', '.', 'HGVS_DNAVariantBody', [] ],
     ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->predicted = (substr($this->matched_pattern, -9) == 'predicted'
+            || !empty($this->DNAVariantBody->predicted)); // NOTE: This is due to c.0? being predicted.
+    }
 }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1900,8 +1900,12 @@ class HGVS_ReferenceSequence extends HGVS
         'refseq_genomic_coding'       => [ '/(N[CG])([_-])?([0-9]+)(\.[0-9]+)?\(([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
         'refseq_genomic_non-coding'   => [ '/(N[CG])([_-])?([0-9]+)(\.[0-9]+)?\(([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
         'refseq_genomic'              => [ '/(N[CG])([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
+        'refseq_coding_with_gene'     => [ '/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?\(([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)\)/', [] ],
         'refseq_coding'               => [ '/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
+        'refseq_non-coding_with_gene' => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?\(([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)\)/', [] ],
         'refseq_non-coding'           => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
+        'refseq_gene_with_coding'     => [ '/(?:[A-Z][A-Za-z0-9#@-]*)\(([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
+        'refseq_gene_with_non-coding' => [ '/(?:[A-Z][A-Za-z0-9#@-]*)\(([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
     ];
 
     public function validate ()
@@ -1973,8 +1977,12 @@ class HGVS_ReferenceSequence extends HGVS
                 }
                 break;
 
+            case 'refseq_coding_with_gene':
             case 'refseq_coding':
+            case 'refseq_non-coding_with_gene':
             case 'refseq_non-coding':
+            case 'refseq_gene_with_coding':
+            case 'refseq_gene_with_non-coding':
                 $this->molecule_type = 'transcript';
                 $this->setCorrectedValue(
                     strtoupper($this->regex[1]) .

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3687,8 +3687,8 @@ class HGVS_Variant extends HGVS
         //  so I need to do that here, once I know whether it was correct or not.
         if ($this->predicted
             || (isset($this->DNAVariantBody->DNAPositions)
-                && ($this->DNAVariantBody->DNAPositions->uncertain || $this->DNAVariantBody->DNAPositions->unknown))
-            || in_array($this->data['type'] ?? '', ['0', '?', ';', 'met'])
+                && ($this->DNAVariantBody->DNAPositions->uncertain || $this->DNAVariantBody->DNAPositions->unknown || $this->DNAVariantBody->DNAPositions->ISCN))
+            || in_array($this->data['type'] ?? '', ['0', '?', ';', 'met', 'repeat'])
             || $this->DNAVariantBody->getCorrectedValue() == '=') {
             if ($this->caseOK
                 && !array_filter(array_keys($this->messages), function ($sKey) { return in_array($sKey[0], ['E','W']); })) {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2474,6 +2474,7 @@ class HGVS_ReferenceSequence extends HGVS
         'refseq_gene_with_coding'     => [ '/(?:[A-Z][A-Za-z0-9#@-]*)\(([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
         'refseq_gene_with_non-coding' => [ '/(?:[A-Z][A-Za-z0-9#@-]*)\(([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
         'refseq_protein'              => [ '/([NX]P)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
+        'refseq_other'                => [ '/^(N[TW]_([0-9]{6})|[A-Z][0-9]{5}|[A-Z]{2}[0-9]{6})(\.[0-9]+)/', [] ],
         'ensembl_genomic'             => [ '/(ENSG)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
         'ensembl_transcript'          => [ '/(ENST)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
         'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
@@ -2602,6 +2603,20 @@ class HGVS_ReferenceSequence extends HGVS
                     $this->messages['WREFERENCEFORMAT'] =
                         'The reference sequence ID should not include a gene symbol.';
                 }
+                break;
+
+            case 'refseq_other':
+                $this->molecule_type = 'genome';
+                // We won't attempt to fix things. We don't actually know if anything like this is valid.
+                $this->setCorrectedValue(strtoupper($this->regex[0]));
+                $this->caseOK = ($this->regex[1] == strtoupper($this->regex[1]));
+
+                // This isn't really a warning, as in, we can't fix it.
+                // But I don't want to throw an error, either. It could still be valid HGVS nomenclature.
+                $this->messages['WREFERENCENOTSUPPORTED'] =
+                    'Currently, variant descriptions using "' . $this->value . '" are not yet supported.' .
+                    ' This does not necessarily mean the description is not valid HGVS.' .
+                    ' Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.';
                 break;
 
             case 'ensembl_genomic':

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2219,6 +2219,33 @@ class HGVS_DNAWildType extends HGVS
 
 
 
+class HGVS_Genome extends HGVS
+{
+    public array $patterns = [
+        'ucsc' => [ '/hg(18|19|38)/', [] ],
+        'ncbi' => [ '/GRCh3(6|7|8)/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        if ($this->matched_pattern == 'ucsc') {
+            $this->setCorrectedValue(strtolower($this->value));
+        } else {
+            $sUCSC = [
+                'grch36' => 'hg18',
+                'grch37' => 'hg19',
+                'grch38' => 'hg38',
+            ][strtolower($this->value)];
+            $this->setCorrectedValue($sUCSC);
+        }
+    }
+}
+
+
+
+
+
 class HGVS_Length extends HGVS
 {
     public array $patterns = [

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2649,6 +2649,22 @@ class HGVS_DNARepeat extends HGVS
                     }
                 }
             }
+
+            // If there is a suffix, check for sequence without a length. We assume they forgot a "[1]".
+            if ($this->suffix) {
+                $Suffix = new HGVS_DNAAlts($this->suffix, $this);
+                if ($Suffix && $Suffix->isValid()) {
+                    $this->messages['WSUFFIXFORMAT'] =
+                        'The part after "' . $aRepeatUnits[array_key_last($aRepeatUnits)]->getValue() . '" does not follow HGVS guidelines.' .
+                        ' When describing repeats, each unit needs a length.';
+                    // Add the sequence to the repeats and try again.
+                    $this->components[] = new HGVS_DNARepeatComponent($this->suffix . '[1]');
+                    $this->corrected_values = [];
+                    $this->suffix = '';
+                    unset($this->messages['EINVALIDREPEATLENGTH']);
+                    return $this->validate();
+                }
+            }
         }
     }
 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2783,8 +2783,8 @@ class HGVS_DNAPositions extends HGVS
 class HGVS_DNAPrefix extends HGVS
 {
     public array $patterns = [
-        'coding'        => [ '/c(?![A-Z])/', [] ],
-        'genomic'       => [ '/g(?![A-Z])/', [] ],
+        'coding'        => [ '/c(?!([A-Z]|[0-9]+[ACGT]+$))/', [] ],
+        'genomic'       => [ '/g(?!([A-Z]|[0-9]+[ACGT]+$))/', [] ],
         'mitochondrial' => [ '/m(?![A-Z])/', [] ],
         'non-coding'    => [ '/n(?![A-Z])/', [] ],
         'circular'      => [ '/o(?![A-Z])/', [] ],

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -531,6 +531,25 @@ class HGVS
 
 
 
+class HGVS_DNACon extends HGVS
+{
+    public array $patterns = [
+        [ '/con/', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->setCorrectedValue('delins');
+        $this->data['type'] = $this->getCorrectedValue();
+        $this->messages['WWRONGTYPE'] = 'A conversion should be described as a deletion-insertion.';
+    }
+}
+
+
+
+
+
 class HGVS_DNADel extends HGVS
 {
     public array $patterns = [
@@ -1734,7 +1753,7 @@ class HGVS_DNARefs extends HGVS
             // This is a special case. We need to prevent that we're matching HGVS reserved terms, like "ins".
             // If we do, we need to pretend that we never matched at all.
             $nReservedWord = false;
-            foreach (['del', 'dup', 'ins', 'inv'] as $sKeyword) {
+            foreach (['con', 'del', 'dup', 'ins', 'inv'] as $sKeyword) {
                 $n = strpos($this->getCorrectedValue(), strtoupper($sKeyword));
                 if ($n !== false && ($nReservedWord === false || $n < $nReservedWord)) {
                     $nReservedWord = $n;
@@ -1799,6 +1818,8 @@ class HGVS_DNAVariantBody extends HGVS
         'ins'                 => [ 'HGVS_DNAPositions', 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for insertions.' ] ],
         'dup_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNADup', 'HGVS_DNADupSuffix', [] ],
         'dup'                 => [ 'HGVS_DNAPositions', 'HGVS_DNADup', [] ],
+        'con_with_suffix'     => [ 'HGVS_DNAPositions', 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
+        'con'                 => [ 'HGVS_DNAPositions', 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
     ];
 
     public function validate ()

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2473,6 +2473,7 @@ class HGVS_ReferenceSequence extends HGVS
         'refseq_non-coding'           => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
         'refseq_gene_with_coding'     => [ '/(?:[A-Z][A-Za-z0-9#@-]*)\(([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
         'refseq_gene_with_non-coding' => [ '/(?:[A-Z][A-Za-z0-9#@-]*)\(([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?\)/', [] ],
+        'refseq_protein'              => [ '/([NX]P)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
         'ensembl_genomic'             => [ '/(ENSG)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
         'ensembl_transcript'          => [ '/(ENST)([_-])?([0-9]+)(\.[0-9]+)?/', [] ],
         'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
@@ -2574,7 +2575,8 @@ class HGVS_ReferenceSequence extends HGVS
             case 'refseq_non-coding':
             case 'refseq_gene_with_coding':
             case 'refseq_gene_with_non-coding':
-                $this->molecule_type = 'transcript';
+            case 'refseq_protein':
+                $this->molecule_type = ($this->matched_pattern == 'refseq_protein'? 'protein' : 'transcript');
                 $this->setCorrectedValue(
                     strtoupper($this->regex[1]) .
                     '_' .
@@ -2588,15 +2590,15 @@ class HGVS_ReferenceSequence extends HGVS
                         'NCBI reference sequence IDs require an underscore between the prefix and the numeric ID.';
                 } elseif (strlen((int) $this->regex[3]) > 9) {
                     $this->messages['EREFERENCEFORMAT'] =
-                        'NCBI transcript reference sequence IDs consist of six or nine digits.';
+                        'NCBI ' . $this->molecule_type . ' reference sequence IDs consist of six or nine digits.';
                 } elseif (!in_array(strlen($this->regex[3]), [6, 9])) {
                     $this->messages['WREFERENCEFORMAT'] =
-                        'NCBI transcript reference sequence IDs consist of six or nine digits.';
+                        'NCBI ' . $this->molecule_type . ' reference sequence IDs consist of six or nine digits.';
                 } elseif (empty($this->regex[4])) {
                     $this->messages['EREFERENCEFORMAT'] =
                         'The reference sequence ID is missing the required version number.' .
                         ' NCBI RefSeq and Ensembl IDs require version numbers when used in variant descriptions.';
-                } elseif (!in_array($this->matched_pattern, ['refseq_coding', 'refseq_non-coding'])) {
+                } elseif (!in_array($this->matched_pattern, ['refseq_coding', 'refseq_non-coding', 'refseq_protein'])) {
                     $this->messages['WREFERENCEFORMAT'] =
                         'The reference sequence ID should not include a gene symbol.';
                 }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2024-12-16
+ * Modified    : 2024-12-18
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -861,17 +861,6 @@ class HGVS_DNADel extends HGVS
 
 
 
-class HGVS_DNADup extends HGVS_DNADel
-{
-    public array $patterns = [
-        [ '/dup/', [] ],
-    ];
-}
-
-
-
-
-
 class HGVS_DNAAlts extends HGVS
 {
     public array $patterns = [
@@ -1028,6 +1017,17 @@ class HGVS_DNADelSuffix extends HGVS
             }
         }
     }
+}
+
+
+
+
+
+class HGVS_DNADup extends HGVS_DNADel
+{
+    public array $patterns = [
+        [ '/dup/', [] ],
+    ];
 }
 class HGVS_DNADupSuffix extends HGVS_DNADelSuffix {}
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -56,6 +56,7 @@ class HGVS
     public array $regex = [];
     public bool $caseOK = true;
     public bool $matched = false;
+    public int $patterns_matched = 0;
     public string $input;
     public string $current_pattern;
     public string $matched_pattern;
@@ -94,6 +95,7 @@ class HGVS
                         // This pattern matched. Store what is left, if anything is left.
                         $sInputToParse = $aPattern[$i]->getSuffix();
                         // Merge their data and messages with ours.
+                        $this->patterns_matched += $aPattern[$i]->getPatternsMatched();
                         $this->data = array_merge(
                             $this->data,
                             $aPattern[$i]->getData()
@@ -123,6 +125,8 @@ class HGVS
                     } else {
                         // Didn't match.
                         $bMatching = false;
+                        // We still need to store whether any patterns were matched.
+                        $this->patterns_matched += $aPattern[$i]->getPatternsMatched();
                         break;
                     }
 
@@ -130,7 +134,9 @@ class HGVS
                     // Regex. Make sure it matches the start of the string. Make sure it's case-insensitive.
                     $sPattern = '/^' . substr($sPattern, 1) . 'i';
                     if (preg_match($sPattern, $sInputToParse, $aRegs)) {
-                        // This pattern matched. Store what is left, if anything is left.
+                        // This pattern matched.
+                        $this->patterns_matched ++;
+                        // Store what is left, if anything is left.
                         // Note that regexes should not be part of a pattern array, but only get their own pattern line. E.g., this object is all about this regex, or we messed up.
                         $sInputToParse = substr($sInputToParse, strlen($aRegs[0]));
                         // Store the regex values for further processing, if needed.
@@ -144,7 +150,9 @@ class HGVS
                 } else {
                     // Assume a simple string match.
                     if (strlen($sInputToParse) >= strlen($sPattern) && substr($sInputToParse, 0, strlen($sPattern)) == $sPattern) {
-                        // This pattern matched. Store what is left, if anything is left.
+                        // This pattern matched.
+                        $this->patterns_matched ++;
+                        // Store what is left, if anything is left.
                         $sInputToParse = substr($sInputToParse, strlen($sPattern));
                     } else {
                         // Didn't match.
@@ -208,7 +216,7 @@ class HGVS
 
     public function __debugInfo ()
     {
-        // This functions is called whenever a var_dump() is called on the object.
+        // This function is called whenever a var_dump() is called on the object.
         // Because we want to limit the space taken up in the var_dump() output, we'll limit it here.
 
         $aReturn = [
@@ -468,6 +476,15 @@ class HGVS
                 return $o->getParentProperty($sPropertyName);
             }
         }
+    }
+
+
+
+
+
+    public function getPatternsMatched ()
+    {
+        return $this->patterns_matched;
     }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -107,7 +107,7 @@ class HGVS
                 // Quick check: do we still have something left?
                 if ($sInputToParse === '') {
                     if ($bDebugging) {
-                        print("$sClassString($sInputToParse) ran out of input, but expecting more. aborting.\n");
+                        print("$sClassString('$sInputToParse') ran out of input, but expecting more. aborting.\n");
                     }
                     $bMatching = false;
                     // This can be a sign that a variant wasn't submitted completely, and we should try to get more input.
@@ -120,17 +120,17 @@ class HGVS
                     // Have we seen this before? Ran it already? But not modified it afterward?
                     if (isset($this->memory[$sPattern][$sInputToParse]) && !$this->memory[$sPattern][$sInputToParse]->isTainted()) {
                         if ($bDebugging) {
-                            print("$sClassString($sInputToParse) rule $sPatternName, pattern $sPattern, reusing previous result.\n");
+                            print("$sClassString('$sInputToParse') rule $sPatternName, pattern $sPattern, reusing previous result.\n");
                         }
                         $aPattern[$i] = $this->memory[$sPattern][$sInputToParse];
                     } else {
                         if ($bDebugging) {
                             if (isset($this->memory[$sPattern][$sInputToParse])) {
-                                print("$sClassString($sInputToParse) rule $sPatternName, pattern $sPattern, previous result is tainted, discarding.\n");
+                                print("$sClassString('$sInputToParse') rule $sPatternName, pattern $sPattern, previous result is tainted, discarding.\n");
                             }
-                            print("$sClassString($sInputToParse) rule $sPatternName, pattern $sPattern, result is pending.\n");
+                            print("$sClassString('$sInputToParse') rule $sPatternName, pattern $sPattern, result is pending.\n");
                         }
-                        $aPattern[$i] = new $sPattern($sInputToParse, $this);
+                        $aPattern[$i] = new $sPattern($sInputToParse, $this, $bDebugging);
                         // Store for later, if needed.
                         $this->memory[$sPattern][$sInputToParse] = $aPattern[$i];
                     }
@@ -138,7 +138,7 @@ class HGVS
                     if ($aPattern[$i]->hasMatched()) {
                         // This pattern matched. Store what is left, if anything is left.
                         if ($bDebugging) {
-                            print("$sClassString($sInputToParse) rule $sPatternName, pattern $sPattern, success.\n");
+                            print("$sClassString('$sInputToParse') rule $sPatternName, pattern $sPattern, success.\n");
                         }
                         $sInputToParse = $aPattern[$i]->getSuffix();
                         // Merge their data and messages with ours.
@@ -176,7 +176,7 @@ class HGVS
                     } else {
                         // Didn't match.
                         if ($bDebugging) {
-                            print("$sClassString($sInputToParse) rule $sPatternName, pattern $sPattern, failed.\n");
+                            print("$sClassString('$sInputToParse') rule $sPatternName, pattern $sPattern, failed.\n");
                         }
                         $bMatching = false;
                         // We still need to store whether any patterns were matched.
@@ -189,7 +189,7 @@ class HGVS
                     // Regex. Make sure it matches the start of the string. Make sure it's case-insensitive.
                     $sPattern = '/^' . substr($sPattern, 1) . 'i';
                     if ($bDebugging) {
-                        print("$sClassString($sInputToParse) rule $sPatternName, pattern $sPattern, and this returned " . (int) preg_match($sPattern, $sInputToParse) . "\n");
+                        print("$sClassString('$sInputToParse') rule $sPatternName, pattern $sPattern, and this returned " . (int) preg_match($sPattern, $sInputToParse) . "\n");
                     }
                     if (preg_match($sPattern, $sInputToParse, $aRegs)) {
                         // This pattern matched.
@@ -208,7 +208,7 @@ class HGVS
                 } else {
                     // Assume a simple string match.
                     if ($bDebugging) {
-                        print("$sClassString($sInputToParse) rule $sPatternName, pattern $sPattern, and this returned " . (int) (strlen($sInputToParse) >= strlen($sPattern) && substr($sInputToParse, 0, strlen($sPattern)) == $sPattern) . "\n");
+                        print("$sClassString('$sInputToParse') rule $sPatternName, pattern $sPattern, and this returned " . (int) (strlen($sInputToParse) >= strlen($sPattern) && substr($sInputToParse, 0, strlen($sPattern)) == $sPattern) . "\n");
                     }
                     if (strlen($sInputToParse) >= strlen($sPattern) && substr($sInputToParse, 0, strlen($sPattern)) == $sPattern) {
                         // This pattern matched.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -358,7 +358,7 @@ class HGVS
                 return ($PositionEnd->offset == 1);
             } else {
                 // No unknowns left, only numeric offsets.
-                return ($PositionStart->offset < $PositionEnd->offset);
+                return ($PositionStart->offset <= $PositionEnd->offset);
             }
 
         } else {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1931,13 +1931,13 @@ class HGVS_DNAPosition extends HGVS
                     }
                 } else {
                     // There really was a prefix, so complain that they used the wrong one.
-                    $this->messages['EWRONGPREFIX'] = 'Chromosomal positions pter, cen, and qter can only be reported using "g." or "m." genomic prefixes.';
+                    $this->messages['EWRONGPREFIX'] = 'Chromosomal positions pter and qter can only be reported using "g." or "m." genomic prefixes.';
                 }
             }
             $RefSeq = $this->getParentProperty('ReferenceSequence');
             if ($RefSeq && $RefSeq->molecule_type != 'chromosome') {
                 $this->messages['EWRONGREFERENCE'] =
-                    'A chromosomal reference sequence is required for pter, cen, or qter positions.';
+                    'A chromosomal reference sequence is required for pter or qter positions.';
             }
             $this->setCorrectedValue(strtolower($this->value));
             $this->caseOK = ($this->value == $this->getCorrectedValue());

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2712,8 +2712,7 @@ class HGVS_DNARepeat extends HGVS
                 $sPrefix = ($Prefix? $Prefix->getCorrectedValue() : 'g');
                 if ($sPrefix == 'c') {
                     foreach ($aRepeatUnits as $Component) {
-                        list($nMinLength, $nMaxLength) = $Component->getLengths();
-                        if ($nMinLength == $nMaxLength && ($nMinLength % 3)) {
+                        if ($Component->hasProperty('DNAAlts') && (strlen($Component->DNAAlts->getCorrectedValue()) % 3)) {
                             // Repeat variants on coding DNA should always have a length of a multiple of three bases.
                             $this->messages['EINVALIDREPEATLENGTH'] =
                                 'A repeat sequence of coding DNA should always have a length of (a multiple of) 3.';

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2768,6 +2768,13 @@ class HGVS_ReferenceSequence extends HGVS
             case 'other':
                 $this->molecule_type = 'unknown';
                 $this->allowed_prefixes = [];
+
+                // Some black listing is needed, though.
+                if (in_array(strtolower($this->value), ['http', 'https'])) {
+                    $this->matched = false;
+                    return;
+                }
+
                 break;
         }
     }

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1022,6 +1022,32 @@ class HGVS_DNAInsSuffixComplexComponent extends HGVS
 
 
 
+class HGVS_DNANull extends HGVS
+{
+    public array $patterns = [
+        'predicted' => [ '0?', [] ],
+        'observed'  => [ '0', [] ],
+    ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        $this->data['type'] = substr($this->getCorrectedValue(), 0, 1);
+        $this->predicted = ($this->matched_pattern == 'predicted');
+
+        $sVariantPrefix = $this->getParent('HGVS_Variant')->DNAPrefix->getCorrectedValue();
+        $this->data['position_start'] = 0;
+        $this->data['position_end'] = 0;
+        $this->data['position_start_intron'] = 0;
+        $this->data['position_end_intron'] = 0;
+        $this->data['range'] = false;
+    }
+}
+
+
+
+
+
 class HGVS_DNAPosition extends HGVS
 {
     public array $patterns = [
@@ -1807,6 +1833,7 @@ class HGVS_DNASub extends HGVS
 class HGVS_DNAVariantBody extends HGVS
 {
     public array $patterns = [
+        'null'                => [ 'HGVS_DNANull', [] ],
         'substitution'        => [ 'HGVS_DNAPositions', 'HGVS_DNARefs', 'HGVS_DNASub', 'HGVS_DNAAlts', [] ],
         'delXins_with_suffix' => [ 'HGVS_DNAPositions', 'HGVS_DNADel', 'HGVS_DNADelSuffix', 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', [] ],
         'delXins'             => [ 'HGVS_DNAPositions', 'HGVS_DNADel', 'HGVS_DNADelSuffix', 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
@@ -1825,6 +1852,12 @@ class HGVS_DNAVariantBody extends HGVS
     public function validate ()
     {
         // Provide additional rules for validation, and stores values for the variant info if needed.
+        if ($this->matched_pattern == 'null') {
+            $this->predicted = $this->DNANull->predicted;
+        } else {
+            $this->predicted = false;
+        }
+
 
         // Delins and substitution variants deserve some additional attention.
         // Based on the REF and ALT info, we may need to shift the variant or change it to a different type.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1311,10 +1311,18 @@ class HGVS_DNAIns extends HGVS
             } elseif (!$Positions->uncertain && $Positions->getCorrectedValue() != '?_?' && $Positions->getLengths() != [2,2]) {
                 // An insertion must always get two positions which are next to each other,
                 //  since the inserted nucleotides will be placed in the middle of those.
-                $this->messages['WPOSITIONSNOTFORINS'] =
-                    'An insertion must have taken place between two neighboring positions.' .
-                    ' If the exact location is unknown, please indicate this by placing parentheses around the positions.';
-                $Positions->makeUncertain();
+                if (!$Positions->unknown) {
+                    // No unknown positions involved, throw a warning and suggest a fix.
+                    // E.g., c.1_10insA -> c.(1_10)insA.
+                    $this->messages['WPOSITIONSNOTFORINS'] =
+                        'An insertion must have taken place between two neighboring positions.' .
+                        ' If the exact location is unknown, please indicate this by placing parentheses around the positions.';
+                    $Positions->makeUncertain();
+                } else {
+                    // E.g., c.1_?insA; we can't suggest anything here.
+                    $this->messages['EPOSITIONSNOTFORINS'] =
+                        'An insertion must have taken place between two neighboring positions.';
+                }
 
             } elseif ($Positions->uncertain && $Positions->getLengths() == [1,2]) {
                 // If the exact location of an insertion is unknown, this can be indicated

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3205,10 +3205,16 @@ class HGVS_DNASup extends HGVS
             if (isset($VariantPrefix->getMessages()['EPREFIXMISSING']) || isset($VariantPrefix->getMessages()['WPREFIXMISSING'])) {
                 // Actually the prefix is missing completely. In that case, remove all suggestions that aren't g.
                 //  and m. and just leave it.
+                $nValues = count($VariantPrefix->getCorrectedValues());
                 foreach (array_keys($VariantPrefix->getCorrectedValues()) as $sPrefix) {
                     if (!in_array($sPrefix, ['g', 'm'])) {
                         unset($VariantPrefix->corrected_values[$sPrefix]);
                     }
+                }
+                $nFactor = ($nValues / count($VariantPrefix->getCorrectedValues()));
+                if ($nFactor > 1) {
+                    // We removed options, increase the current confidence scores.
+                    $VariantPrefix->appendCorrectedValue('', $nFactor);
                 }
             } else {
                 // There really was a prefix, so complain that they used the wrong one.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -740,6 +740,31 @@ class HGVS
 
 
 
+    public function requireMissingReferenceSequence ()
+    {
+        // Flips the requirement for a reference sequence.
+        // Instead of complaining where there is none, complain when we do have one.
+
+        // We could simply check for EREFSEQMISSING, but that means calling this function twice will result in issues.
+        // We are assuming that we're the root class.
+        if ($this->hasProperty('ReferenceSequence')) {
+            $this->messages['WREFSEQGIVEN'] = 'In this field, a reference sequence should not be provided.';
+            // FIXME: And what about the corrected values?
+
+        } else {
+            // Unset the error in case we had it.
+            unset($this->messages['EREFSEQMISSING']);
+        }
+        // Rebuild the info just in case.
+        $this->buildInfo();
+
+        return true;
+    }
+
+
+
+
+
     public function setCorrectedValue ($sValue, $nConfidence = 1)
     {
         // Conveniently sets the corrected value for us.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-30   // When modified, also change the library_version.
+ * Modified    : 2025-01-31   // When modified, also change the library_version.
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -44,12 +44,12 @@ class HGVS
     //        you should create an object. The reason for this is that we can't deduce from a regular expression what it
     //        matched. An object holds its value, a string has a fixed value by itself, but a regex can't store a value.
     public array $patterns = [
-        'full_variant'       => [ 'HGVS_ReferenceSequence', ':', 'HGVS_Variant', [] ],
-        'variant'            => [ 'HGVS_Variant', ['EREFSEQMISSING' => 'This variant is missing a reference sequence.'] ],
-        'VCF'                => [ 'HGVS_VCF', ['WVCF' => 'Recognized a VCF-like format; converting this format to HGVS nomenclature.'] ],
-        'reference_sequence' => [ 'HGVS_ReferenceSequence', [] ],
-        'genome_build'       => [ 'HGVS_Genome', [] ],
-        'variant_identifier' => [ 'HGVS_VariantIdentifier', [] ],
+        'full_variant'       => ['HGVS_ReferenceSequence', ':', 'HGVS_Variant', []],
+        'variant'            => ['HGVS_Variant', ['EREFSEQMISSING' => 'This variant is missing a reference sequence.']],
+        'VCF'                => ['HGVS_VCF', ['WVCF' => 'Recognized a VCF-like format; converting this format to HGVS nomenclature.']],
+        'reference_sequence' => ['HGVS_ReferenceSequence', []],
+        'genome_build'       => ['HGVS_Genome', []],
+        'variant_identifier' => ['HGVS_VariantIdentifier', []],
     ];
     public array $corrected_values = [];
     public array $data = [];
@@ -156,7 +156,7 @@ class HGVS
                         // Sometimes we have multiple values. E.g., positions. Store them in an array.
                         if (isset($this->$sName)) {
                             if (!is_array($this->$sName)) {
-                                $this->$sName = [ $this->$sName ];
+                                $this->$sName = [$this->$sName];
                             }
                             $this->$sName[] = $aPattern[$i];
                         } else {
@@ -690,7 +690,7 @@ class HGVS
     public static function getVersions ()
     {
         return [
-            'library_version' => '2025-01-30',
+            'library_version' => '2025-01-31',
             'HGVS_nomenclature_versions' => [
                 'input' => [
                     'minimum' => '15.11',
@@ -850,7 +850,7 @@ class HGVS_Caret extends HGVS
     public array $patterns = [
         // NOTE: The HGVS nomenclature hasn't clarified the "or" syntax well. It's likely a "moving target" and needs
         //        clarification and an improved definition in the HGVS nomenclature. Until then, we won't support it.
-        'anything' => [ '/.*\^.+/', [] ],
+        'anything' => ['/.*\^.+/', []],
     ];
 
     public function validate ()
@@ -879,9 +879,9 @@ class HGVS_DNAAllele extends HGVS
 {
     public array $components = [];
     public array $patterns = [
-        'multiple_cis'     => [ 'HGVS_DNAVariantBody', ';', 'HGVS_DNAAllele', [] ],
-        'multiple_comma'   => [ 'HGVS_DNAVariantBody', ',', 'HGVS_DNAAllele', [ 'WALLELEFORMAT' => 'The allele syntax uses semicolons (;) to separate variants, not commas.' ] ],
-        'single'           => [ 'HGVS_DNAVariantBody', [] ],
+        'multiple_cis'     => ['HGVS_DNAVariantBody', ';', 'HGVS_DNAAllele', []],
+        'multiple_comma'   => ['HGVS_DNAVariantBody', ',', 'HGVS_DNAAllele', ['WALLELEFORMAT' => 'The allele syntax uses semicolons (;) to separate variants, not commas.']],
+        'single'           => ['HGVS_DNAVariantBody', []],
     ];
 
     public function getComponents ()
@@ -940,7 +940,7 @@ class HGVS_DNAAllele extends HGVS
 class HGVS_Chr extends HGVS
 {
     public array $patterns = [
-        [ '/chr(omosome)?/', [] ],
+        ['/chr(omosome)?/', []],
     ];
 
     public function validate ()
@@ -958,14 +958,14 @@ class HGVS_Chr extends HGVS
 class HGVS_Chromosome extends HGVS
 {
     public array $patterns = [
-        'chr#(Genome)' => [ 'HGVS_Chr', 'HGVS_ChromosomeNumber', '(', 'HGVS_Genome', ')', [] ],
-        'chr#{Genome}' => [ 'HGVS_Chr', 'HGVS_ChromosomeNumber', '{', 'HGVS_Genome', '}', [] ],
-        'chr#[Genome]' => [ 'HGVS_Chr', 'HGVS_ChromosomeNumber', '[', 'HGVS_Genome', ']', [] ],
-        'chr#'         => [ 'HGVS_Chr', 'HGVS_ChromosomeNumber', [] ],
-        '#(Genome)'    => [ 'HGVS_ChromosomeNumber', '(', 'HGVS_Genome', ')', [] ],
-        '#{Genome}'    => [ 'HGVS_ChromosomeNumber', '{', 'HGVS_Genome', '}', [] ],
-        '#[Genome]'    => [ 'HGVS_ChromosomeNumber', '[', 'HGVS_Genome', ']', [] ],
-        '#'            => [ 'HGVS_ChromosomeNumber', [] ],
+        'chr#(Genome)' => ['HGVS_Chr', 'HGVS_ChromosomeNumber', '(', 'HGVS_Genome', ')', []],
+        'chr#{Genome}' => ['HGVS_Chr', 'HGVS_ChromosomeNumber', '{', 'HGVS_Genome', '}', []],
+        'chr#[Genome]' => ['HGVS_Chr', 'HGVS_ChromosomeNumber', '[', 'HGVS_Genome', ']', []],
+        'chr#'         => ['HGVS_Chr', 'HGVS_ChromosomeNumber', []],
+        '#(Genome)'    => ['HGVS_ChromosomeNumber', '(', 'HGVS_Genome', ')', []],
+        '#{Genome}'    => ['HGVS_ChromosomeNumber', '{', 'HGVS_Genome', '}', []],
+        '#[Genome]'    => ['HGVS_ChromosomeNumber', '[', 'HGVS_Genome', ']', []],
+        '#'            => ['HGVS_ChromosomeNumber', []],
     ];
     public array $refseqs = [
         'hg18' => [
@@ -1095,10 +1095,10 @@ class HGVS_Chromosome extends HGVS
 class HGVS_ChromosomeNumber extends HGVS
 {
     public array $patterns = [
-        'number' => [ '/[0-9]{1,2}(?![0-9])/', [] ],
-        'X'      => [ '/X(?![A-Z])/', [] ],
-        'Y'      => [ '/Y(?![A-Z])/', [] ],
-        'M'      => [ '/M(?![A-Z])/', [] ],
+        'number' => ['/[0-9]{1,2}(?![0-9])/', []],
+        'X'      => ['/X(?![A-Z])/', []],
+        'Y'      => ['/Y(?![A-Z])/', []],
+        'M'      => ['/M(?![A-Z])/', []],
     ];
 
     public function validate ()
@@ -1122,8 +1122,8 @@ class HGVS_ChromosomeNumber extends HGVS
 class HGVS_DNAAlts extends HGVS
 {
     public array $patterns = [
-        'invalid' => [ '/[A-Z]+/', [] ],
-        'valid'   => [ '/[ACGTMRWSYKVHDBN]+/', [] ],
+        'invalid' => ['/[A-Z]+/', []],
+        'valid'   => ['/[ACGTMRWSYKVHDBN]+/', []],
     ];
 
     public function validate ()
@@ -1159,7 +1159,7 @@ class HGVS_DNAAlts extends HGVS
 class HGVS_DNACNV extends HGVS
 {
     public array $patterns = [
-        [ '[', 'HGVS_Lengths', ']', [] ],
+        ['[', 'HGVS_Lengths', ']', []],
     ];
 
     public function validate ()
@@ -1197,7 +1197,7 @@ class HGVS_DNACNV extends HGVS
 class HGVS_DNACon extends HGVS
 {
     public array $patterns = [
-        [ '/con/', [] ],
+        ['/con/', []],
     ];
 
     public function validate ()
@@ -1231,7 +1231,7 @@ class HGVS_DNACon extends HGVS
 class HGVS_DNADel extends HGVS
 {
     public array $patterns = [
-        [ '/del/', [] ],
+        ['/del/', []],
     ];
 
     public function validate ()
@@ -1254,17 +1254,17 @@ class HGVS_DNADelSuffix extends HGVS
     use HGVS_DNASequence; // Gets us getSequence() and getLengths().
     public array $patterns = [
         // Since none of these match "ins", a "delAinsC" won't ever pass here.
-        [ 'HGVS_Lengths', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '[', 'HGVS_Lengths', ']', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ 'HGVS_DNARefs', 'HGVS_Lengths', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ 'HGVS_DNARefs', '[', 'HGVS_Lengths', ']', [] ],
-        [ 'HGVS_DNARefs', [] ],
-        [ '(', 'HGVS_DNARefs', ')', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '(', 'HGVS_DNARefs', 'HGVS_Lengths', ')', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '(', 'HGVS_DNARefs', '[', 'HGVS_Lengths', '])', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '[', 'HGVS_DNARefs', ']', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '[', 'HGVS_DNARefs', 'HGVS_Lengths', ']', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
-        [ '[', 'HGVS_DNARefs', '[', 'HGVS_Lengths', ']]', [ 'WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.' ] ],
+        ['HGVS_Lengths', ['WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.']],
+        ['[', 'HGVS_Lengths', ']', ['WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.']],
+        ['HGVS_DNARefs', 'HGVS_Lengths', ['WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.']],
+        ['HGVS_DNARefs', '[', 'HGVS_Lengths', ']', []],
+        ['HGVS_DNARefs', []],
+        ['(', 'HGVS_DNARefs', ')', ['WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.']],
+        ['(', 'HGVS_DNARefs', 'HGVS_Lengths', ')', ['WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.']],
+        ['(', 'HGVS_DNARefs', '[', 'HGVS_Lengths', '])', ['WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.']],
+        ['[', 'HGVS_DNARefs', ']', ['WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.']],
+        ['[', 'HGVS_DNARefs', 'HGVS_Lengths', ']', ['WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.']],
+        ['[', 'HGVS_DNARefs', '[', 'HGVS_Lengths', ']]', ['WSUFFIXFORMAT' => 'The part after "del" does not follow HGVS guidelines.']],
     ];
 
     public function validate ()
@@ -1371,7 +1371,7 @@ class HGVS_DNADelSuffix extends HGVS
 class HGVS_DNADup extends HGVS_DNADel
 {
     public array $patterns = [
-        [ '/dup/', [] ],
+        ['/dup/', []],
     ];
 }
 
@@ -1413,7 +1413,7 @@ class HGVS_DNADupSuffix extends HGVS_DNADelSuffix
 class HGVS_DNAIns extends HGVS
 {
     public array $patterns = [
-        [ '/ins/', [] ],
+        ['/ins/', []],
     ];
 
     public function validate ()
@@ -1503,24 +1503,24 @@ class HGVS_DNAInsSuffix extends HGVS
 {
     use HGVS_DNASequence; // Gets us getSequence() and getLengths().
     public array $patterns = [
-        'refseq_with_positions_inv'        => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.' ] ],
-        'refseq_with_positions'            => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.' ] ],
-        'refseq_only'                      => [ 'HGVS_ReferenceSequence', [ 'WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.', 'EPOSITIONSMISSING' => 'The insertion of a reference sequence also requires the positions of the sequence taken from this reference sequence.' ] ],
-        'complex_in_brackets'              => [ '[', 'HGVS_DNAInsSuffixComplex', ']', [] ],
-        'positions_inverted'               => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
-        'positions'                        => [ 'HGVS_DNAPositions', [] ],
+        'refseq_with_positions_inv'        => ['HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', ['WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.']],
+        'refseq_with_positions'            => ['HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', ['WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.']],
+        'refseq_only'                      => ['HGVS_ReferenceSequence', ['WSUFFIXFORMATISCOMPLEX' => 'Use square brackets for complex insertions.', 'EPOSITIONSMISSING' => 'The insertion of a reference sequence also requires the positions of the sequence taken from this reference sequence.']],
+        'complex_in_brackets'              => ['[', 'HGVS_DNAInsSuffixComplex', ']', []],
+        'positions_inverted'               => ['HGVS_DNAPositions', 'HGVS_DNAInv', []],
+        'positions'                        => ['HGVS_DNAPositions', []],
         // NOTE: This one only gets matched with "bp" is used, like "100_200bp". Positions refuse to match when "bp" follows the input.
-        'length'                           => [ 'HGVS_Lengths', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'length_in_brackets'               => [ '[', 'HGVS_Lengths', ']', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_number'             => [ 'HGVS_DNAAlts', 'HGVS_Lengths', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_length'             => [ 'HGVS_DNAAlts', '[', 'HGVS_Lengths', ']', [] ],
-        'sequence'                         => [ 'HGVS_DNAAlts', [] ],
-        'sequence_in_parens'               => [ '(', 'HGVS_DNAAlts', ')', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_number_in_parens'   => [ '(', 'HGVS_DNAAlts', 'HGVS_Lengths', ')', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_length_in_parens'   => [ '(', 'HGVS_DNAAlts', '[', 'HGVS_Lengths', '])', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_in_brackets'             => [ '[', 'HGVS_DNAAlts', ']', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_number_in_brackets' => [ '[', 'HGVS_DNAAlts', 'HGVS_Lengths', ']', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
-        'sequence_with_length_in_brackets' => [ '[', 'HGVS_DNAAlts', '[', 'HGVS_Lengths', ']]', [ 'WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.' ] ],
+        'length'                           => ['HGVS_Lengths', ['WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.']],
+        'length_in_brackets'               => ['[', 'HGVS_Lengths', ']', ['WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.']],
+        'sequence_with_number'             => ['HGVS_DNAAlts', 'HGVS_Lengths', ['WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.']],
+        'sequence_with_length'             => ['HGVS_DNAAlts', '[', 'HGVS_Lengths', ']', []],
+        'sequence'                         => ['HGVS_DNAAlts', []],
+        'sequence_in_parens'               => ['(', 'HGVS_DNAAlts', ')', ['WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.']],
+        'sequence_with_number_in_parens'   => ['(', 'HGVS_DNAAlts', 'HGVS_Lengths', ')', ['WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.']],
+        'sequence_with_length_in_parens'   => ['(', 'HGVS_DNAAlts', '[', 'HGVS_Lengths', '])', ['WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.']],
+        'sequence_in_brackets'             => ['[', 'HGVS_DNAAlts', ']', ['WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.']],
+        'sequence_with_number_in_brackets' => ['[', 'HGVS_DNAAlts', 'HGVS_Lengths', ']', ['WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.']],
+        'sequence_with_length_in_brackets' => ['[', 'HGVS_DNAAlts', '[', 'HGVS_Lengths', ']]', ['WSUFFIXFORMAT' => 'The part after "ins" does not follow HGVS guidelines.']],
     ];
 
     public function validate ()
@@ -1655,8 +1655,8 @@ class HGVS_DNAInsSuffixComplex extends HGVS
 {
     public array $components = [];
     public array $patterns = [
-        'multiple' => [ 'HGVS_DNAInsSuffixComplexComponent', ';', 'HGVS_DNAInsSuffixComplex', [] ],
-        'single'   => [ 'HGVS_DNAInsSuffixComplexComponent', [] ],
+        'multiple' => ['HGVS_DNAInsSuffixComplexComponent', ';', 'HGVS_DNAInsSuffixComplex', []],
+        'single'   => ['HGVS_DNAInsSuffixComplexComponent', []],
     ];
 
     public function getComponents ()
@@ -1750,12 +1750,12 @@ class HGVS_DNAInsSuffixComplex extends HGVS
 class HGVS_DNAInsSuffixComplexComponent extends HGVS_DNAInsSuffix
 {
     public array $patterns = [
-        'refseq_with_positions_inv' => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
-        'refseq_with_positions'     => [ 'HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', [] ],
-        'sequence_with_length'      => [ 'HGVS_DNAAlts', '[', 'HGVS_Lengths', ']', [] ],
-        'sequence'                  => [ 'HGVS_DNAAlts', [] ],
-        'positions_inverted'        => [ 'HGVS_DNAPositions', 'HGVS_DNAInv', [] ],
-        'positions'                 => [ 'HGVS_DNAPositions', [] ],
+        'refseq_with_positions_inv' => ['HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', 'HGVS_DNAInv', []],
+        'refseq_with_positions'     => ['HGVS_ReferenceSequence', ':', 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAPositions', []],
+        'sequence_with_length'      => ['HGVS_DNAAlts', '[', 'HGVS_Lengths', ']', []],
+        'sequence'                  => ['HGVS_DNAAlts', []],
+        'positions_inverted'        => ['HGVS_DNAPositions', 'HGVS_DNAInv', []],
+        'positions'                 => ['HGVS_DNAPositions', []],
     ];
 }
 
@@ -1766,7 +1766,7 @@ class HGVS_DNAInsSuffixComplexComponent extends HGVS_DNAInsSuffix
 class HGVS_DNAInv extends HGVS
 {
     public array $patterns = [
-        [ '/inv/', [] ],
+        ['/inv/', []],
     ];
 
     public function validate ()
@@ -1848,8 +1848,8 @@ class HGVS_DNAInvSuffix extends HGVS_DNADelSuffix
 class HGVS_DNANull extends HGVS
 {
     public array $patterns = [
-        'predicted' => [ '0?', [] ],
-        'observed'  => [ '0', [] ],
+        'predicted' => ['0?', []],
+        'observed'  => ['0', []],
     ];
 
     public function validate ()
@@ -1883,8 +1883,8 @@ class HGVS_DNAPipe extends HGVS
 {
     use HGVS_CheckBasesGiven; // Gives us checkBasesGiven().
     public array $patterns = [
-        'pipe(s)' => [ '/\|+/', [] ],
-        'nothing' => [ 'HGVS_DNAPipeSuffix', [] ],
+        'pipe(s)' => ['/\|+/', []],
+        'nothing' => ['HGVS_DNAPipeSuffix', []],
     ];
 
     public function validate ()
@@ -1915,12 +1915,12 @@ class HGVS_DNAPipe extends HGVS
 class HGVS_DNAPipeSuffix extends HGVS
 {
     public array $patterns = [
-        'met='    => [ '/met=/', [] ],
-        'met'     => [ '/met/', [] ],
-        '='       => [ '/=/', [] ],
-        'gom'     => [ '/gom/', [] ],
-        'lom'     => [ '/lom/', [] ],
-        'invalid' => [ '/[A-Z]+/', [] ],
+        'met='    => ['/met=/', []],
+        'met'     => ['/met/', []],
+        '='       => ['/=/', []],
+        'gom'     => ['/gom/', []],
+        'lom'     => ['/lom/', []],
+        'invalid' => ['/[A-Z]+/', []],
     ];
 
     public function validate ()
@@ -1959,11 +1959,11 @@ class HGVS_DNAPipeSuffix extends HGVS
 class HGVS_DNAPosition extends HGVS
 {
     public array $patterns = [
-        'unknown'          => [ '?', [] ],
-        'unknown_intronic' => [ '/([-‐−–—*]?([0-9,]+))([+—–−‐-]\?)/u', [] ],
-        'known'            => [ '/([-‐−–—*]?([0-9,]+))([+—–−‐-]([0-9,]+))?(?![0-9]*bp)/u', [] ],
-        'pter'             => [ '/pter/', [] ],
-        'qter'             => [ '/qter/', [] ],
+        'unknown'          => ['?', []],
+        'unknown_intronic' => ['/([-‐−–—*]?([0-9,]+))([+—–−‐-]\?)/u', []],
+        'known'            => ['/([-‐−–—*]?([0-9,]+))([+—–−‐-]([0-9,]+))?(?![0-9]*bp)/u', []],
+        'pter'             => ['/pter/', []],
+        'qter'             => ['/qter/', []],
     ];
     public array $position_limits = [
         'g' => [1, 4294967295, 0, 0], // position min, position max, offset min, offset max.
@@ -2158,7 +2158,7 @@ class HGVS_DNAPosition extends HGVS
 class HGVS_DNAPositionSeparator extends HGVS
 {
     public array $patterns = [
-        [ '_', [] ],
+        ['_', []],
     ];
 
     public function validate ()
@@ -2194,9 +2194,9 @@ class HGVS_DNAPositionSeparator extends HGVS
 class HGVS_DNAPositionStart extends HGVS
 {
     public array $patterns = [
-        'uncertain_range'  => [ '(', 'HGVS_DNAPosition', '_', 'HGVS_DNAPosition', ')', [] ],
-        'uncertain_single' => [ '(', 'HGVS_DNAPosition', ')', [ 'WTOOMANYPARENS' => "The variant's positions contain redundant parentheses." ] ],
-        'single'           => [ 'HGVS_DNAPosition', [] ],
+        'uncertain_range'  => ['(', 'HGVS_DNAPosition', '_', 'HGVS_DNAPosition', ')', []],
+        'uncertain_single' => ['(', 'HGVS_DNAPosition', ')', ['WTOOMANYPARENS' => "The variant's positions contain redundant parentheses."]],
+        'single'           => ['HGVS_DNAPosition', []],
     ];
 
     public function validate ()
@@ -2346,10 +2346,10 @@ class HGVS_DNAPositionEnd extends HGVS_DNAPositionStart {}
 class HGVS_DNAPositions extends HGVS
 {
     public array $patterns = [
-        'range'            => [ 'HGVS_DNAPositionStart', 'HGVS_DNAPositionSeparator', 'HGVS_DNAPositionEnd', [] ],
-        'uncertain_range'  => [ '(', 'HGVS_DNAPositionStart', 'HGVS_DNAPositionSeparator', 'HGVS_DNAPositionEnd', ')', [] ],
-        'uncertain_single' => [ '(', 'HGVS_DNAPosition', ')', [ 'WTOOMANYPARENS' => "This variant description contains a position with redundant parentheses." ] ],
-        'single'           => [ 'HGVS_DNAPosition', [] ],
+        'range'            => ['HGVS_DNAPositionStart', 'HGVS_DNAPositionSeparator', 'HGVS_DNAPositionEnd', []],
+        'uncertain_range'  => ['(', 'HGVS_DNAPositionStart', 'HGVS_DNAPositionSeparator', 'HGVS_DNAPositionEnd', ')', []],
+        'uncertain_single' => ['(', 'HGVS_DNAPosition', ')', ['WTOOMANYPARENS' => "This variant description contains a position with redundant parentheses."]],
+        'single'           => ['HGVS_DNAPosition', []],
     ];
     public array $lengths = [];
 
@@ -2852,12 +2852,12 @@ class HGVS_DNAPositions extends HGVS
 class HGVS_DNAPrefix extends HGVS
 {
     public array $patterns = [
-        'coding'        => [ '/c(?!([A-Z]|[0-9]+[ACGT]+$))/', [] ],
-        'genomic'       => [ '/g(?!([A-Z]|[0-9]+[ACGT]+$))/', [] ],
-        'mitochondrial' => [ '/m(?![A-Z])/', [] ],
-        'non-coding'    => [ '/n(?![A-Z])/', [] ],
-        'circular'      => [ '/o(?![A-Z])/', [] ],
-        'nothing'       => [ 'HGVS_Dot', [] ],
+        'coding'        => ['/c(?!([A-Z]|[0-9]+[ACGT]+$))/', []],
+        'genomic'       => ['/g(?!([A-Z]|[0-9]+[ACGT]+$))/', []],
+        'mitochondrial' => ['/m(?![A-Z])/', []],
+        'non-coding'    => ['/n(?![A-Z])/', []],
+        'circular'      => ['/o(?![A-Z])/', []],
+        'nothing'       => ['HGVS_Dot', []],
     ];
 
     public function validate ()
@@ -2927,9 +2927,9 @@ class HGVS_DNARefs extends HGVS
     public array $patterns = [
         // NOTE: I could merge the top two into  '/[A-Z]+(?=(con|del|dup|ins|inv))?/', an optional positive look-ahead.
         //       However, for some reason, since the whole pattern is made to match ignoring the case, A-Z takes it all.
-        'invalid_with_keyword' => [ '/[A-Z]+(?=(con|del|dup|ins|inv))/', [] ],
-        'invalid'              => [ '/[A-Z]+/', [] ],
-        'valid'                => [ '/[ACGTN]+/', [] ],
+        'invalid_with_keyword' => ['/[A-Z]+(?=(con|del|dup|ins|inv))/', []],
+        'invalid'              => ['/[A-Z]+/', []],
+        'valid'                => ['/[ACGTN]+/', []],
     ];
 
     public function validate ()
@@ -2964,8 +2964,8 @@ class HGVS_DNARepeat extends HGVS
 {
     public array $components = [];
     public array $patterns = [
-        'multiple' => [ 'HGVS_DNARepeatComponent', 'HGVS_DNARepeat', [] ],
-        'single'   => [ 'HGVS_DNARepeatComponent', [] ],
+        'multiple' => ['HGVS_DNARepeatComponent', 'HGVS_DNARepeat', []],
+        'single'   => ['HGVS_DNARepeatComponent', []],
     ];
 
     public function getComponents ()
@@ -3150,7 +3150,7 @@ class HGVS_DNARepeatComponent extends HGVS
     use HGVS_DNASequence;
     public array $patterns = [
         // NOTE: We're using DNAAlts, because mixed repeats can be described using IUPAC codes other than A, C, G, or T.
-        'sequence_with_length'      => [ 'HGVS_DNAAlts', '[', 'HGVS_Lengths', ']', [] ],
+        'sequence_with_length'      => ['HGVS_DNAAlts', '[', 'HGVS_Lengths', ']', []],
     ];
 }
 
@@ -3161,7 +3161,7 @@ class HGVS_DNARepeatComponent extends HGVS
 class HGVS_DNASomatic extends HGVS
 {
     public array $patterns = [
-        [ '/\/+/', [] ],
+        ['/\/+/', []],
     ];
 
     public function validate ()
@@ -3187,7 +3187,7 @@ class HGVS_DNASomatic extends HGVS
 class HGVS_DNASomaticVariant extends HGVS
 {
     public array $patterns = [
-        [ 'HGVS_DNASomatic', 'HGVS_DNAVariantType', [] ],
+        ['HGVS_DNASomatic', 'HGVS_DNAVariantType', []],
     ];
 }
 
@@ -3198,8 +3198,8 @@ class HGVS_DNASomaticVariant extends HGVS
 class HGVS_DNASub extends HGVS
 {
     public array $patterns = [
-        'valid'   => [ '>', [] ],
-        'slash'   => [ '/', [] ],
+        'valid'   => ['>', []],
+        'slash'   => ['/', []],
         // Special characters arising from copying variants from PDFs. Some journals decided to use specialized fonts to
         //  create markup for normal characters, such as the ">" in a substitution. This is a terrible idea, as
         //  text-recognition then completely fails and copying the variant from the PDF results in a broken format.
@@ -3212,7 +3212,7 @@ class HGVS_DNASub extends HGVS
         // "→" seen in NYX_11062472_Pusch-2000.pdf ("1040T→C")
         // Because " " has already been trimmed to "", make pattern optional.
         // Note the "u" modifier to allow for UTF-8 characters.
-        'invalid' => [ '/[⬎®?!.4→]?/u', [] ],
+        'invalid' => ['/[⬎®?!.4→]?/u', []],
     ];
 
     public function validate ()
@@ -3246,7 +3246,7 @@ class HGVS_DNASub extends HGVS
 class HGVS_DNASup extends HGVS
 {
     public array $patterns = [
-        [ '/sup/', [] ],
+        ['/sup/', []],
     ];
 
     public function validate ()
@@ -3294,7 +3294,7 @@ class HGVS_DNAUnknown extends HGVS
 {
     use HGVS_CheckBasesGiven; // Gives us checkBasesGiven().
     public array $patterns = [
-        [ '?', [] ],
+        ['?', []],
     ];
 
     public function validate ()
@@ -3315,15 +3315,15 @@ class HGVS_DNAVariantBody extends HGVS
     public array $patterns = [
         // NOTE: The allele syntax with unknown phasing ("variant(;)variant") is handled outside of these patterns.
         //       Otherwise, many patterns will need to be repeated here as we don't support optional patterns (yet).
-        'null'                => [ 'HGVS_DNANull', [] ],
-        'allele_trans'        => [ '[', 'HGVS_DNAAllele', '];[', 'HGVS_DNAAllele', ']', [] ],
-        'allele_cis'          => [ '[', 'HGVS_DNAAllele', ']', [] ],
-        'or'                  => [ 'HGVS_DNAPositions', 'HGVS_Caret', [] ],
-        'somatic'             => [ 'HGVS_DNAPositions', 'HGVS_DNAVariantType', 'HGVS_DNASomaticVariant', [] ],
-        'other'               => [ 'HGVS_DNAPositions', 'HGVS_DNAVariantType', [] ],
-        'protein-like_subst'  => [ 'HGVS_DNARefs', 'HGVS_DNAPositions', 'HGVS_DNAAlts', [ 'WINVALID' => 'This is not a valid HGVS description. Did you mean to write a substitution?' ] ],
-        'unknown'             => [ 'HGVS_DNAUnknown', [] ],
-        'wildtype'            => [ 'HGVS_DNAWildType', [] ],
+        'null'                => ['HGVS_DNANull', []],
+        'allele_trans'        => ['[', 'HGVS_DNAAllele', '];[', 'HGVS_DNAAllele', ']', []],
+        'allele_cis'          => ['[', 'HGVS_DNAAllele', ']', []],
+        'or'                  => ['HGVS_DNAPositions', 'HGVS_Caret', []],
+        'somatic'             => ['HGVS_DNAPositions', 'HGVS_DNAVariantType', 'HGVS_DNASomaticVariant', []],
+        'other'               => ['HGVS_DNAPositions', 'HGVS_DNAVariantType', []],
+        'protein-like_subst'  => ['HGVS_DNARefs', 'HGVS_DNAPositions', 'HGVS_DNAAlts', ['WINVALID' => 'This is not a valid HGVS description. Did you mean to write a substitution?']],
+        'unknown'             => ['HGVS_DNAUnknown', []],
+        'wildtype'            => ['HGVS_DNAWildType', []],
     ];
 
     public function validate ()
@@ -3605,32 +3605,32 @@ class HGVS_DNAVariantBody extends HGVS
 class HGVS_DNAVariantType extends HGVS
 {
     public array $patterns = [
-        'substitution'        => [ 'HGVS_DNARefs', 'HGVS_DNASub', 'HGVS_DNAAlts', [] ],
-        'substitution_VCF'    => [ 'HGVS_VCFRefs', 'HGVS_DNASub', 'HGVS_VCFAlts', [] ],
-        'delXins_with_suffix' => [ 'HGVS_DNADel', 'HGVS_DNADelSuffix', 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', [] ],
-        'delXins'             => [ 'HGVS_DNADel', 'HGVS_DNADelSuffix', 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
-        'delins_with_suffix'  => [ 'HGVS_DNADel', 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', [] ],
-        'delins'              => [ 'HGVS_DNADel', 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
-        'del_with_suffix'     => [ 'HGVS_DNADel', 'HGVS_DNADelSuffix', [] ],
-        'del'                 => [ 'HGVS_DNADel', [] ],
-        'ins_with_suffix'     => [ 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', [] ],
-        'ins'                 => [ 'HGVS_DNAIns', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for insertions.' ] ],
-        'dup_with_suffix'     => [ 'HGVS_DNADup', 'HGVS_DNADupSuffix', [] ],
-        'dup'                 => [ 'HGVS_DNADup', [] ],
-        'inv_with_suffix'     => [ 'HGVS_DNAInv', 'HGVS_DNAInvSuffix', [] ],
-        'inv'                 => [ 'HGVS_DNAInv', [] ],
-        'con_with_suffix'     => [ 'HGVS_DNACon', 'HGVS_DNAInsSuffix', [] ],
-        'con'                 => [ 'HGVS_DNACon', [ 'ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.' ] ],
-        'cnv'                 => [ 'HGVS_DNACNV', [] ],
-        'sup'                 => [ 'HGVS_DNASup', [] ],
-        'repeat'              => [ 'HGVS_DNARepeat', [] ],
-        'pipe_with_refs'      => [ 'HGVS_DNARefs', 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
-        'pipe'                => [ 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', [] ],
-        'unknown_with_refs'   => [ 'HGVS_DNARefs', 'HGVS_DNAUnknown', [ 'EINVALID' => 'This variant description seems incomplete.' ] ],
-        'unknown'             => [ 'HGVS_DNAUnknown', [ 'EINVALID' => 'This variant description seems incomplete.' ] ],
-        'wildtype_with_refs'  => [ 'HGVS_DNARefs', 'HGVS_DNAWildType', [] ],
-        'wildtype'            => [ 'HGVS_DNAWildType', [] ],
-        'refs'                => [ '/[ACGTN]+(?=([^A-Z]|$))/', [] ], // We only want to match valid nucleotides to prevent false positives.
+        'substitution'        => ['HGVS_DNARefs', 'HGVS_DNASub', 'HGVS_DNAAlts', []],
+        'substitution_VCF'    => ['HGVS_VCFRefs', 'HGVS_DNASub', 'HGVS_VCFAlts', []],
+        'delXins_with_suffix' => ['HGVS_DNADel', 'HGVS_DNADelSuffix', 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', []],
+        'delXins'             => ['HGVS_DNADel', 'HGVS_DNADelSuffix', 'HGVS_DNAIns', ['ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.']],
+        'delins_with_suffix'  => ['HGVS_DNADel', 'HGVS_DNAIns', 'HGVS_DNAInsSuffix', []],
+        'delins'              => ['HGVS_DNADel', 'HGVS_DNAIns', ['ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.']],
+        'del_with_suffix'     => ['HGVS_DNADel', 'HGVS_DNADelSuffix', []],
+        'del'                 => ['HGVS_DNADel', []],
+        'ins_with_suffix'     => ['HGVS_DNAIns', 'HGVS_DNAInsSuffix', []],
+        'ins'                 => ['HGVS_DNAIns', ['ESUFFIXMISSING' => 'The inserted sequence must be provided for insertions.']],
+        'dup_with_suffix'     => ['HGVS_DNADup', 'HGVS_DNADupSuffix', []],
+        'dup'                 => ['HGVS_DNADup', []],
+        'inv_with_suffix'     => ['HGVS_DNAInv', 'HGVS_DNAInvSuffix', []],
+        'inv'                 => ['HGVS_DNAInv', []],
+        'con_with_suffix'     => ['HGVS_DNACon', 'HGVS_DNAInsSuffix', []],
+        'con'                 => ['HGVS_DNACon', ['ESUFFIXMISSING' => 'The inserted sequence must be provided for deletion-insertions.']],
+        'cnv'                 => ['HGVS_DNACNV', []],
+        'sup'                 => ['HGVS_DNASup', []],
+        'repeat'              => ['HGVS_DNARepeat', []],
+        'pipe_with_refs'      => ['HGVS_DNARefs', 'HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', []],
+        'pipe'                => ['HGVS_DNAPipe', 'HGVS_DNAPipeSuffix', []],
+        'unknown_with_refs'   => ['HGVS_DNARefs', 'HGVS_DNAUnknown', ['EINVALID' => 'This variant description seems incomplete.']],
+        'unknown'             => ['HGVS_DNAUnknown', ['EINVALID' => 'This variant description seems incomplete.']],
+        'wildtype_with_refs'  => ['HGVS_DNARefs', 'HGVS_DNAWildType', []],
+        'wildtype'            => ['HGVS_DNAWildType', []],
+        'refs'                => ['/[ACGTN]+(?=([^A-Z]|$))/', []], // We only want to match valid nucleotides to prevent false positives.
     ];
 
     public function validate ()
@@ -3887,7 +3887,7 @@ class HGVS_DNAWildType extends HGVS
 {
     use HGVS_CheckBasesGiven; // Gives us checkBasesGiven().
     public array $patterns = [
-        [ '=', [] ],
+        ['=', []],
     ];
 
     public function validate ()
@@ -3906,8 +3906,8 @@ class HGVS_DNAWildType extends HGVS
 class HGVS_Dot extends HGVS
 {
     public array $patterns = [
-        'something' => [ '/[:.,]+/', [] ],
-        'nothing'   => [ '/(?=[[(A-Z0-9*-])/', [] ],
+        'something' => ['/[:.,]+/', []],
+        'nothing'   => ['/(?=[[(A-Z0-9*-])/', []],
     ];
 
     public function validate ()
@@ -3932,8 +3932,8 @@ class HGVS_Dot extends HGVS
 class HGVS_Genome extends HGVS
 {
     public array $patterns = [
-        'ucsc' => [ '/hg(18|19|38)(?![0-9])/', [] ],
-        'ncbi' => [ '/GRCh3(6|7|8)(?![0-9])/', [] ],
+        'ucsc' => ['/hg(18|19|38)(?![0-9])/', []],
+        'ncbi' => ['/GRCh3(6|7|8)(?![0-9])/', []],
     ];
 
     public function validate ()
@@ -3959,9 +3959,9 @@ class HGVS_Genome extends HGVS
 class HGVS_Length extends HGVS
 {
     public array $patterns = [
-        'unknown'  => [ '?', [] ],
-        'known_bp' => [ '/([0-9]+)bp/', [] ],
-        'known'    => [ '/([0-9]+)/', [] ],
+        'unknown'  => ['?', []],
+        'known_bp' => ['/([0-9]+)bp/', []],
+        'known'    => ['/([0-9]+)/', []],
     ];
 
     public function validate ()
@@ -4002,10 +4002,10 @@ class HGVS_Length extends HGVS
 class HGVS_Lengths extends HGVS
 {
     public array $patterns = [
-        'range'              => [ 'HGVS_Length', '_', 'HGVS_Length', [] ],
-        'range_with_parens'  => [ '(', 'HGVS_Length', '_', 'HGVS_Length', ')', [] ],
-        'single'             => [ 'HGVS_Length', [] ],
-        'single_with_parens' => [ '(', 'HGVS_Length', ')', [ 'WTOOMANYPARENS' => 'This variant description contains a sequence length with redundant parentheses.' ] ],
+        'range'              => ['HGVS_Length', '_', 'HGVS_Length', []],
+        'range_with_parens'  => ['(', 'HGVS_Length', '_', 'HGVS_Length', ')', []],
+        'single'             => ['HGVS_Length', []],
+        'single_with_parens' => ['(', 'HGVS_Length', ')', ['WTOOMANYPARENS' => 'This variant description contains a sequence length with redundant parentheses.']],
     ];
     public array $lengths = [];
 
@@ -4100,31 +4100,31 @@ class HGVS_Lengths extends HGVS
 class HGVS_ReferenceSequence extends HGVS
 {
     public array $patterns = [
-        'refseq_genomic_coding'       => [ '/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[({]([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
-        'refseq_genomic_non-coding'   => [ '/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[({]([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
-        'refseq_genomic_with_gene'    => [ '/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[({]([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)[)}]/', [] ],
-        'refseq_genomic'              => [ '/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
-        'refseq_coding_genomic'       => [ '/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[({](N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
-        'refseq_coding_with_gene'     => [ '/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[({]([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)[)}]/', [] ],
-        'refseq_coding'               => [ '/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
-        'refseq_non-coding_genomic'   => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[({](N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
-        'refseq_non-coding_with_gene' => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[({]([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)[)}]/', [] ],
-        'refseq_non-coding'           => [ '/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
-        'refseq_gene_with_genomic'    => [ '/([A-Z][A-Za-z0-9#@-]*)[({](N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
-        'refseq_gene_with_coding'     => [ '/(?:[A-Z][A-Za-z0-9#@-]*)[({]([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
-        'refseq_gene_with_non-coding' => [ '/(?:[A-Z][A-Za-z0-9#@-]*)[({]([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', [] ],
-        'refseq_protein'              => [ '/([NXY]P)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
-        'refseq_other'                => [ '/^(N[TW]_([0-9]{6})|[A-Z][0-9]{5}|[A-Z]{2}[0-9]{6})(\.[0-9]+)/', [] ],
-        'ensembl_genomic'             => [ '/(ENSG)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
-        'ensembl_transcript'          => [ '/(ENST)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
-        'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)([({[]?)(t)([0-9]+)([)}\]]?)/', [] ],
-        'LRG_genomic'                 => [ '/(LRG)([_-]?)([0-9]+)/', [] ],
-        'build_and_chr'               => [ 'HGVS_Genome', 'HGVS_VCFSeparator', 'HGVS_Chromosome', [] ],
-        'build(chr)'                  => [ 'HGVS_Genome', '(', 'HGVS_Chromosome', ')', [] ],
+        'refseq_genomic_coding'       => ['/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[({]([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', []],
+        'refseq_genomic_non-coding'   => ['/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[({]([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', []],
+        'refseq_genomic_with_gene'    => ['/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[({]([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)[)}]/', []],
+        'refseq_genomic'              => ['/(N[CG])([_-]?)([0-9]+)(\.[0-9]+)?/', []],
+        'refseq_coding_genomic'       => ['/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[({](N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', []],
+        'refseq_coding_with_gene'     => ['/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[({]([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)[)}]/', []],
+        'refseq_coding'               => ['/([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?/', []],
+        'refseq_non-coding_genomic'   => ['/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[({](N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', []],
+        'refseq_non-coding_with_gene' => ['/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[({]([A-Z][A-Za-z0-9#@-]*(_v[0-9]+)?)[)}]/', []],
+        'refseq_non-coding'           => ['/([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?/', []],
+        'refseq_gene_with_genomic'    => ['/([A-Z][A-Za-z0-9#@-]*)[({](N[CG])([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', []],
+        'refseq_gene_with_coding'     => ['/(?:[A-Z][A-Za-z0-9#@-]*)[({]([NX]M)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', []],
+        'refseq_gene_with_non-coding' => ['/(?:[A-Z][A-Za-z0-9#@-]*)[({]([NX]R)([_-]?)([0-9]+)(\.[0-9]+)?[)}]/', []],
+        'refseq_protein'              => ['/([NXY]P)([_-]?)([0-9]+)(\.[0-9]+)?/', []],
+        'refseq_other'                => ['/^(N[TW]_([0-9]{6})|[A-Z][0-9]{5}|[A-Z]{2}[0-9]{6})(\.[0-9]+)/', []],
+        'ensembl_genomic'             => ['/(ENSG)([_-]?)([0-9]+)(\.[0-9]+)?/', []],
+        'ensembl_transcript'          => ['/(ENST)([_-]?)([0-9]+)(\.[0-9]+)?/', []],
+        'LRG_transcript'              => ['/(LRG)([_-]?)([0-9]+)([({[]?)(t)([0-9]+)([)}\]]?)/', []],
+        'LRG_genomic'                 => ['/(LRG)([_-]?)([0-9]+)/', []],
+        'build_and_chr'               => ['HGVS_Genome', 'HGVS_VCFSeparator', 'HGVS_Chromosome', []],
+        'build(chr)'                  => ['HGVS_Genome', '(', 'HGVS_Chromosome', ')', []],
         // NOTE: The HGVS_Chromosome class also handles the chr(build) syntax.
-        'chr'                         => [ 'HGVS_Chromosome', [] ],
+        'chr'                         => ['HGVS_Chromosome', []],
         // Because I do actually want to match something so we can validate the variant itself, match anything.
-        'other'                       => [ '/([^:;\[\]]{2,})?(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.'] ],
+        'other'                       => ['/([^:;\[\]]{2,})?(?=:)/', ['EREFERENCEFORMAT' => 'The reference sequence could not be recognised. Supported reference sequence IDs are from NCBI Refseq, Ensembl, and LRG.']],
     ];
 
     public function validate ()
@@ -4417,8 +4417,8 @@ class HGVS_ReferenceSequence extends HGVS
 class HGVS_RNAAlts extends HGVS_DNAAlts
 {
     public array $patterns = [
-        'invalid' => [ '/[A-Z]+/', [] ],
-        'valid'   => [ '/[ACGUMRWSYKVHDBN]+/', [] ],
+        'invalid' => ['/[A-Z]+/', []],
+        'valid'   => ['/[ACGUMRWSYKVHDBN]+/', []],
     ];
 }
 
@@ -4429,8 +4429,8 @@ class HGVS_RNAAlts extends HGVS_DNAAlts
 class HGVS_RNAPrefix extends HGVS
 {
     public array $patterns = [
-        'RNA'     => [ '/r(?![A-Z])/', [] ],
-        'nothing' => [ 'HGVS_Dot', [] ],
+        'RNA'     => ['/r(?![A-Z])/', []],
+        'nothing' => ['HGVS_Dot', []],
     ];
 
     public function validate ()
@@ -4465,9 +4465,9 @@ class HGVS_RNARefs extends HGVS_DNARefs
     public array $patterns = [
         // NOTE: I could merge the top two into  '/[A-Z]+(?=(con|del|dup|ins|inv))?/', an optional positive look-ahead.
         //       However, for some reason, since the whole pattern is made to match ignoring the case, A-Z takes it all.
-        'invalid_with_keyword' => [ '/[A-Z]+(?=(con|del|dup|ins|inv))/', [] ],
-        'invalid'              => [ '/[A-Z]+/', [] ],
-        'valid'                => [ '/[ACGUN]+/', [] ],
+        'invalid_with_keyword' => ['/[A-Z]+(?=(con|del|dup|ins|inv))/', []],
+        'invalid'              => ['/[A-Z]+/', []],
+        'valid'                => ['/[ACGUN]+/', []],
     ];
 }
 
@@ -4480,7 +4480,7 @@ class HGVS_ProteinPosition extends HGVS
     public array $patterns = [
         // NOTE: The HGVS nomenclature doesn't state that unknown protein positions can't be used in a description.
         //       However, the nomenclature doesn't explain how to use it, and therefore, we will not define it.
-        [ 'HGVS_ProteinRef', 'HGVS_ProteinPositionPosition', [] ],
+        ['HGVS_ProteinRef', 'HGVS_ProteinPositionPosition', []],
     ];
 
     public function validate ()
@@ -4499,7 +4499,7 @@ class HGVS_ProteinPosition extends HGVS
 class HGVS_ProteinPositionPosition extends HGVS
 {
     public array $patterns = [
-        [ '/([0-9]+)/', [] ],
+        ['/([0-9]+)/', []],
     ];
     public array $position_limits = [
         'p' => [1, 65535], // position min, position max.
@@ -4555,8 +4555,8 @@ class HGVS_ProteinPositionPosition extends HGVS
 class HGVS_ProteinPrefix extends HGVS
 {
     public array $patterns = [
-        'protein' => [ '/p(?![A-Z])/', [] ],
-        'nothing' => [ 'HGVS_Dot', [] ],
+        'protein' => ['/p(?![A-Z])/', []],
+        'nothing' => ['HGVS_Dot', []],
     ];
 
     public function validate ()
@@ -4589,9 +4589,9 @@ class HGVS_ProteinPrefix extends HGVS
 class HGVS_ProteinRef extends HGVS
 {
     public array $patterns = [
-        'valid_long'   => [ '/(Ala|Cys|Asp|Glu|Phe|Gly|His|Ile|Lys|Leu|Met|Asn|Pro|Gln|Arg|Ser|Thr|Sec|Val|Trp|Xaa|Tyr|Ter)/', [] ],
-        'invalid_long' => [ '/[A-Z][a-z]{2}/', [] ],
-        'valid_short'  => [ '/[AC-IK-NP-Y*]/', [] ],
+        'valid_long'   => ['/(Ala|Cys|Asp|Glu|Phe|Gly|His|Ile|Lys|Leu|Met|Asn|Pro|Gln|Arg|Ser|Thr|Sec|Val|Trp|Xaa|Tyr|Ter)/', []],
+        'invalid_long' => ['/[A-Z][a-z]{2}/', []],
+        'valid_short'  => ['/[AC-IK-NP-Y*]/', []],
     ];
 
     public function validate ()
@@ -4639,8 +4639,8 @@ class HGVS_ProteinRef extends HGVS
 class HGVS_Variant extends HGVS
 {
     public array $patterns = [
-        'DNA_predicted' => [ 'HGVS_DNAPrefix', 'HGVS_Dot', '(', 'HGVS_DNAVariantBody', ')', [] ],
-        'DNA'           => [ 'HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAVariantBody', [] ],
+        'DNA_predicted' => ['HGVS_DNAPrefix', 'HGVS_Dot', '(', 'HGVS_DNAVariantBody', ')', []],
+        'DNA'           => ['HGVS_DNAPrefix', 'HGVS_Dot', 'HGVS_DNAVariantBody', []],
     ];
 
     public function validate ()
@@ -4677,10 +4677,10 @@ class HGVS_Variant extends HGVS
 class HGVS_VariantIdentifier extends HGVS
 {
     public array $patterns = [
-        'dbSNP'              => [ '/rs[0-9]+/', [] ],
-        'ClinVar_reference'  => [ '/RCV[0-9]+(\.[0-9]+)?/', [] ],
-        'ClinVar_submission' => [ '/SCV[0-9]+(\.[0-9]+)?/', [] ],
-        'ClinVar_variation'  => [ '/VCV[0-9]+(\.[0-9]+)?/', [] ],
+        'dbSNP'              => ['/rs[0-9]+/', []],
+        'ClinVar_reference'  => ['/RCV[0-9]+(\.[0-9]+)?/', []],
+        'ClinVar_submission' => ['/SCV[0-9]+(\.[0-9]+)?/', []],
+        'ClinVar_variation'  => ['/VCV[0-9]+(\.[0-9]+)?/', []],
     ];
 
     public function validate ()
@@ -4712,10 +4712,10 @@ class HGVS_VariantIdentifier extends HGVS
 class HGVS_VCF extends HGVS
 {
     public array $patterns = [
-        'with_build' => [ 'HGVS_Genome', 'HGVS_VCFSeparator', 'HGVS_Chromosome', 'HGVS_VCFSeparator', 'HGVS_VCFBody', [] ],
-        'with_chr'   => [ 'HGVS_Chromosome', 'HGVS_VCFSeparator', 'HGVS_VCFBody', ['WREFSEQMISSING' => 'This VCF variant is missing a genome build, which is required to determine the reference sequence used.'] ],
-        'basic'      => [ 'HGVS_VCFBody', ['EREFSEQMISSING' => 'This VCF variant is missing a genome build and chromosome, which is required to determine the reference sequence used.'] ],
-        'full_SPDI'  => [ 'HGVS_ReferenceSequence', 'HGVS_VCFSeparator', 'HGVS_VCFBody', [] ],
+        'with_build' => ['HGVS_Genome', 'HGVS_VCFSeparator', 'HGVS_Chromosome', 'HGVS_VCFSeparator', 'HGVS_VCFBody', []],
+        'with_chr'   => ['HGVS_Chromosome', 'HGVS_VCFSeparator', 'HGVS_VCFBody', ['WREFSEQMISSING' => 'This VCF variant is missing a genome build, which is required to determine the reference sequence used.']],
+        'basic'      => ['HGVS_VCFBody', ['EREFSEQMISSING' => 'This VCF variant is missing a genome build and chromosome, which is required to determine the reference sequence used.']],
+        'full_SPDI'  => ['HGVS_ReferenceSequence', 'HGVS_VCFSeparator', 'HGVS_VCFBody', []],
     ];
 
     public function validate ()
@@ -4761,9 +4761,9 @@ class HGVS_VCF extends HGVS
 class HGVS_VCFAlts extends HGVS_DNAAlts
 {
     public array $patterns = [
-        'invalid' => [ '/[A-Z]+/', [] ],
-        'valid'   => [ '/(\.|[ACGTMRWSYKVHDBN]+)/', [] ],
-        'nothing' => [ '/$/', [] ],
+        'invalid' => ['/[A-Z]+/', []],
+        'valid'   => ['/(\.|[ACGTMRWSYKVHDBN]+)/', []],
+        'nothing' => ['/$/', []],
     ];
 
     public function validate ()
@@ -4783,7 +4783,7 @@ class HGVS_VCFAlts extends HGVS_DNAAlts
 class HGVS_VCFBody extends HGVS
 {
     public array $patterns = [
-        [ 'HGVS_VCFPosition', 'HGVS_VCFSeparator', 'HGVS_VCFRefs', 'HGVS_VCFSeparator', 'HGVS_VCFAlts', [] ],
+        ['HGVS_VCFPosition', 'HGVS_VCFSeparator', 'HGVS_VCFRefs', 'HGVS_VCFSeparator', 'HGVS_VCFAlts', []],
     ];
 
     function getPositionString ($sPosition, $nIntronOffset, $nOffset, $nLength = 1)
@@ -4964,7 +4964,7 @@ class HGVS_VCFPosition extends HGVS_DNAPositions
     // We use VCFPosition to enforce a single position
     //  while at the same time inheriting the helper methods from DNAPositions.
     public array $patterns = [
-        'single' => [ 'HGVS_DNAPosition', [] ],
+        'single' => ['HGVS_DNAPosition', []],
     ];
 }
 
@@ -4975,9 +4975,9 @@ class HGVS_VCFPosition extends HGVS_DNAPositions
 class HGVS_VCFRefs extends HGVS_DNARefs
 {
     public array $patterns = [
-        'invalid' => [ '/[A-Z]+/', [] ],
-        'valid'   => [ '/(\.|[ACGTN]+)/', [] ],
-        'nothing' => [ '/(?=[: -])/', [] ],
+        'invalid' => ['/[A-Z]+/', []],
+        'valid'   => ['/(\.|[ACGTN]+)/', []],
+        'nothing' => ['/(?=[: -])/', []],
     ];
 
     public function validate ()
@@ -5003,7 +5003,7 @@ class HGVS_VCFRefs extends HGVS_DNARefs
 class HGVS_VCFSeparator extends HGVS
 {
     public array $patterns = [
-        [ '/[: -]?/', [] ],
+        ['/[: -]?/', []],
     ];
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-29
+ * Modified    : 2025-01-29   // When modified, also change the library_version.
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -681,6 +681,24 @@ class HGVS
     public function getValue ()
     {
         return ($this->value ?? '');
+    }
+
+
+
+
+
+    public static function getVersions ()
+    {
+        return [
+            'library_version' => '2025-01-29',
+            'HGVS_nomenclature_versions' => [
+                'input' => [
+                    'minimum' => '15.11',
+                    'maximum' => '21.1.1',
+                ],
+                'output' => '21.1.1',
+            ],
+        ];
     }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4675,7 +4675,17 @@ class HGVS_VCFAlts extends HGVS_DNAAlts
     public array $patterns = [
         'invalid' => [ '/[A-Z]+/', [] ],
         'valid'   => [ '/(\.|[ACGTMRWSYKVHDBN]+)/', [] ],
+        'nothing' => [ '/$/', [] ],
     ];
+
+    public function validate ()
+    {
+        // Provide additional rules for validation, and stores values for the variant info if needed.
+        if ($this->matched_pattern == 'nothing') {
+            $this->value = '.';
+        }
+        return parent::validate();
+    }
 }
 
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1624,7 +1624,7 @@ class HGVS_DNANull extends HGVS
         // We're a bit special. We don't allow any input to be left.
         // The reason for this is that we don't want to match DNAPositions starting with a zero.
         // However, if we would go last in line, the DNAPositions + DNAUnknown would pick c.0? up.
-        if ($this->suffix) {
+        if ($this->suffix !== '') {
             // There is more left. We're not an actual DNANull.
             $this->matched = false;
             return;
@@ -2792,7 +2792,7 @@ class HGVS_DNARepeat extends HGVS
             }
 
             // If there is a suffix, check for sequence without a length. We assume they forgot a "[1]".
-            if ($this->suffix) {
+            if ($this->suffix !== '') {
                 $Suffix = new HGVS_DNAAlts($this->suffix, $this);
                 if ($Suffix && $Suffix->isValid()) {
                     $this->messages['WSUFFIXFORMAT'] =

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -53,6 +53,7 @@ class HGVS
     public array $corrected_values = [];
     public array $data = [];
     public array $info = [];
+    public array $memory = [];
     public array $messages = [];
     public array $properties = [];
     public array $regex = [];
@@ -115,10 +116,21 @@ class HGVS
 
                 if (substr($sPattern, 0, 5) == 'HGVS_') {
                     // This is a class.
-                    $aPattern[$i] = new $sPattern($sInputToParse, $this);
-                    if ($bDebugging) {
-                        print("$sClassString($sInputToParse) rule $sPatternName, pattern $sPattern, result is pending.\n");
+                    // Have we seen this before? Ran it already?
+                    if (isset($this->memory[$sPattern][$sInputToParse])) {
+                        if ($bDebugging) {
+                            print("$sClassString($sInputToParse) rule $sPatternName, pattern $sPattern, reusing previous result.\n");
+                        }
+                        $aPattern[$i] = $this->memory[$sPattern][$sInputToParse];
+                    } else {
+                        if ($bDebugging) {
+                            print("$sClassString($sInputToParse) rule $sPatternName, pattern $sPattern, result is pending.\n");
+                        }
+                        $aPattern[$i] = new $sPattern($sInputToParse, $this);
+                        // Store for later, if needed.
+                        $this->memory[$sPattern][$sInputToParse] = $aPattern[$i];
                     }
+
                     if ($aPattern[$i]->hasMatched()) {
                         // This pattern matched. Store what is left, if anything is left.
                         if ($bDebugging) {

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2025-01-17
+ * Modified    : 2025-01-20
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -242,7 +242,7 @@ class HGVS
                         if (trim($sInputToParse) === '') {
                             $this->messages['WWHITESPACE'] = 'This variant description contains one or more whitespace characters (spaces, tabs, etc).';
                         } else {
-                            $this->messages['WINPUTLEFT'] = 'We stopped reading past "' . $this->value . '".';
+                            $this->messages['WINPUTLEFT'] = 'We stopped reading past "' . $this->value . '". We could not interpret "' . $sInputToParse . '".';
                         }
                     }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1014,7 +1014,7 @@ class HGVS_DNADelSuffix extends HGVS
         }
 
         // In case of any error, remove WSUFFIXFORMAT.
-        if (array_filter(array_keys($this->messages), function ($sKey) { return ($sKey[0] == 'E'); })) {
+        if (isset($this->messages['ELENGTHFORMAT'])) {
             unset($this->messages['WSUFFIXFORMAT']);
         }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2024-12-31
+ * Modified    : 2025-01-01
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -3676,7 +3676,7 @@ class HGVS_RNAPrefix extends HGVS
 
         // If we have seen a reference sequence, check if we match that.
         $RefSeq = $this->getParentProperty('ReferenceSequence');
-        if ($RefSeq && $RefSeq->molecule_type != $this->molecule_type) {
+        if ($RefSeq && $RefSeq->molecule_type != $this->molecule_type && $RefSeq->molecule_type != 'genome_transcript') {
             $this->messages['EWRONGREFERENCE'] =
                 'The given reference sequence (' . $RefSeq->getCorrectedValue() . ') does not match the RNA type (' . $this->getCorrectedValue() . ').' .
                 ' For ' . $this->getCorrectedValue() . '. variants, please use a ' . $this->molecule_type . ' reference sequence.';

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3844,7 +3844,7 @@ class HGVS_DNAVariantType extends HGVS
             // But not A>A.
             unset($this->corrected_values[$this->value . '>' . $this->value]);
             // Also inform the user properly.
-            $this->messages['WINVALID'] = 'This variant description seems incomplete. Did you mean to write a substitution?' .
+            $this->messages['EINVALID'] = 'This variant description seems incomplete. Did you mean to write a substitution?' .
                 ' Substitutions are written like "' . $Positions->getCorrectedValue() . $this->getCorrectedValue() . '".' .
                 ' Alternatively, did you mean to indicate this position was unchanged?' .
                 ' That is written like "' . $Positions->getCorrectedValue() . '=".';

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -4,7 +4,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2024-11-05
- * Modified    : 2024-12-06
+ * Modified    : 2024-12-09
  * For LOVD    : 3.0-31
  *
  * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
@@ -1991,14 +1991,14 @@ class HGVS_Length extends HGVS
         if ($this->range) {
             if ($this->lengths[0] == $this->lengths[1]) {
                 // If the lengths are the same, warn and remove one.
-                $this->messages['WLENGTHFORMAT'] = 'This variant description contains two sequence lengths that are the same.';
+                $this->messages['WSAMELENGTHS'] = 'This variant description contains two sequence lengths that are the same.';
                 $nCorrectionConfidence *= 0.9;
                 // Discard the other object.
                 $this->range = false;
 
             } elseif ($this->lengths[0] > $this->lengths[1]) {
                 // Lengths aren't given in the right order.
-                $this->messages['WLENGTHFORMAT'] = 'This variant description contains two sequence lengths that are not given in the correct order.';
+                $this->messages['WLENGTHORDER'] = 'This variant description contains two sequence lengths that are not given in the correct order.';
                 $nCorrectionConfidence *= 0.9;
                 // Swap the lengths.
                 list($this->lengths[0], $this->lengths[1]) = [$this->lengths[1], $this->lengths[0]];

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -107,17 +107,6 @@ class HGVS
                     $this->messages['WWHITESPACE'] = 'This variant description contains one or more whitespace characters (spaces, tabs, etc).';
                 }
 
-                // Quick check: do we still have something left?
-                if ($sInputToParse === '') {
-                    if ($bDebugging) {
-                        print("$sClassString('$sInputToParse') ran out of input, but expecting more. aborting.\n");
-                    }
-                    $bMatching = false;
-                    // This can be a sign that a variant wasn't submitted completely, and we should try to get more input.
-                    $this->possibly_incomplete = true;
-                    break;
-                }
-
                 if (substr($sPattern, 0, 5) == 'HGVS_') {
                     // This is a class.
                     // Have we seen this before? Ran it already? But not modified it afterward?
@@ -187,6 +176,16 @@ class HGVS
                         $this->possibly_incomplete = ($this->possibly_incomplete || $aPattern[$i]->isPossiblyIncomplete());
                         break;
                     }
+
+                } elseif ($sInputToParse === '' && $sPatternName != 'nothing') {
+                    // Quick check: do we still have something left?
+                    if ($bDebugging) {
+                        print("$sClassString('$sInputToParse') ran out of input, but expecting more. aborting.\n");
+                    }
+                    $bMatching = false;
+                    // This can be a sign that a variant wasn't submitted completely, and we should try to get more input.
+                    $this->possibly_incomplete = true;
+                    break;
 
                 } elseif (strlen($sPattern) >= 3 && substr($sPattern, 0, 1) == '/') {
                     // Regex. Make sure it matches the start of the string. Make sure it's case-insensitive.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3039,7 +3039,7 @@ class HGVS_Variant extends HGVS
         if ($this->predicted
             || (isset($this->DNAVariantBody->DNAPositions)
                 && ($this->DNAVariantBody->DNAPositions->uncertain || $this->DNAVariantBody->DNAPositions->unknown))
-            || in_array($this->data['type'] ?? '', ['0', '?', ';'])
+            || in_array($this->data['type'] ?? '', ['0', '?', ';', 'met'])
             || $this->DNAVariantBody->getCorrectedValue() == '=') {
             if (empty($this->messages) && $this->caseOK) {
                 $this->messages['WNOTSUPPORTED'] = 'Although this variant is a valid HGVS description, this syntax is currently not supported for mapping and validation.';

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -1302,7 +1302,7 @@ class HGVS_DNADelSuffix extends HGVS
         } else {
             $this->corrected_values = $this->buildCorrectedValues(
                 ($this->hasProperty('DNARefs')? $this->DNARefs->getCorrectedValues() : 'N'),
-                (!$this->Lengths->getCorrectedValues()? '' :
+                (!$this->Lengths->getCorrectedValue()? '' :
                     $this->buildCorrectedValues('[', $this->Lengths->getCorrectedValues(), ']'))
             );
         }
@@ -1547,7 +1547,7 @@ class HGVS_DNAInsSuffix extends HGVS
         } elseif ($this->hasProperty('Lengths')) {
             $this->corrected_values = $this->buildCorrectedValues(
                 ($this->hasProperty('DNAAlts')? $this->DNAAlts->getCorrectedValues() : 'N'),
-                (!$this->Lengths->getCorrectedValues()? '' :
+                (!$this->Lengths->getCorrectedValue()? '' :
                     $this->buildCorrectedValues('[', $this->Lengths->getCorrectedValues(), ']'))
             );
 
@@ -3841,6 +3841,7 @@ class HGVS_Lengths extends HGVS
             );
         } elseif ($this->lengths[0] == 1 && !$this->getParent('HGVS_DNARepeatComponent')) {
             // Actually, when the length is 1, and we're not a repeat, it's redundant and it shouldn't be given.
+            $this->messages['WLENGTHGIVEN'] = 'A length of "1" is redundant and should be removed.';
             $this->setCorrectedValue('');
         } else {
             $this->corrected_values = $this->buildCorrectedValues(

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -351,6 +351,24 @@ class HGVS
 
 
 
+    public function discardSuffix ()
+    {
+        // This function discards the suffix. This is used in text parsing, when
+        //  suffixes are very common (periods, commas, closing parentheses).
+
+        $this->input = substr($this->input, 0, -strlen($this->suffix));
+        $this->suffix = '';
+        unset($this->messages['WINPUTLEFT']);
+        // Also reset the info variable, so that we'll have to rebuild it.
+        $this->info = [];
+
+        return true;
+    }
+
+
+
+
+
     public function getCorrectedValue ($nKey = 0)
     {
         // This function gets the first corrected value and returns the string.

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -2703,6 +2703,11 @@ class HGVS_VCF extends HGVS
                 $this->VCFBody->getCorrectedValues()
             );
         }
+
+        // We also need to store the data fields. Yes, this is duplicated work.
+        // However, it's much simpler to do it here; everything the VCFBody does is string-based.
+        $HGVSVariant = new HGVS_Variant('g.' . $this->VCFBody->getCorrectedValue());
+        $this->data = $HGVSVariant->getInfo();
     }
 }
 

--- a/src/class/HGVS.php
+++ b/src/class/HGVS.php
@@ -3829,7 +3829,7 @@ class HGVS_ReferenceSequence extends HGVS
         'refseq_other'                => [ '/^(N[TW]_([0-9]{6})|[A-Z][0-9]{5}|[A-Z]{2}[0-9]{6})(\.[0-9]+)/', [] ],
         'ensembl_genomic'             => [ '/(ENSG)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
         'ensembl_transcript'          => [ '/(ENST)([_-]?)([0-9]+)(\.[0-9]+)?/', [] ],
-        'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)(t)([0-9]+)/', [] ],
+        'LRG_transcript'              => [ '/(LRG)([_-]?)([0-9]+)([({[]?)(t)([0-9]+)([)}\]]?)/', [] ],
         'LRG_genomic'                 => [ '/(LRG)([_-]?)([0-9]+)/', [] ],
         'build_and_chr'               => [ 'HGVS_Genome', 'HGVS_VCFSeparator', 'HGVS_Chromosome', [] ],
         'chr'                         => [ 'HGVS_Chromosome', [] ],
@@ -4054,15 +4054,18 @@ class HGVS_ReferenceSequence extends HGVS
                     strtoupper($this->regex[1]) .
                     '_' .
                     (int) $this->regex[3] .
-                    strtolower($this->regex[4]) .
-                    (int) $this->regex[5]
+                    strtolower($this->regex[5]) .
+                    (int) $this->regex[6]
                 );
                 $this->caseOK = ($this->regex[1] == strtoupper($this->regex[1])
-                    && $this->regex[4] == strtolower($this->regex[4]));
+                    && $this->regex[5] == strtolower($this->regex[5]));
 
                 if ($this->regex[2] != '_') {
                     $this->messages['WREFERENCEFORMAT'] =
                         'LRG reference sequence IDs require an underscore between the prefix and the numeric ID.';
+                } elseif ($this->regex[4] || $this->regex[7]) {
+                    $this->messages['WREFERENCEFORMAT'] =
+                        'LRG reference sequence IDs do not use brackets around the transcript number.';
                 }
                 break;
 


### PR DESCRIPTION
This work started as an experiment to see if I could handle the HGVS functionality in a different way. The code had gotten too complex. I decided to build something new entirely, replacing all three functions and merging all functionality in a single class. The old HGVS-related libraries remain in use at this time; currently, the new HGVS class is not used in LOVD yet.

Not all commits are listed below.

- Add the basics of a brand new HGVS class. I've thought long and hard whether I would continue on the path that I laid out with `lovd_getVariantInfo()` and `lovd_fixHGVS()`, but the code became more and more complex and wasn't manageable anymore. This completely new idea will require a complete rebuild of the functionality but will open up many more possibilities that I didn't have before. Not only will the code be much more compartmentalized and, therefore, more readable and manageable, but it'll allow for matching all DNA types as well as RNA and protein variants, fixing mistakes directly instead of through a different function, and even the possibility of returning multiple possible fixes (probably).
- Add the basics of the constructor. It loops rules and patterns, which is WIP. When it matches a rule, it marks it as matched and stores the key. Suffixes are collected and will result in a warning when we're in the main class.
- Handle regex patterns.
- Handle simple string patterns.
- Add helper function `hasMatched()`.
- Add helper function `getSuffix()`.
- Add helper function `getMessages()`.
- Add method to add classes to patterns. This is where the real power of this setup lies. With classes that handle separate parts of the nomenclature, we compartmentalize the code in a BNF-like structure. Each class can handle its own input and validation. Currently, classes can communicate with the parent classes using `$this->parent`.
- Add some basics; HGVS is a full variant, starting with a refseq. Currently, just supporting a full NC.
- A Variant is a DNAPrefix and a DNAVariantBody, separated by a period. I first thought to use generic classes for Prefix and VariantBody, but that would not be efficient. It would try to find DNA variants after protein prefixes or vice versa, whatever will come first. This way is a bit more strict, but it forces the parsing to take an early path towards the intended variant type.
- Define a DNAPrefix.
- DNAVariantBody is DNAPositions, DNADel, and possibly DNADelSuffix. Obviously, more variant types will be supported later.
- Add helper function `getData()`. This will allow us to store data other than messages and bubble it up to the parent classes.
- A DNADel is "del", and it stores a type in the variant object.
- Define DNAPositions. This is more complex now. It can be a single position or a range. The range may or may not be surrounded by parentheses.
- After matching, run `validate()` to handle more checks. It can also store data.
- Define DNAPosition. It can either be unknown or known. The known pattern also allows UTR and intronic positions. I didn't feel it was a good idea to arrange the definitions in such a way that only c. variants allow UTRs and only c. and n. variants intronic values, etc. Let's parse everything and later check whether the prefix matches the style. We do that in `lovd_getVariantInfo()` as well, and the alternative is no match at all, which isn't convenient.
- Determine the position, the sortable position, and the offset. For unknown positions, we can't determine the sortable position immediately. It depends on how they are used (start or stop, etc). For positions in the 3' UTR, we choose an arbitrary value for the sortable position. This won't allow us to determine the length of a variant spanning from the CDS to the 3' UTR, but at least it won't require us to use the database. I'll probably fix this later, when I actually need to have a proper length.
- Check positions and warn for positions with zeros. This is for zeros prefixing positions as well as positions that translate to zero, e.g., *0, 010, 10+0, etc.
- Also handle variants with unknown intronic positions. E.g., c.31+?. Internally, store an offset of 1 or -1 for these.
- Define DNAPositionStart and DNAPositionEnd. They are the same class by inhertitance. But because the class name is different, internally we can do a quick check whether we're the start or end of a variant position. The DNAPositionStart and DNAPositionEnd values are either an uncertain range of two DNAPosition instances or one single DNAPosition instance.
- Add helper function `getParent()`. It either returns the current parent (or false if there is none), or it can be given a class name and it will go through all parents until it finds the requested class. That way, we can safely "bubble" up to the class we need even if we don't know how many layers of parents we need to traverse.
- Add helper function `getValue()`.
- Store minimum and maximum values per Position, and check them. For now, the minimum and maximum values are based on storage limits, but the PositionStart and PositionEnd objects can modify the limits based on other values present so that we can do very specific checks on variant positions. The added checks also make sure genomic sequences don't have intronic positions and such.
- Start validating the PositionStart and PositionEnd values. It's a bit of a hack, but I had to handle multiple instances of the same error when we're dealing with ranged positions.
- Suppress deprecation notices about declaring dynamic properties.
- Always store min and max values for positions, and update them. To allow further processing, including distance calculations, we need the maximum and minimum values for all positions. When precise positions have been given, they will define the range.
- Actually, for intronic unknown offsets, we can set some limits.
- Reset the array of properties after unsetting them.
- Add helper function `getCorrectedValue()`. This is for objects that want to store what the value should have been like.
- Use the corected value to compare positions in Start or End. When positions are the same, remove one. Also make sure that we don't accept positions on either side of the intron but using the same base position. That would indicate a one-base exon.
- Add helper function `arePositionsSorted()` for Position objects.
- Use `arePositionsSorted()` to check the order of Positions in Start or End.
- Make a difference between unknown positions and unknown offsets. Since "unknown" was ambiguous, sometimes we were implementing exact checks like checking if the position was "?", but that defeats the purpose of having boolean flags.
- Don't allow `g.(A_?)_(?_B)` notation; remove the questionmarks.
- Give unknown positions a sortable position.
- PositionStart and -End can't be the same unless they're unknown.
- Add position information to the data array. This will make sure that we'll be able to return a data structure like the old code does, for which much of LOVD relies.
- Add support for `g.(100)_200del`, which can be auto-corrected. The old code didn't recognize this.
- Add support for `g.(100)del`, which can be auto-corrected. The old code didn't recognize this.
- Add `DNAPositions::getLengths()`. This function calculates the Position's minimum and maximum lengths, if possible. In some cases, the given lengths are not reliable (see the function header for examples). Also, in even rarer cases, false will be returned when a length can't be determined at all.
- Add support for deletions with a given suffix with sequence.
- Don't check deletion suffix length when the positions are in error.
- Add a simple redundancy check for the deletion suffix. Note that I chose to change the warning message.
- Treat all regexes as case-insensitive and catch invalid cases. This allows us full control over the cases; each object decides whether the case matters (positions don't care) and if so, what it should be, e.g., uppercase for DNA sequence, lowercase for variant types.
- Add checks for invalid nucleotides.
- Complete the DelSuffix length checks. I simplified things quite a bit; the old code contains lots of very specific warnings (that should actually be errors). There isn't really a need for all those very specific messages. This works just as well and saves us a lot of complexity.
- Make sure the corrected value bubbles up. This required me to build a standard way to create the corrected value; for super classes that don't have their own validation logic, this should be based on the pattern that was matched.
- Recognize some invalid suffixes and make sure they are fixed.
- Add the basics of the HGVS_Length class. This can be used for deletion lengths, but also lengths in repeats.
- Add a check for zeros in lengths. This code is based on the code in the DNAPosition class.
- Check the lengths some more and store them. This code is based on the DNAPositionStart code.
- Implement the Length object in the DNASuffix class. Add lots of crazy formats to recognize. Due to our new structure, they're merely a single line per format.
- When a length is 1, it's redundant.
- Add a class for matching "ins". Make sure the variant type is set to "ins" or changed to "delins" when we already matched "del". The reason why I didn't make a "delins" class is to make sure we also match "delAinsGG" properly.
- Add a DNAAlts class for insertions suffixes. It allows for more different bases than DNARefs.
- Add the DNAInsSuffix class modeled after the DNADelSuffix class. I couldn't just extend the DelSuffix class, as the definitions and length calculations need to use Alts and not Refs, and the checks will be quite different.
- Add code that handles delins to substitution. E.g., convert `delAinsG` into `A>G`.
- Finish the InsSuffix class.
- Add the patterns for parsing deleletion-insertions and insertions.
- Add `DNAPositions->addPosition()` to manipulate existing positions. This changes a single position into a range.
- Make sure that insertions have two positions. When an unknown position has been given, we can even fix it.
- Reduce the output whenever I use `var_dump()` on a HGVS object.
- Insertions require certain Start and End positions.
- Add more checks for insertions. Uncertain positions should show a range longer than two bases and certain positions must be exactly two consecutive bases.
- Add a function that will handle corrected values for us.
- Use the new methods for the corrected values everywhere.
- Now that we have this ability, add confidence values everywhere.
- Replace Us to Ts in REF and ALT sequences.
- Add trait HGVS_DNASequence to handle sequences better. This prepares us for analyzing delins variants better.
- Add basic support for substitutions. Right now any position and any length of REF or ALT is accepted.
- Start with building VCF support. We'll use a VCF parser for resolving delXinsX variants and substitutions, as they can become all kinds of variants, just like VCF descriptions.
- Add support for multiple VCF separators.
- Add VCF Refs. Explicitly allow for a period. Other than that, rely on the DNARefs object.
- Define VCF Alts, again explicitly allowing a period.
- Define VCFBody; this is the part from the position to the ALT. We will leverage this class to solve all `delXinsX` and `X>X` variants, where X can be any number of nucleotides. Just like in VCF parsing, we'll need to examine the REF and ALT and shift the positions if needed. If we keep this all in one place, it'll save us a lot of time.
- Define `getPositionString()` for VCFBody. I had to think hard whether I wanted a function that modifies the Positions class or subclasses, or just works with strings. I decided in the end to just work with strings, as I won't need a Positions object (corrected values are always returned as strings) and it would become too complex to build. This method could be built relatively easily by basing it on some functions that exist already: `lovd_modifyVariantPosition()` and `lovd_formatPositions()`. They are used in `lovd_fixHGVS()` for the functionality that I will now implement in the VCFBody class.
- Add the basics of VCF parsing. This code is mostly based on what `lovd_fixHGVS()` was doing with substitutions, but REF is now allowed to be a dot/period (.). The old code couldn't handle that, because it could suggest only one fix. Now that we can suggest multiple fixes, we _can_ handle that.
- Process the REF and ALT sequences and determine the variant type. Also, correct the positions using the new `getPositionString()` method. Note that we're handling intronic positions etc because we'll also end up here when trying to fix substitutions and delins variants with REF and ALT provided. Add a warning when an empty REF (.) has been passed to us. That can only happen when we'll be actually parsing real VCF values, so the warning can mention this, too.
- Implement this new VCFBody class and use it to resolve variants. All `delXinsX` variants and substitutions (using DNARefs and DNAAlts and thus allowing REF and ALT sequences of more than one base) are now processed using this feature to make sure we have the right variant type. This is only done when the REF and ALT are fixed (not flexible) and when the variant positions are certain, or we can't shift the positions.
- Add some more basics: methods to build the info array. This info array simulates the output of the `lovd_getVariantInfo()` function, so that existing code can interface with the HGVS classes more easily.
- Add `isValid()` to quickly check whether an HGVS object is valid.
- Insertions followed by numbers should be interpreted as positions.
- Insertions of positions need more checks; handle ins? and ins(?).
- Single numeric positions are assumed to be lengths.
- Inserted uncertain positions can be lengths or positions.
- Start building components for complex insertions.
- Allow for complex insertions consisting of multiple parts.
- Add `getComponents()` that collects a complex insertion's components.
- Make sure that `getComponents()` detects sequences that can be merged.
- Check if complex insertions have to be complex; if not, fix it.
- Add helper methods `getProperties()` and `hasProperty()`.
- To support more variant types, we have to add reserved keywords. Otherwise, DNARefs or DNAAlts interpret them as invalid nucleotides and throw an error.
- Positions are used for VCFs now; fix errors not finding a prefix.
- Positions are now used for insertions; generalize the warnings.
- Handle unknown positions better; the data array had NULL positions.
- When something doesn't match, clean the data.
- Auto-fix `WPOSITIONSCERTAIN` and `WPOSITIONSUNCERTAIN`.
- When we changed a position's certainty, actually fix it.
- Fix printing of negative offsets; they got double hyphens.
- Remove a deletion's suffix as well for `WPOSITIONSUNCERTAIN`.
- Don't throw an `ESUFFIXTOOLONG` when the maximum length is unknown.
- Correct `g.?_(100_?)` and `g.(?_100)_?` to `g.(?_100)_(100_?)`.
- Improve the message for `WPOSITIONSUNCERTAIN`. The suffix is getting deleted, so add to the message, that already contains instructions, that this should be done.
- Report when positions and intronic positions are prefixed by 0.
- Apply position limits in the DNAPosition class. The stored positions could be outside of the limits. That is no longer allowed, as the idea is that we prevent issues with the storage of these variants.
- Apply position limits in the DNAPositions class. Now that the DNAPosition objects have the limits stored correctly, apply the limits to the stored data.
- Also swap unordered uncertain Starts and Ends, if they're not unknown. Rebuild the positions completely, though, to fix issues with position limits and stored positions.
- Improve reference sequence checks. Also allow for NGs.
- Add support for NC(NM) and related genomic transcripts. Supported are NMs, XMs, NRs, and XRs. They are separated in coding and non-coding just to later I'll be able to add checks for matching variants to reference sequences. All kinds of typos are detected and fixed.
- Add support for coding and non-coding transcripts. Just like with the genomic transcripts, we're separating coding and non-coding for checks to be implemented later. Supporting NM, XM, NR, and XR reference sequences.
- Add support for NM(GENE) and GENE(NM) notations. They are not official, but used in ClinVar and in the past, in LOVD as well.
- Add support for Ensembl genomic and transcript reference sequences.
- Add support for LRG transcripts.
- Add support for LRGs.
- Add the basics to support duplications. This is so easy now, due to our new setup. We can just reuse the DelSuffix class to handle suffixes and add all validations.
- Fix all validation messages for duplications.
- Add support for "con", which should now be "delins".
- Add the "null" variant (c.0).
- Allow the "null" variant type only for transcript-based prefixes.
- Allow for "unknown" variants, like "c.?".
- Add "wild-type" variants, e.g., "c.=" and "g.123_456=".
- Update some length-related warnings following position-related warnings.
- Recognize VCF-style REF and ALT values for substitutions and add checks.
- Add checks on positions for substitutions. Some problems are fixable and generate warnings. Other problems can not reliably be fixed, and we'll choose to throw an error, instead.
- Substitutions with issues will be parsed by a VCF parser. That will update their positions and change their type, if needed. For instance, this can detect deletions, deletion-insertions, insertions, duplications, and even inversions.
- Lower our confidence for single-base multi-REF substitutions.
- Handle an interesting case; `c.(100)A>G`. It may be meant as `c.100A>G` or `c.(100A>G)`. For this, we need to start tracking what our parent is doing. Added `$current_pattern` for this.
- Add support for the allele syntax. Thanks to the setup of my classes, this takes only a few lines of code to get basic support.
- Set the variant data correctly for the allele syntax. The first variant determines the position info, but the type will always be set to ";".
- Recognize and fix single variants in one cis allele.
- Handle allele syntax using commas. This is an error that we can automatically fix.
- Unset some warnings in the presence of other messages. Some, more generic warnings make no sense anymore when other warnings or errors are present.
- Don't do a del or dup suffix check when we have a `EPOSITIONLIMIT`.
- Prevent throwing an `ESUFFIXTOOSHORT` when we have a "0" in the suffix.
- When errors occur, greatly reduce the confidence of any corrections.
- Renamed the old `WSUFFIXGIVEN` to `WINPUTLEFT` and updated the text. We're using `WSUFFIXGIVEN` also for warnings where we actually did recognize the suffix but realized it was obsolete. `WINPUTLEFT` is different, as the suffix was never checked. It just stopped reading there. Updated the text to match this explanation.
- Add helper function `getInput()`. This way, we can double-check what was actually parsed and what was not read (see `getSuffix()`).
- Add support for predicted DNA variants.
- Add `WNOTSUPPORTED`, when appropriate. This signals us that the use of VV is not possible with this variant description.
- Prepare for parsing full VCF data; add "chr". We have to add a class for this to make sure we match CHR as well.
- Prepare for parsing full VCF data; add chromosomes (1-22, X, Y, M).
- Add support for genome builds. We deliberately don't check the casing; HG19 isn't really wrong.
- Add the Chromosome class that recognizes chromosomes. Optionally, chromosomes can be prefixed with "chr".
- Add the VCF class and parse multiple types of variants. Add support for genome build, chromosome, position, REF, and ALT; the above without the genome build (an actual VCF file), and the above without the chromosome (a simple VCF "body"). Also, add support for HGVS variants without reference sequences.
- Make sure the Chromosome class returns HGVS nomenclature when possible. When the chromosome isn't valid, just return as-is. When we received a genome build, use that NC. Without a given genome build, return all options.
- Make sure the VCF class returns HGVS nomenclature.
- Let the VCF class return data for the info array. This repeats the parsing of a variant that we already parsed. However, this saves us a lot of dev time. The VCFBody class does most of its work with strings. It doesn't create new objects, which would be a lot more work to handle and much more difficult to code. This shortcut increases the time used to parse VCF values by a fraction but helps us write simple code that's easily maintainable.
- Add `WNOTSUPPORTED` to whole-refseq wildtype variants, like `g.=`. Without positions, we can't map or anything.
- Recognize and handle NM(NC) and NR(NC).
- Recognize NP reference sequences. It's not throwing an error yet when used in combination with a DNA variant, but it will once we add the checks for the prefix.
- Recognize other GenBank reference sequences. They are not really invalid, but not supported, either.
- Add a fallback for reference sequences, matching anything. The reason why we need this is that otherwise, a reference sequence that we don't match will render the entire variant unmatched. But we still want to know about the variant and perhaps validate it. So, we're matching whatever we can until the first colon.
- For each reference sequence type, store the possible prefixes. This can be used for implementing a check.
- Add helper function `getParentProperty()`. It allows us to search for the closest parent with a certain property. This is useful for, e.g., finding the closest reference sequence. When in a complex insertion, it may be just a few levels up, or all the way up the HGVS object. Using this method, we won't have to try and find it manually.
- Add a refseq <-> prefix check, using our new `getParentProperty()`. A prefix should match the most recently given reference sequence. Because we can't fix this problem ourselves, provide as much information as possible in the error message, guiding the user to figure out the problem themselves.
- Make sure that intronic positions have a genomic transcript refseq. These currently consist of the abandoned LRG_123t1 type and the debated NC(NM)-type of reference sequences. However, they are needed for intronic variants.
- Count how many patterns matched, so we can query the process. This way, we can see better how something failed. Did nothing match at all? Were there quite some matches but it failed somewhere close to the end? We can also observe changes this way; if we fix the input a bit, is the matching improving? Even if it still fails, we'll still be able to tell that things improved.
- Track whether input may be incomplete. E.g., for `c.100_101ins`, we throw an error, but we'd also like to know that the variant actually may be missing another part. This is especially useful when parsing text; people sometimes add spaces to variant descriptions that should not be there. Examples are substitutions or complex insertions.
- Support the use of non-breaking hyphens in DNA positions.
- Add a method to dump the suffix. This is useful for text parsing, where suffixes happen because of surrounding text. E.g., periods ending a sentence or commas are suffixes to our class. We can now be instructed to dump this suffix and pretend it never existed, so we report the valid value.
- Add methods that allow a user to see what we matched. Especially when using the HGVS main class, anything could have been matched, from variants to genome builds. This way, users will be able to quickly find out what matched.
- Create a class for "inv", which also makes it case-insensitive.
- Add more support for inserting inverted sequences.
- Add the requirements that inversions have on their positions.
- Add support for inversions.
- Add support for inversions with a suffix. The suffix will be handled the same way that deletion and duplication suffixes are handled.
- Add `appendCorrectedValue()` that lets me easily update corrected values. E.g., I can update confidences or append suffixes.
- Add the basic support for methylation-related variants.
- Recognize and correct "|met" to "|met=".
- Handle both the lack of a pipe as well as using too many.
- Handle the absence of the dot, alternatives (",", ":"), and repetitions.
- Add a `WNOTSUPPORTED` to methylation-related variants.
- Handle whitespace better; allow whitespace between any elements.
- Add support for somatic variants. That's very easy now due to the new structure. Currently, we handle only combinations of wildtype and substitutions, but as more variant types move over to the new DNAVariantType object, that will solve itself.
- What's before and after the slash must not be the same.
- Store the variant type and resort the parts, if needed. WT should go first, according to the nomenclature rules.
- Generalize code from DNANull that fills in positions. All variants without positions (e.g., c.?) now also get position fields, albeit set to zero.
- Add a message to wildtype variants without positions. The user may not realize that this means the entire reference sequence is checked and found not to be changed.
- Add debugging code. I commit debugging code almost never. But in this case, I need it so often that I think it's good to have it baked in officially.
- Implement a memory, reusing objects so they don't get reparsed. This makes the code execute much faster, as lots of re-parsing is prevented.
- When objects are modified, do NOT re-use them. We sometimes modify the Positions object because that's easier for us, but it causes downstream issues when the object is re-used.
- Mark objects following tainted ones also as tainted. When we're not matching, our properties are at risk of being re-used. When the Positions object was tainted, we need to make sure that everything following the Positions object also gets re-run. Otherwise, only the Positions are rebuilt but, e.g., the insertion code isn't re-run and the warnings and fixes aren't added properly. So then just rebuild everything.
- When throwing `WNOTSUPPORTED`, info messages aren't a bad thing. Anything is the messages array caused the code to think this was not a valid description.
- For uncertain start or stop positions, store the inner positions. This is also how it was originally done, so we should stick to this design. Amongst other things, BED files rely on this setting.
- Handle missing prefixes. By simply matching HGVS_Dot, that by itself can also match nothing, we can easily fallback on not having a prefix. With a very simple check, we can predict what the missing prefix should be based on the reference sequence or a previously found prefix. This was a lot more code in the old solution.
- Define HGVS_RNAPrefix for future use.
- Add HGVS_ProteinPrefix for future use.
- Prepare HGVS_Dot for the use in protein descriptions.
- When the variant length is unknown, don't do suffix length checks.
- Consider positions sorted when they are equal.
- Handle all deletion-insertion related `WWRONGTYPE` warnings. For most variants, we would only throw a `WSUFFIXGIVEN`. That is now removed when we provide other feedback.
- Change variant type "subst" to ">"; a custom string makes no sense.
- Reduce the output of `var_dump()` some more. Memory got recently introduced and was also included in the `var_dump()`, leading to a very large output.
- Remove a `WPREFIXFORMAT` if we're already throwing a `PREFIXMISSING`.
- Add more variant types that aren't fully correct. Some more checks will need to be added. Adding support for positions and REFs in unknown variants and adding REFs just before pipes and "=".
- Add a HGVS_CheckBasesGiven trait to check REF/position length.
- Implement HGVS_CheckBasesGiven for three variant types. Methylation-related variants (`g.123G|met=`), wild-type variants (`g.123G=`), and unknown variants (`g.123G?`).
- Add the basics for DNA repeats.
- Add helper functions for DNA repeats. These were inspired by the complex insertion code.
- Start building the validation for DNA repeats. They can't have uncertain positions, and they must be divisible by three on coding transcripts.
- Add the basic length checks.
- Add a complex length check for DNA repeats. This code is ported from the old methods. It tries all combinations of repeat counts until it finds a combo that matches the position length. If this is not possible, it complains.
- If the repeat suffix is a sequence, assume a "[1]" is missing.
- Add support for the `o.` prefix. It was allowed already as a prefix, but the code broke because there were no limits defined yet.
- Add support for `pter` and `qter` and actually assign them positions. This means we'll be able to detect whether `pter` and `qter` are given in the correct order.
- Add a feature that allows for missing a reference sequence. It makes an `EREFSEQMISSING` into an `IREFSEQMISSING`. This is useful for the future online validator and for LOVD itself.
- Add a feature that forces a reference sequence to be absent. When one is given, a warning will be raised. This is useful for LOVD, where refseqs can't be given in the data entry fields.
- More variant types get a `WNOTSUPPORTED`; `pter`/`qter` and repeats.
- Handle `EFALSEUTR` a bit better. Surely, it's still an error because we really aren't certain at all that the prefix was the problem, but we will suggest this as a fix, when appropriate.
- Handle `EFALSEINTRONIC` a bit better. Also for this error, we keep this an error and not a warning since we're pretty much in the dark here. But, try to see what happens when we just replace the hyphen with an underscore. If that removes the issues, then suggest it as a fix.
- Allow RNA prefixes with LRGt reference sequences, as well.
- Add HGVS_RNARefs, based upon HGVS_DNARefs.
- Add HGVS_RNAAlts based on HGVS_DNAAlts.
- Add HGVS_ProteinPositionPosition; the numeric part of a p. position.
- Add HGVS_ProteinRef to match amino acids.
- Handle misspelled amino acids; we can provide a suggestion.
- Add ProteinPosition using ProteinRef and ProteinPositionPosition.
- Implement unknown phasing correctly. It currently assumes square brackets are needed, but that's not the case. They are actually required to be absent.
- Handle unknown phasing given within square brackets.
- Improve handling unknown phasing within square brackets. Suggest to either use a plain semicolon or to keep the unknown phasing, but then to remove the square brackets.
- Handle allele syntax without square brackets.
- Don't allow a "null" value (`c.0`) to be reported in cis allele syntax.
- Don't check the position order for `m.` and `o.` prefixes.
- Add basic support for "or" variants. The nomenclature isn't clear about how this variant type exactly works, so we can't fully implement it.
- Improve handling "or" variants. We shouldn't fully eat the suffix, handle closing parentheses and brackets so that the pattern we're in can fully close.
- Allow for `?_?ins` variants.
- Split `WPOSITIONSNOTFORINS` into a warning and an error. When an unknown position is involved, I can't fix it.
- Recognize and support `N[CG](GENE)` reference sequences. They are allowed for mitochondrial reference sequences. Otherwise, get rid of the gene symbol and keep the genomic refseq.
- Add support for CNV notation like `g.pter_qter[2]`. This seems to conflict with the old repeat syntax, e.g. `c.100[3]`, which means something else entirely than a triplication of `c.100`.
- Make sure that `pter` and `qter` enforce the use of the `g.` or `m.` prefix. Also, when there isn't a prefix, make sure only `g.` or `m.` are suggested fixes.
- Add support for supernumerary chromosomes. This concerns, e.g., `NC_000001.10:g.pter_1000000sup`.
- Add the same requirements to sup that we also have for `pter` and `qter`. They require a chromosomal reference sequence and the `g.` or `m.` prefix. If no prefix has been given, make sure only `g.` or `m.` are suggested as fixes. Also, "sup" should throw a `WNOTSUPPORTED`.
- Handle a missing second position for insertions. We'll simply toss the given position into the VCF parser to provide us with the two suggestions for the variant positions. However, make sure we remove a suggested negative position when we don't use the `c.` prefix.
- Add support for insertions of a reference sequence without brackets.
- We can't convert `c.1delinsT` into a substitution, so throw an error. It was previously throwing a warning, but unless we have a deletion suffix, we can't convert this.
- Add support of complex insertions to `getSequences()`. Simply take the components and add them to our list of components to check, while we're going through the list.
- Add support for protein-like substitutions, e.g., `C100A`.
- Add support for genome builds and/or chromosomes as refseqs. Just like with VCF variants, we'll try to determine which NCs were meant to be used.
- Add support for all kinds of invalid characters in substitutions. They are introduced when variants are copied from PDFs that use alternative fonts to produce the ">".
- Allow also a space between the bases of a substitution. Also this happens when the ">" gets replaced by some other font.
- Recognize a slash instead of a ">" for substitutions. This example was taken from the HGVS website.
- Add support for copy-paste errors like ":c.10del". A reference sequence is now optional, but still only matches when seeing a colon. Then, in the HGVS class we check if we had an empty reference sequence but still found a colon. If so, both are removed.
- Add support for the `GENE(NC)` format, seen on the varnomen website. It was used to a mitochondrial variant, so allow it only for that, and correct it to `NC(GENE)`. That is the HGVS nomenclature's recommended way to select chrM transcripts.
- Recognize and correct curly braces in refseq structures. E.g., `NC{NM}`. This will be corrected to `NC(NM)`.
- Add support for "chromosome 1".
- Correct `g.100_200[1]` to `g.100_200=`.
- Let "POS REF ALT" strings be matched by the VCF class. They were handled by the DNASub class, which then threw two warnings because the format wasn't as expected. I'd rather have the VCF class handle this, throwing a WVCF.
- Match variant identifiers as well, so we'll notice them.
- Add support for `LRG_123(t1)`, a syntax used by Mutalyzer. While at it, also recognize `LRG_123[t1]` and `LRG_123{t1}`.
- Recognize and correct grouping separators (commas) in positions. Especially in VCF-like syntax, sometimes the format "123,456,789" is used for positions.
- Add support for the `GRCh38(chr11)` notation.
- Rename one `EPOSITIONFORMAT` to `EPOSITIONSNOTFORINS`. This matches more with other message codes.
- For genomic LRGs with a transcript prefix (c,n), suggest adding "t1". This is not necessarily correct, but it's quite possible that it is, and we will always have a low confidence since we're throwing an error.
- Throw a `WNOTSUPPORTED` for unsorted positions on circular refseqs.
- When `pter` or `qter` are in the wrong order, add another suggested fix. E.g., `g.1000_pterdel`; it could also be a typo.
- Also handle invalid suffixes after the pipe, e.g., `c.100|bsrC`.
- Also recognize, e.g., `c.100|=`, as seen in LOVD.
- Recognize and fix more hypen-like characters.
- Add a new class for separating positions (the underscore).
- Use the new HGVS_DNAPositionSeparator class to detect `c.100_c.200`.
- The chromosomal location indicator "cen" will not be used.
- Also rewrite variants like `c.100delAAinsTT`. Because the deletion suffix is longer than the position range, an error was logged and the rewrite didn't take place.
- Improve the use of `WPOSITIONSCORRECTED`. It's now also used for deletions-insertions and deletions with a single position and a deletion suffix longer than one base.
- Split `EINVALIDNUCLEOTIDES` into a warning and an error. U<->T conversion is done automatically, so these are warnings. Also, remove the exception for `EINVALIDNUCLEOTIDES` for VCF parsing.
- Add support for protein-like substitutions using multiple bases. This applies to, e.g., `c.CC123AA`, representing a deletion-insertion on positions `123_124`. This does open the door for more mis-interpretations, as many gene symbols will have a letter-number-letter combination. Therefore, make sure we have a valid prefix when multiple nucleotides are given.
- Add support for SPDI variant descriptions. They are basically VCF fields, but with a proper reference sequence given; therefore, simply re-use the VCF parser.
- Also handle `chr10(hg19)`-style input.
- Handle empty REFs, like `chr10-40--A`. This format was submitted by a VV user.
- Handle empty ALTs like `chr10-40-A-`. This format was submitted by a VV user.
- Any number followed by "bp" must be a Length, not a Position.
- Handle "insREFSEQ" cases, without positions. This was submitted to us this month. Inform the user that positions are needed, and come up with some random suggestions. Reduce the confidence of this suggestion to only 1%, to indicate it's just a random suggestion. However, having some kind of suggestion may really help the user.
- Correct `c.100_200delA` to `c.(100_200)delA`. This is an assumption, but the most logical one. Adding a second suggestion, `c.100_200del`, is complicated from the DNADelSuffix class. For now, we settle for having this single suggestion, having low confidence due to the error thrown.
- Add support for, e.g., `c.100A`. These are possible substitutions, but we don't have the REF base. It's also possible that it's a REF call. It's too dangerous to provide a single suggestion, so provide all possible suggestions in an array, for them to choose what it could be.
- Add an `HGVS::getVersions()` to provide information about the library.
- Handle `c.100_101A` and `c.100_101AA` as well. We will always suggest a deletion-insertion, or a '=' when the lengths match.

Closes #580.
Closes #581.